### PR TITLE
feat(vscode-provider): update French translations

### DIFF
--- a/vscode-provider/i18n/fr.json
+++ b/vscode-provider/i18n/fr.json
@@ -1,0 +1,32 @@
+{
+    "settings": {
+        "fork": {
+            "label": "Version de VS Code",
+            "description": "Quelle version de VS Code vous utilisez"
+        },
+        "includeInSearch": {
+            "label": "Inclure dans la recherche principale",
+            "description": "Indique si les espaces de travail VS Code doivent être inclus dans les résultats de recherche du lanceur principal"
+        },
+        "otherCommand": {
+            "label": "Commande",
+            "description": "La commande pour lancer cette version de VS Code"
+        },
+        "otherConfigName": {
+            "label": "Nom de configuration",
+            "description": "Le nom du répertoire de configuration de cette version dans ~/.config"
+        }
+    },
+    "launcher": {
+        "title": "Espaces de travail VS Code",
+        "description": "Rechercher et ouvrir des espaces de travail VS Code",
+        "loading": {
+            "title": "Chargement...",
+            "description": "Chargement des sessions..."
+        },
+        "error": {
+            "title": "Espaces de travail VS Code non chargés",
+            "description": "Vérifiez vos logs pour les messages d'erreur"
+        }
+    }
+}

--- a/vscode-provider/manifest.json
+++ b/vscode-provider/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "vscode-provider",
     "name": "VS Code Provider",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Open VS Code Folders and Workspaces",
     "tags": ["Launcher", "Development"],
     "minNoctaliaVersion": "4.5.0",

--- a/vscode-provider/manifest.json
+++ b/vscode-provider/manifest.json
@@ -6,7 +6,6 @@
     "tags": ["Launcher", "Development"],
     "minNoctaliaVersion": "4.5.0",
     "author": "Krendil",
-    "official": false,
     "license": "MIT",
     "repository": "https://github.com/noctalia-dev/noctalia-plugins",
     "entryPoints": {


### PR DESCRIPTION
This pull request adds French language support to the VS Code Provider extension and bumps the extension version to 1.0.2. The main change is the introduction of a new French translation file for UI labels and descriptions related to workspace launching and settings.

Localization:

* Added a new French translation file `fr.json` with localized labels and descriptions for settings and launcher UI, improving accessibility for French-speaking users.

Versioning:

* Updated the extension version from 1.0.1 to 1.0.2 in `manifest.json` to reflect the new localization support.