### PR TITLE
screenshot: Add options for capturing active window and screen

### DIFF
--- a/screenshot/BarWidget.qml
+++ b/screenshot/BarWidget.qml
@@ -19,7 +19,7 @@ NIconButton {
     property int sectionWidgetsCount: 0
 
     icon: "camera"
-    tooltipText: pluginApi?.tr("tooltip") || "Take a screenshot"
+    tooltipText: pluginApi?.tr("tooltip")
     tooltipDirection: BarService.getTooltipDirection()
     baseSize: Style.capsuleHeight
     applyUiScale: false
@@ -45,11 +45,13 @@ NIconButton {
         }
     }
 
-    function takeScreenshot() {
+    function takeScreenshot(customArgs = null) {
         if (screenshotProcess.running) return;
 
         var args = [];
-        if (CompositorService.isHyprland) {
+        if (customArgs) {
+            args = customArgs;
+        } else if (CompositorService.isHyprland) {
             args = ["hyprshot", "--freeze", "--clipboard-only", "--mode", screenshotMode, "--silent"];
         } else if (CompositorService.isNiri) {
             args = ["niri", "msg", "action", "screenshot"];
@@ -81,19 +83,49 @@ NIconButton {
     NPopupContextMenu {
         id: contextMenu
 
-        model: [
-            {
+        model: {
+            var items = [
+                {
+                    "label": pluginApi?.tr("tooltip"),
+                    "action": "take-screenshot",
+                    "icon": "camera"
+                }
+            ];
+
+            if (CompositorService.isHyprland) {
+                items.push({
+                    "label": pluginApi?.tr("actions.active-window"),
+                    "action": "take-screenshot-active-window",
+                    "icon": "window"
+                });
+
+                items.push({
+                    "label": pluginApi?.tr("actions.active-screen"),
+                    "action": "take-screenshot-active-screen",
+                    "icon": "screen-share"
+                });
+            }
+
+            items.push({
                 "label": I18n.tr("actions.widget-settings"),
                 "action": "widget-settings",
                 "icon": "settings"
-            },
-        ]
+            });
+
+            return items;
+        }
 
         onTriggered: action => {
             contextMenu.close();
             PanelService.closeContextMenu(screen);
 
-            if (action === "widget-settings") {
+            if (action === "take-screenshot") {
+                root.takeScreenshot();
+            } else if (action === "take-screenshot-active-window") {
+                root.takeScreenshot(["hyprshot", "-m", "window", "-m", "active", "--clipboard-only"]);
+            } else if (action === "take-screenshot-active-screen") {
+                root.takeScreenshot(["hyprshot", "-m", "output", "-m", "active", "--clipboard-only"]);
+            } else if (action === "widget-settings") {
                 BarService.openPluginSettings(screen, pluginApi.manifest);
             }
         }

--- a/screenshot/i18n/en.json
+++ b/screenshot/i18n/en.json
@@ -6,6 +6,10 @@
     "error-grimshot": "Failed to run grimshot. Please ensure grimshot is installed and in PATH.",
     "unsupported-compositor": "Screenshots are not supported in this compositor."
   },
+  "actions": {
+    "active-window": "Capture active window",
+    "active-screen": "Capture active screen"
+  },
   "settings": {
     "mode": {
       "label": "Screenshot Mode",

--- a/screenshot/i18n/fr.json
+++ b/screenshot/i18n/fr.json
@@ -6,6 +6,10 @@
     "error-grimshot": "Échec du lancement de grimshot. Vérifiez qu'il est installé et présent dans votre PATH.",
     "unsupported-compositor": "Les captures d'écran ne sont pas supportées dans ce compositeur."
   },
+  "actions": {
+    "active-window": "Prendre une capture de la fenêtre active",
+    "active-screen": "Prendre une capture de l'écran actif"
+  },
   "settings": {
     "mode": {
       "label": "Mode de capture",

--- a/screenshot/manifest.json
+++ b/screenshot/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "screenshot",
   "name": "Screenshot",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "minNoctaliaVersion": "3.6.0",
   "author": "Cleboost",
   "license": "MIT",


### PR DESCRIPTION
This pull request enhances the screenshot widget by adding new screenshot options for Hyprland users, improving internationalization, and updating the plugin version. The most significant changes are the addition of "Capture active window" and "Capture active screen" actions in the context menu, with proper localization support.

Request in : https://github.com/noctalia-dev/noctalia-plugins/discussions/593

**New screenshot actions and context menu improvements:**
* Added "Capture active window" and "Capture active screen" options to the context menu for Hyprland users, allowing quick access to these specific screenshot modes. The context menu logic now dynamically includes these options based on the compositor. (`screenshot/BarWidget.qml`, [screenshot/BarWidget.qmlL84-R128](diffhunk://#diff-66726a0034892b7f2cc2fdf84f8f23ec6abedc671619d08911442bd2a252a918L84-R128))
* Updated the `takeScreenshot` function to accept custom arguments, enabling the new context menu actions to trigger different screenshot modes. (`screenshot/BarWidget.qml`, [screenshot/BarWidget.qmlL48-R54](diffhunk://#diff-66726a0034892b7f2cc2fdf84f8f23ec6abedc671619d08911442bd2a252a918L48-R54))

**Internationalization:**
* Added new translation keys for the new actions in both English and French locales, ensuring proper localization of the context menu items. (`screenshot/i18n/en.json`, [[1]](diffhunk://#diff-182ad6344965865fff85483522e19b02e6545ae8940c8c635bdeaae12b5d2900R9-R12); `screenshot/i18n/fr.json`, [[2]](diffhunk://#diff-8d42f554e8fb90df30d22544c3416dda0b9aceabecd5be17ab0067cda38251e0R9-R12)

**Other improvements:**
* Removed the fallback string from the tooltip, so it now only uses the translated value if available. (`screenshot/BarWidget.qml`, [screenshot/BarWidget.qmlL22-R22](diffhunk://#diff-66726a0034892b7f2cc2fdf84f8f23ec6abedc671619d08911442bd2a252a918L22-R22))
* Bumped the plugin version to `1.1.0` to reflect the new features. (`screenshot/manifest.json`, [screenshot/manifest.jsonL4-R4](diffhunk://#diff-ac323c08bc5296031c06a8e11569809f03c4ece388517797cf8bf8b405e8bf0bL4-R4))