### PR TITLE
kde-connect: French translations for device browsing

### DIFF
--- a/kde-connect/i18n/fr.json
+++ b/kde-connect/i18n/fr.json
@@ -18,6 +18,7 @@
     "other-devices": "Autres appareils",
     "send-file-picker": "Choisir un fichier à envoyer à l'appareil",
     "send-file": "Envoyer un fichier",
+    "browse-device": "Parcourir les fichiers de l'appareil",
     "find-device": "Trouver mon appareil",
     "pair": "Coupler avec l'appareil",
     "unpair": "Découpler l'appareil",
@@ -26,6 +27,10 @@
       "unavailable-title": "kdeconnectd ne semble pas être en cours d'exécution !",
       "unavailable-desc": "Assurez-vous d'avoir installé l'application KDE Connect sur votre système et qu'elle a démarré le démon kdeconnectd",
       "device-unavailable": "L'appareil est actuellement indisponible"
+    },
+    "busctl-error": {
+      "unavailable-title": "busctl est introuvable !",
+      "unavailable-desc": "Assurez-vous que busctl (faisant partie de systemd) est installé sur votre système"
     }
   },
   "bar": {
@@ -39,6 +44,12 @@
       "unavailable": "Indisponible",
       "no-device": "Aucun appareil",
       "not-paired": "Non couplé"
+    }
+  },
+  "settings": {
+    "no-device-connected-hide": {
+      "label": "Masquer si indisponible",
+      "description": "Masquer entièrement le bouton de la barre si aucun appareil n'est connecté"
     }
   }
 }

--- a/kde-connect/manifest.json
+++ b/kde-connect/manifest.json
@@ -5,7 +5,7 @@
   "minNoctaliaVersion": "4.4.0",
   "author": "WerWolv",
   "license": "GPLv2",
-  "repository": "https://github.com/WerWolv/noctalia-kde-connect",
+  "repository": "https://github.com/noctalia-dev/noctalia-plugins",
   "description": "A Plugin integrating your mobile devices into a panel using KDEConnect",
   "tags": [
     "Bar",

--- a/kde-connect/manifest.json
+++ b/kde-connect/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "kde-connect",
   "name": "KDE Connect",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "minNoctaliaVersion": "4.4.0",
   "author": "WerWolv",
   "official": false,

--- a/kde-connect/manifest.json
+++ b/kde-connect/manifest.json
@@ -4,7 +4,6 @@
   "version": "1.2.2",
   "minNoctaliaVersion": "4.4.0",
   "author": "WerWolv",
-  "official": false,
   "license": "GPLv2",
   "repository": "https://github.com/WerWolv/noctalia-kde-connect",
   "description": "A Plugin integrating your mobile devices into a panel using KDEConnect",


### PR DESCRIPTION
This pull request updates the French translations in `fr.json` for KDE Connect and increments the extension version to 1.2.2. The changes primarily add new translation keys for recently introduced UI features and error messages.

Localization updates:

* Added translation for browsing device files with the new `browse-device` key in `fr.json`.
* Added a new `busctl-error` section with titles and descriptions to inform users when `busctl` is missing.
* Added a `settings.no-device-connected-hide` section with label and description to support hiding the bar button when no device is connected.

Versioning:

* Bumped the extension version from 1.2.1 to 1.2.2 in `manifest.json`.