### PR TITLE
i18n (ssh-sessions): added german translations

### DIFF
--- a/ssh-sessions/i18n/de.json
+++ b/ssh-sessions/i18n/de.json
@@ -10,6 +10,7 @@
   "panel": {
     "activeSessions": "Aktive Sitzungen",
     "hosts": "Hosts",
+    "search": "Hosts suchen...",
     "noActive": "Keine aktiven Sitzungen",
     "noHosts": "Keine Hosts in ~/.ssh/config",
     "refresh": "Aktualisieren",

--- a/ssh-sessions/i18n/de.json
+++ b/ssh-sessions/i18n/de.json
@@ -1,0 +1,37 @@
+{
+  "widget": {
+    "tooltip": "SSH Sessions"
+  },
+  "bar": {
+    "noSessions": "Keine aktiven SSH Sitzungen",
+    "oneSession": "1 aktive SSH Sitzung",
+    "multipleSessions": "aktive SSH Sitzungen"
+  },
+  "panel": {
+    "activeSessions": "Aktive Sitzungen",
+    "hosts": "Hosts",
+    "noActive": "Keine aktiven Sitzungen",
+    "noHosts": "Keine Hosts in ~/.ssh/config",
+    "refresh": "Aktualisieren",
+    "settings": "Einstellungen"
+  },
+  "launcher": {
+    "name": "SSH",
+    "description": "Mit SSH Host verbinden"
+  },
+  "settings": {
+    "terminal": "Terminal",
+    "terminalDetected": "Automatisch erkanntes Terminal: {terminal}",
+    "terminalNone": "Es wurde kein Terminalemulator erkannt",
+    "terminalOverride": "Terminal Befehl",
+    "terminalOverrideDesc": "Leer lassen, um das automatisch erkannte Terminal zu verwenden",
+    "pollInterval": "Abfrageintervall",
+    "pollIntervalDesc": "Sekunden zwischen den Sitzungsprüfungen: ",
+    "showInactiveHosts": "Inaktive Hosts anzeigen",
+    "showInactiveHostsDesc": "Hosts ohne aktive Sitzungen im Panel anzeigen"
+  },
+  "context": {
+    "refresh": "Aktualisieren",
+    "settings": "Einstellungen"
+  }
+}

--- a/ssh-sessions/manifest.json
+++ b/ssh-sessions/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "ssh-sessions",
   "name": "SSH Sessions",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "minNoctaliaVersion": "3.6.0",
   "author": "adriamartin91",
   "license": "MIT",


### PR DESCRIPTION
added german translations to the `ssh-sessions` plugin
I have also added a translation string from #600 

Therefore, the version bump also applies to the version following the mentioned PR