### PR TITLE
feat(air-quality): add AQICN as alternative data source

### DIFF
--- a/air-quality/Main.qml
+++ b/air-quality/Main.qml
@@ -26,10 +26,13 @@ Item {
   property bool loading: false
   property bool hasData: false
   property string errorMessage: ""
+  property string stationName: ""
 
   // Current scale from settings
   readonly property string aqiScale: cfg.aqiScale ?? defaults.aqiScale ?? "us"
   readonly property bool useNoctaliaLocation: cfg.useNoctaliaLocation ?? defaults.useNoctaliaLocation ?? true
+  readonly property string dataSource: cfg.dataSource ?? defaults.dataSource ?? "open-meteo"
+  readonly property string aqicnToken: cfg.aqicnToken ?? defaults.aqicnToken ?? ""
 
   Component.onCompleted: {
     Logger.i("Air Quality", "Plugin loaded, starting initial fetch...")
@@ -110,6 +113,54 @@ Item {
     }
   }
 
+  Process {
+    id: aqicnFetchProcess
+    onExited: (exitCode, exitStatus) => {
+      if (exitCode !== 0) {
+        Logger.w("Air Quality", "AQICN curl exited with code " + exitCode)
+        root.loading = false
+      }
+    }
+    stdout: StdioCollector {
+      onStreamFinished: {
+        var output = this.text.trim()
+        if (!output) {
+          Logger.w("Air Quality", "Empty response from AQICN API")
+          root.loading = false
+          return
+        }
+        try {
+          var response = JSON.parse(output)
+          if (response.status !== "ok") {
+            root.errorMessage = pluginApi?.tr("errors.aqicnApiFailed")
+            Logger.w("Air Quality", "AQICN API error: " + (response.data ?? "unknown"))
+            root.loading = false
+            return
+          }
+          var data = response.data
+          root.usAqi = data.aqi ?? 0
+          root.europeanAqi = 0
+          root.pm25 = data.iaqi?.pm25?.v ?? 0
+          root.pm10 = data.iaqi?.pm10?.v ?? 0
+          root.ozone = data.iaqi?.o3?.v ?? 0
+          root.no2 = data.iaqi?.no2?.v ?? 0
+          root.co = data.iaqi?.co?.v ?? 0
+          root.so2 = data.iaqi?.so2?.v ?? 0
+          root.stationName = data.city?.name ?? ""
+          root.hasData = true
+
+          var now = new Date()
+          root.lastUpdate = Qt.formatTime(now, "HH:mm")
+
+          Logger.i("Air Quality", "AQICN data updated — AQI: " + root.usAqi + " Station: " + root.stationName)
+        } catch (e) {
+          Logger.e("Air Quality", "Failed to parse AQICN response: " + e.message)
+        }
+        root.loading = false
+      }
+    }
+  }
+
   // Get current AQI value based on selected scale
   function getAqi() {
     return aqiScale === "eu" ? europeanAqi : usAqi
@@ -157,6 +208,9 @@ Item {
 
   // Get location name for display
   function getLocationName() {
+    if (dataSource === "aqicn" && stationName) {
+      return stationName
+    }
     if (useNoctaliaLocation) {
       var name = Settings.data.location?.name ?? ""
       if (name) {
@@ -220,9 +274,23 @@ Item {
     }
 
     root.loading = true
-    var url = "https://air-quality-api.open-meteo.com/v1/air-quality?latitude=" + lat + "&longitude=" + lon + "&current=us_aqi,european_aqi,pm2_5,pm10,ozone,nitrogen_dioxide,carbon_monoxide,sulphur_dioxide&timezone=auto"
-    Logger.d("Air Quality", "Fetching: " + url)
-    fetchProcess.command = ["curl", "-s", url]
-    fetchProcess.running = true
+
+    if (root.dataSource === "aqicn") {
+      if (!root.aqicnToken) {
+        root.errorMessage = pluginApi?.tr("errors.aqicnTokenMissing")
+        Logger.w("Air Quality", "AQICN token not configured")
+        root.loading = false
+        return
+      }
+      var aqicnUrl = "https://api.waqi.info/feed/geo:" + lat + ";" + lon + "/?token=" + root.aqicnToken
+      Logger.d("Air Quality", "Fetching AQICN: " + aqicnUrl)
+      aqicnFetchProcess.command = ["curl", "-s", aqicnUrl]
+      aqicnFetchProcess.running = true
+    } else {
+      var url = "https://air-quality-api.open-meteo.com/v1/air-quality?latitude=" + lat + "&longitude=" + lon + "&current=us_aqi,european_aqi,pm2_5,pm10,ozone,nitrogen_dioxide,carbon_monoxide,sulphur_dioxide&timezone=auto"
+      Logger.d("Air Quality", "Fetching Open-Meteo: " + url)
+      fetchProcess.command = ["curl", "-s", url]
+      fetchProcess.running = true
+    }
   }
 }

--- a/air-quality/Main.qml
+++ b/air-quality/Main.qml
@@ -274,6 +274,7 @@ Item {
     }
 
     root.loading = true
+    root.stationName = ""
 
     if (root.dataSource === "aqicn") {
       if (!root.aqicnToken) {
@@ -283,7 +284,7 @@ Item {
         return
       }
       var aqicnUrl = "https://api.waqi.info/feed/geo:" + lat + ";" + lon + "/?token=" + root.aqicnToken
-      Logger.d("Air Quality", "Fetching AQICN: " + aqicnUrl)
+      Logger.d("Air Quality", "Fetching AQICN data for geo:" + lat + ";" + lon)
       aqicnFetchProcess.command = ["curl", "-s", aqicnUrl]
       aqicnFetchProcess.running = true
     } else {

--- a/air-quality/README.md
+++ b/air-quality/README.md
@@ -1,7 +1,17 @@
 # Air Quality
 
-Displays real-time air quality data from the Open-Meteo API with EPA color coding.
+Displays real-time air quality data with EPA color coding.
 Shows AQI index (US EPA or European scale) and pollutant breakdown for PM2.5, PM10, O3, NO2, CO, and SO2.
+
+## Data Sources
+
+| Source | Type | API Key | AQI Scales |
+|--------|------|---------|------------|
+| **Open-Meteo** (default) | Forecasting (CAMS atmospheric models) | Not required | US EPA, European |
+| **AQICN** | Real monitoring station data | Free token required | US EPA only |
+
+- **Open-Meteo** uses Copernicus CAMS atmospheric models at 11-40km resolution. No API key needed, but values are forecasted estimates.
+- **AQICN** provides real-time data from the nearest EPA monitoring station. Requires a free API token from [aqicn.org/data-platform/token](https://aqicn.org/data-platform/token). Shows the station name in the location pill.
 
 ## Features
 
@@ -14,7 +24,7 @@ Shows AQI index (US EPA or European scale) and pollutant breakdown for PM2.5, PM
 
 **Panel**
 - Large AQI number with level indicator
-- Location pill with last update time
+- Location pill with last update time (shows station name when using AQICN)
 - Pollutant rows with colored indicators
 - Refresh and settings buttons
 
@@ -25,7 +35,9 @@ Shows AQI index (US EPA or European scale) and pollutant breakdown for PM2.5, PM
 - Middle click to refresh
 
 **Settings**
-- AQI scale: US AQI (EPA) or European AQI
+- Data source: Open-Meteo (forecasting) or AQICN (real station data)
+- AQICN API token field (visible when AQICN selected)
+- AQI scale: US AQI (EPA) or European AQI (disabled when using AQICN)
 - Location: use Noctalia location or custom coordinates
 - Refresh interval (5-120 minutes)
 - Bold text toggle
@@ -33,7 +45,3 @@ Shows AQI index (US EPA or European scale) and pollutant breakdown for PM2.5, PM
 **IPC**
 - Refresh: `qs -c noctalia-shell ipc call plugin:air-quality refresh`
 - Toggle panel: `qs -c noctalia-shell ipc call plugin:air-quality toggle`
-
-## Data Source
-
-[Open-Meteo Air Quality API](https://open-meteo.com/)

--- a/air-quality/Settings.qml
+++ b/air-quality/Settings.qml
@@ -54,6 +54,7 @@ ColumnLayout {
       currentKey: root.editDataSource
       onSelected: key => {
         root.editDataSource = key
+        if (key === "aqicn") root.editAqiScale = "us"
       }
     }
   }
@@ -94,6 +95,7 @@ ColumnLayout {
     NComboBox {
       Layout.preferredWidth: 180 * Style.uiScaleRatio
       Layout.preferredHeight: Style.baseWidgetSize
+      enabled: root.editDataSource !== "aqicn"
       model: [
         { key: "us", name: pluginApi?.tr("settings.aqiScaleUs") },
         { key: "eu", name: pluginApi?.tr("settings.aqiScaleEu") }
@@ -197,7 +199,7 @@ ColumnLayout {
 
     pluginApi.saveSettings()
 
-    // Only refresh if location or scale changed
+    // Only refresh if location, scale, or data source changed
     if (locationChanged || scaleChanged || dataSourceChanged) {
       root.pluginApi.mainInstance?.refresh()
     }

--- a/air-quality/Settings.qml
+++ b/air-quality/Settings.qml
@@ -17,8 +17,57 @@ ColumnLayout {
   property string editCustomLongitude: cfg.customLongitude ?? defaults.customLongitude ?? ""
   property int editRefreshInterval: cfg.refreshInterval ?? defaults.refreshInterval ?? 30
   property bool editBoldText: cfg.boldText ?? defaults.boldText ?? true
+  property string editDataSource: cfg.dataSource ?? defaults.dataSource ?? "open-meteo"
+  property string editAqicnToken: cfg.aqicnToken ?? defaults.aqicnToken ?? ""
 
   spacing: Style.marginM
+
+  // --- Data Source ---
+  RowLayout {
+    Layout.fillWidth: true
+    spacing: Style.marginM
+
+    ColumnLayout {
+      Layout.fillWidth: true
+      spacing: Style.marginXS
+
+      NText {
+        text: pluginApi?.tr("settings.dataSource")
+        pointSize: Style.fontSizeM
+        color: Color.mOnSurface
+      }
+
+      NText {
+        text: pluginApi?.tr("settings.dataSourceDesc")
+        pointSize: Style.fontSizeS
+        color: Color.mOnSurfaceVariant
+      }
+    }
+
+    NComboBox {
+      Layout.preferredWidth: 260 * Style.uiScaleRatio
+      Layout.preferredHeight: Style.baseWidgetSize
+      model: [
+        { key: "open-meteo", name: pluginApi?.tr("settings.dataSourceOpenMeteo") },
+        { key: "aqicn", name: pluginApi?.tr("settings.dataSourceAqicn") }
+      ]
+      currentKey: root.editDataSource
+      onSelected: key => {
+        root.editDataSource = key
+      }
+    }
+  }
+
+  // --- AQICN Token ---
+  NTextInput {
+    Layout.fillWidth: true
+    visible: root.editDataSource === "aqicn"
+    label: pluginApi?.tr("settings.aqicnToken")
+    description: pluginApi?.tr("settings.aqicnTokenDesc")
+    placeholderText: pluginApi?.tr("settings.aqicnTokenPlaceholder")
+    text: root.editAqicnToken
+    onTextChanged: root.editAqicnToken = text
+  }
 
   // --- AQI Scale ---
   RowLayout {
@@ -134,8 +183,12 @@ ColumnLayout {
         || pluginApi.pluginSettings.customLatitude !== root.editCustomLatitude
         || pluginApi.pluginSettings.customLongitude !== root.editCustomLongitude
     var scaleChanged = pluginApi.pluginSettings.aqiScale !== root.editAqiScale
+    var dataSourceChanged = pluginApi.pluginSettings.dataSource !== root.editDataSource
+        || pluginApi.pluginSettings.aqicnToken !== root.editAqicnToken
 
     pluginApi.pluginSettings.aqiScale = root.editAqiScale
+    pluginApi.pluginSettings.dataSource = root.editDataSource
+    pluginApi.pluginSettings.aqicnToken = root.editAqicnToken
     pluginApi.pluginSettings.useNoctaliaLocation = root.editUseNoctaliaLocation
     pluginApi.pluginSettings.customLatitude = root.editCustomLatitude
     pluginApi.pluginSettings.customLongitude = root.editCustomLongitude
@@ -145,7 +198,7 @@ ColumnLayout {
     pluginApi.saveSettings()
 
     // Only refresh if location or scale changed
-    if (locationChanged || scaleChanged) {
+    if (locationChanged || scaleChanged || dataSourceChanged) {
       root.pluginApi.mainInstance?.refresh()
     }
 

--- a/air-quality/i18n/de.json
+++ b/air-quality/i18n/de.json
@@ -1,0 +1,49 @@
+{
+  "widget": { "tooltip": "Luftqualität" },
+  "scale": { "us": "US AQI", "eu": "EU AQI" },
+  "location": { "custom": "Benutzerdefiniert" },
+  "unit": { "ugm3": "µg/m³" },
+  "levels": {
+    "good": "Gut", "moderate": "Mäßig",
+    "unhealthySensitive": "Ungesund für empfindliche Gruppen",
+    "unhealthy": "Ungesund", "veryUnhealthy": "Sehr ungesund",
+    "hazardous": "Gefährlich", "fair": "Akzeptabel", "poor": "Schlecht",
+    "veryPoor": "Sehr schlecht", "extremelyPoor": "Extrem schlecht", "unknown": "Unbekannt"
+  },
+  "pollutants": {
+    "pm25": "PM2.5", "pm10": "PM10", "ozone": "O\u2083", "no2": "NO\u2082", "co": "CO", "so2": "SO\u2082",
+    "pm25Value": "PM2.5: {value} µg/m³", "pm10Value": "PM10: {value} µg/m³",
+    "ozoneValue": "O\u2083: {value} µg/m³", "no2Value": "NO\u2082: {value} µg/m³",
+    "coValue": "CO: {value} µg/m³", "so2Value": "SO\u2082: {value} µg/m³",
+    "pm25Short": "PM2.5: {value}", "pm10Short": "PM10: {value}"
+  },
+  "errors": {
+    "weatherDisabled": "Wetter in den Noctalia-Einstellungen aktivieren oder benutzerdefinierte Koordinaten verwenden",
+    "locationUnavailable": "Standort noch nicht verfügbar, wird erneut versucht...",
+    "aqicnTokenMissing": "AQICN ausgewählt, aber kein API-Token konfiguriert",
+    "aqicnApiFailed": "AQICN API-Fehler"
+  },
+  "panel": {
+    "title": "Luftqualität", "lastUpdate": "Letzte Aktualisierung", "pollutants": "Schadstoffe",
+    "refresh": "Aktualisieren", "settings": "Einstellungen", "noData": "Keine Daten verfügbar", "loading": "Wird geladen..."
+  },
+  "settings": {
+    "aqiScale": "AQI-Skala", "aqiScaleDesc": "Luftqualitätsindex-Skala auswählen",
+    "aqiScaleUs": "US AQI (EPA)", "aqiScaleEu": "Europäischer AQI",
+    "location": "Standort", "useNoctaliaLocation": "Noctalia-Standort verwenden",
+    "useNoctaliaLocationDesc": "Den in den Noctalia-Einstellungen konfigurierten Standort verwenden",
+    "customLatitude": "Breitengrad", "customLongitude": "Längengrad",
+    "customLocationDesc": "Koordinaten manuell eingeben",
+    "refreshInterval": "Aktualisierungsintervall", "refreshIntervalDesc": "Minuten zwischen Aktualisierungen: ",
+    "boldText": "Fetter Text", "boldTextDesc": "AQI-Zahl fett anzeigen",
+    "dataSource": "Datenquelle", "dataSourceDesc": "Auswählen, woher die Luftqualitätsdaten stammen",
+    "dataSourceOpenMeteo": "Open-Meteo (kein Schlüssel erforderlich)", "dataSourceAqicn": "AQICN (echte Stationsdaten)",
+    "aqicnToken": "AQICN API-Token", "aqicnTokenDesc": "Kostenlosen Token erhalten unter aqicn.org/data-platform/token",
+    "aqicnTokenPlaceholder": "Token hier einfügen"
+  },
+  "desktop": {
+    "noData": "Keine Daten", "tipLeft": "Linksklick: Panel öffnen",
+    "tipMiddle": "Mittelklick: Aktualisieren", "tipRight": "Rechtsklick: Einstellungen"
+  },
+  "context": { "refresh": "Aktualisieren", "settings": "Einstellungen" }
+}

--- a/air-quality/i18n/en.json
+++ b/air-quality/i18n/en.json
@@ -43,7 +43,9 @@
   },
   "errors": {
     "weatherDisabled": "Enable weather in Noctalia settings or use custom coordinates",
-    "locationUnavailable": "Location not available yet, retrying..."
+    "locationUnavailable": "Location not available yet, retrying...",
+    "aqicnTokenMissing": "AQICN selected but no API token configured",
+    "aqicnApiFailed": "AQICN API error"
   },
   "panel": {
     "title": "Air Quality",
@@ -52,7 +54,8 @@
     "refresh": "Refresh",
     "settings": "Settings",
     "noData": "No data available",
-    "loading": "Loading..."
+    "loading": "Loading...",
+    "station": "Station"
   },
   "settings": {
     "aqiScale": "AQI Scale",
@@ -68,7 +71,14 @@
     "refreshInterval": "Refresh interval",
     "refreshIntervalDesc": "Minutes between updates: ",
     "boldText": "Bold text",
-    "boldTextDesc": "Display the AQI number in bold"
+    "boldTextDesc": "Display the AQI number in bold",
+    "dataSource": "Data source",
+    "dataSourceDesc": "Choose where air quality data comes from",
+    "dataSourceOpenMeteo": "Open-Meteo (no key needed)",
+    "dataSourceAqicn": "AQICN (real station data)",
+    "aqicnToken": "AQICN API Token",
+    "aqicnTokenDesc": "Get your free token at aqicn.org/data-platform/token",
+    "aqicnTokenPlaceholder": "Paste your token here"
   },
   "desktop": {
     "noData": "No data",

--- a/air-quality/i18n/en.json
+++ b/air-quality/i18n/en.json
@@ -54,8 +54,7 @@
     "refresh": "Refresh",
     "settings": "Settings",
     "noData": "No data available",
-    "loading": "Loading...",
-    "station": "Station"
+    "loading": "Loading..."
   },
   "settings": {
     "aqiScale": "AQI Scale",

--- a/air-quality/i18n/es.json
+++ b/air-quality/i18n/es.json
@@ -1,0 +1,49 @@
+{
+  "widget": { "tooltip": "Calidad del aire" },
+  "scale": { "us": "US AQI", "eu": "EU AQI" },
+  "location": { "custom": "Personalizada" },
+  "unit": { "ugm3": "µg/m³" },
+  "levels": {
+    "good": "Buena", "moderate": "Moderada",
+    "unhealthySensitive": "No saludable para grupos sensibles",
+    "unhealthy": "No saludable", "veryUnhealthy": "Muy perjudicial",
+    "hazardous": "Peligrosa", "fair": "Aceptable", "poor": "Mala",
+    "veryPoor": "Muy mala", "extremelyPoor": "Extremadamente mala", "unknown": "Desconocida"
+  },
+  "pollutants": {
+    "pm25": "PM2.5", "pm10": "PM10", "ozone": "O\u2083", "no2": "NO\u2082", "co": "CO", "so2": "SO\u2082",
+    "pm25Value": "PM2.5: {value} µg/m³", "pm10Value": "PM10: {value} µg/m³",
+    "ozoneValue": "O\u2083: {value} µg/m³", "no2Value": "NO\u2082: {value} µg/m³",
+    "coValue": "CO: {value} µg/m³", "so2Value": "SO\u2082: {value} µg/m³",
+    "pm25Short": "PM2.5: {value}", "pm10Short": "PM10: {value}"
+  },
+  "errors": {
+    "weatherDisabled": "Activa la ubicación en los ajustes de Noctalia o usa coordenadas personalizadas",
+    "locationUnavailable": "Ubicación no disponible todavía, reintentando...",
+    "aqicnTokenMissing": "AQICN seleccionado pero no hay ningún token de API configurado",
+    "aqicnApiFailed": "Error en la API de AQICN"
+  },
+  "panel": {
+    "title": "Calidad del aire", "lastUpdate": "Última actualización", "pollutants": "Contaminantes",
+    "refresh": "Actualizar", "settings": "Ajustes", "noData": "No hay datos disponibles", "loading": "Cargando..."
+  },
+  "settings": {
+    "aqiScale": "Escala AQI", "aqiScaleDesc": "Elige la escala del índice de calidad del aire",
+    "aqiScaleUs": "US AQI (EPA)", "aqiScaleEu": "AQI europeo",
+    "location": "Ubicación", "useNoctaliaLocation": "Usar la ubicación de Noctalia",
+    "useNoctaliaLocationDesc": "Usa la ubicación configurada en los ajustes de Noctalia",
+    "customLatitude": "Latitud", "customLongitude": "Longitud",
+    "customLocationDesc": "Introduce las coordenadas manualmente",
+    "refreshInterval": "Intervalo de actualización", "refreshIntervalDesc": "Minutos entre actualizaciones: ",
+    "boldText": "Texto en negrita", "boldTextDesc": "Mostrar el número AQI en negrita",
+    "dataSource": "Fuente de datos", "dataSourceDesc": "Elige de dónde provienen los datos de calidad del aire",
+    "dataSourceOpenMeteo": "Open-Meteo (sin clave necesaria)", "dataSourceAqicn": "AQICN (datos de estaciones reales)",
+    "aqicnToken": "Token de API de AQICN", "aqicnTokenDesc": "Obtén tu token gratuito en aqicn.org/data-platform/token",
+    "aqicnTokenPlaceholder": "Pega tu token aquí"
+  },
+  "desktop": {
+    "noData": "Sin datos", "tipLeft": "Clic izquierdo: Abrir panel",
+    "tipMiddle": "Clic central: Actualizar", "tipRight": "Clic derecho: Ajustes"
+  },
+  "context": { "refresh": "Actualizar", "settings": "Ajustes" }
+}

--- a/air-quality/i18n/fr.json
+++ b/air-quality/i18n/fr.json
@@ -1,0 +1,49 @@
+{
+  "widget": { "tooltip": "Qualité de l'air" },
+  "scale": { "us": "US AQI", "eu": "EU AQI" },
+  "location": { "custom": "Personnalisé" },
+  "unit": { "ugm3": "µg/m³" },
+  "levels": {
+    "good": "Bon", "moderate": "Modéré",
+    "unhealthySensitive": "Mauvais pour les groupes sensibles",
+    "unhealthy": "Mauvais", "veryUnhealthy": "Très mauvais",
+    "hazardous": "Dangereux", "fair": "Acceptable", "poor": "Médiocre",
+    "veryPoor": "Très médiocre", "extremelyPoor": "Extrêmement médiocre", "unknown": "Inconnu"
+  },
+  "pollutants": {
+    "pm25": "PM2.5", "pm10": "PM10", "ozone": "O\u2083", "no2": "NO\u2082", "co": "CO", "so2": "SO\u2082",
+    "pm25Value": "PM2.5 : {value} µg/m³", "pm10Value": "PM10 : {value} µg/m³",
+    "ozoneValue": "O\u2083 : {value} µg/m³", "no2Value": "NO\u2082 : {value} µg/m³",
+    "coValue": "CO : {value} µg/m³", "so2Value": "SO\u2082 : {value} µg/m³",
+    "pm25Short": "PM2.5 : {value}", "pm10Short": "PM10 : {value}"
+  },
+  "errors": {
+    "weatherDisabled": "Activez la météo dans les paramètres de Noctalia ou utilisez des coordonnées personnalisées",
+    "locationUnavailable": "Localisation pas encore disponible, nouvelle tentative...",
+    "aqicnTokenMissing": "AQICN sélectionné mais aucun jeton API configuré",
+    "aqicnApiFailed": "Erreur de l'API AQICN"
+  },
+  "panel": {
+    "title": "Qualité de l'air", "lastUpdate": "Dernière mise à jour", "pollutants": "Polluants",
+    "refresh": "Actualiser", "settings": "Paramètres", "noData": "Aucune donnée disponible", "loading": "Chargement..."
+  },
+  "settings": {
+    "aqiScale": "Échelle AQI", "aqiScaleDesc": "Choisir l'échelle de l'indice de qualité de l'air",
+    "aqiScaleUs": "US AQI (EPA)", "aqiScaleEu": "AQI européen",
+    "location": "Localisation", "useNoctaliaLocation": "Utiliser la localisation de Noctalia",
+    "useNoctaliaLocationDesc": "Utiliser la localisation configurée dans les paramètres de Noctalia",
+    "customLatitude": "Latitude", "customLongitude": "Longitude",
+    "customLocationDesc": "Saisir les coordonnées manuellement",
+    "refreshInterval": "Intervalle d'actualisation", "refreshIntervalDesc": "Minutes entre les mises à jour : ",
+    "boldText": "Texte en gras", "boldTextDesc": "Afficher le nombre AQI en gras",
+    "dataSource": "Source de données", "dataSourceDesc": "Choisir la provenance des données de qualité de l'air",
+    "dataSourceOpenMeteo": "Open-Meteo (sans clé)", "dataSourceAqicn": "AQICN (données de stations réelles)",
+    "aqicnToken": "Jeton API AQICN", "aqicnTokenDesc": "Obtenez votre jeton gratuit sur aqicn.org/data-platform/token",
+    "aqicnTokenPlaceholder": "Collez votre jeton ici"
+  },
+  "desktop": {
+    "noData": "Aucune donnée", "tipLeft": "Clic gauche : Ouvrir le panneau",
+    "tipMiddle": "Clic du milieu : Actualiser", "tipRight": "Clic droit : Paramètres"
+  },
+  "context": { "refresh": "Actualiser", "settings": "Paramètres" }
+}

--- a/air-quality/i18n/pt.json
+++ b/air-quality/i18n/pt.json
@@ -1,0 +1,49 @@
+{
+  "widget": { "tooltip": "Qualidade do Ar" },
+  "scale": { "us": "US AQI", "eu": "EU AQI" },
+  "location": { "custom": "Personalizado" },
+  "unit": { "ugm3": "µg/m³" },
+  "levels": {
+    "good": "Bom", "moderate": "Moderado",
+    "unhealthySensitive": "Prejudicial para Grupos Sensíveis",
+    "unhealthy": "Prejudicial", "veryUnhealthy": "Muito Prejudicial",
+    "hazardous": "Perigoso", "fair": "Razoável", "poor": "Mau",
+    "veryPoor": "Muito Mau", "extremelyPoor": "Extremamente Mau", "unknown": "Desconhecido"
+  },
+  "pollutants": {
+    "pm25": "PM2.5", "pm10": "PM10", "ozone": "O\u2083", "no2": "NO\u2082", "co": "CO", "so2": "SO\u2082",
+    "pm25Value": "PM2.5: {value} µg/m³", "pm10Value": "PM10: {value} µg/m³",
+    "ozoneValue": "O\u2083: {value} µg/m³", "no2Value": "NO\u2082: {value} µg/m³",
+    "coValue": "CO: {value} µg/m³", "so2Value": "SO\u2082: {value} µg/m³",
+    "pm25Short": "PM2.5: {value}", "pm10Short": "PM10: {value}"
+  },
+  "errors": {
+    "weatherDisabled": "Ative o tempo nas definições do Noctalia ou use coordenadas personalizadas",
+    "locationUnavailable": "Localização ainda não disponível, a tentar novamente...",
+    "aqicnTokenMissing": "AQICN selecionado mas nenhum token de API configurado",
+    "aqicnApiFailed": "Erro na API do AQICN"
+  },
+  "panel": {
+    "title": "Qualidade do Ar", "lastUpdate": "Última atualização", "pollutants": "Poluentes",
+    "refresh": "Atualizar", "settings": "Definições", "noData": "Sem dados disponíveis", "loading": "A carregar..."
+  },
+  "settings": {
+    "aqiScale": "Escala AQI", "aqiScaleDesc": "Escolha a escala do índice de qualidade do ar",
+    "aqiScaleUs": "US AQI (EPA)", "aqiScaleEu": "AQI Europeu",
+    "location": "Localização", "useNoctaliaLocation": "Usar localização do Noctalia",
+    "useNoctaliaLocationDesc": "Usar a localização configurada nas definições do Noctalia",
+    "customLatitude": "Latitude", "customLongitude": "Longitude",
+    "customLocationDesc": "Introduzir coordenadas manualmente",
+    "refreshInterval": "Intervalo de atualização", "refreshIntervalDesc": "Minutos entre atualizações: ",
+    "boldText": "Texto em negrito", "boldTextDesc": "Mostrar o número AQI em negrito",
+    "dataSource": "Fonte de dados", "dataSourceDesc": "Escolha de onde provêm os dados de qualidade do ar",
+    "dataSourceOpenMeteo": "Open-Meteo (sem chave necessária)", "dataSourceAqicn": "AQICN (dados de estações reais)",
+    "aqicnToken": "Token da API AQICN", "aqicnTokenDesc": "Obtenha o seu token gratuito em aqicn.org/data-platform/token",
+    "aqicnTokenPlaceholder": "Cole o seu token aqui"
+  },
+  "desktop": {
+    "noData": "Sem dados", "tipLeft": "Clique esquerdo: Abrir painel",
+    "tipMiddle": "Clique do meio: Atualizar", "tipRight": "Clique direito: Definições"
+  },
+  "context": { "refresh": "Atualizar", "settings": "Definições" }
+}

--- a/air-quality/i18n/ru.json
+++ b/air-quality/i18n/ru.json
@@ -1,0 +1,49 @@
+{
+  "widget": { "tooltip": "Качество воздуха" },
+  "scale": { "us": "US AQI", "eu": "EU AQI" },
+  "location": { "custom": "Произвольное" },
+  "unit": { "ugm3": "µg/m³" },
+  "levels": {
+    "good": "Хорошее", "moderate": "Умеренное",
+    "unhealthySensitive": "Вредное для чувствительных групп",
+    "unhealthy": "Вредное", "veryUnhealthy": "Очень вредное",
+    "hazardous": "Опасное", "fair": "Приемлемое", "poor": "Плохое",
+    "veryPoor": "Очень плохое", "extremelyPoor": "Крайне плохое", "unknown": "Неизвестно"
+  },
+  "pollutants": {
+    "pm25": "PM2.5", "pm10": "PM10", "ozone": "O\u2083", "no2": "NO\u2082", "co": "CO", "so2": "SO\u2082",
+    "pm25Value": "PM2.5: {value} µg/m³", "pm10Value": "PM10: {value} µg/m³",
+    "ozoneValue": "O\u2083: {value} µg/m³", "no2Value": "NO\u2082: {value} µg/m³",
+    "coValue": "CO: {value} µg/m³", "so2Value": "SO\u2082: {value} µg/m³",
+    "pm25Short": "PM2.5: {value}", "pm10Short": "PM10: {value}"
+  },
+  "errors": {
+    "weatherDisabled": "Включите погоду в настройках Noctalia или используйте произвольные координаты",
+    "locationUnavailable": "Местоположение ещё недоступно, повторная попытка...",
+    "aqicnTokenMissing": "Выбран AQICN, но токен API не настроен",
+    "aqicnApiFailed": "Ошибка API AQICN"
+  },
+  "panel": {
+    "title": "Качество воздуха", "lastUpdate": "Последнее обновление", "pollutants": "Загрязнители",
+    "refresh": "Обновить", "settings": "Настройки", "noData": "Нет данных", "loading": "Загрузка..."
+  },
+  "settings": {
+    "aqiScale": "Шкала AQI", "aqiScaleDesc": "Выберите шкалу индекса качества воздуха",
+    "aqiScaleUs": "US AQI (EPA)", "aqiScaleEu": "Европейский AQI",
+    "location": "Местоположение", "useNoctaliaLocation": "Использовать местоположение Noctalia",
+    "useNoctaliaLocationDesc": "Использовать местоположение, настроенное в параметрах Noctalia",
+    "customLatitude": "Широта", "customLongitude": "Долгота",
+    "customLocationDesc": "Введите координаты вручную",
+    "refreshInterval": "Интервал обновления", "refreshIntervalDesc": "Минут между обновлениями: ",
+    "boldText": "Жирный текст", "boldTextDesc": "Отображать значение AQI жирным шрифтом",
+    "dataSource": "Источник данных", "dataSourceDesc": "Выберите источник данных о качестве воздуха",
+    "dataSourceOpenMeteo": "Open-Meteo (ключ не требуется)", "dataSourceAqicn": "AQICN (данные реальных станций)",
+    "aqicnToken": "Токен API AQICN", "aqicnTokenDesc": "Получите бесплатный токен на aqicn.org/data-platform/token",
+    "aqicnTokenPlaceholder": "Вставьте ваш токен здесь"
+  },
+  "desktop": {
+    "noData": "Нет данных", "tipLeft": "Левая кнопка: открыть панель",
+    "tipMiddle": "Средняя кнопка: обновить", "tipRight": "Правая кнопка: настройки"
+  },
+  "context": { "refresh": "Обновить", "settings": "Настройки" }
+}

--- a/air-quality/i18n/zh-CN.json
+++ b/air-quality/i18n/zh-CN.json
@@ -1,0 +1,49 @@
+{
+  "widget": { "tooltip": "空气质量" },
+  "scale": { "us": "US AQI", "eu": "EU AQI" },
+  "location": { "custom": "自定义" },
+  "unit": { "ugm3": "µg/m³" },
+  "levels": {
+    "good": "优", "moderate": "良",
+    "unhealthySensitive": "对敏感人群不健康",
+    "unhealthy": "不健康", "veryUnhealthy": "非常不健康",
+    "hazardous": "危险", "fair": "尚可", "poor": "差",
+    "veryPoor": "很差", "extremelyPoor": "极差", "unknown": "未知"
+  },
+  "pollutants": {
+    "pm25": "PM2.5", "pm10": "PM10", "ozone": "O\u2083", "no2": "NO\u2082", "co": "CO", "so2": "SO\u2082",
+    "pm25Value": "PM2.5: {value} µg/m³", "pm10Value": "PM10: {value} µg/m³",
+    "ozoneValue": "O\u2083: {value} µg/m³", "no2Value": "NO\u2082: {value} µg/m³",
+    "coValue": "CO: {value} µg/m³", "so2Value": "SO\u2082: {value} µg/m³",
+    "pm25Short": "PM2.5: {value}", "pm10Short": "PM10: {value}"
+  },
+  "errors": {
+    "weatherDisabled": "请在 Noctalia 设置中启用天气功能，或使用自定义坐标",
+    "locationUnavailable": "位置暂不可用，正在重试...",
+    "aqicnTokenMissing": "已选择 AQICN 但未配置 API 令牌",
+    "aqicnApiFailed": "AQICN API 错误"
+  },
+  "panel": {
+    "title": "空气质量", "lastUpdate": "最近更新", "pollutants": "污染物",
+    "refresh": "刷新", "settings": "设置", "noData": "暂无数据", "loading": "加载中..."
+  },
+  "settings": {
+    "aqiScale": "AQI 标准", "aqiScaleDesc": "选择空气质量指数标准",
+    "aqiScaleUs": "US AQI（EPA）", "aqiScaleEu": "欧洲 AQI",
+    "location": "位置", "useNoctaliaLocation": "使用 Noctalia 位置",
+    "useNoctaliaLocationDesc": "使用 Noctalia 设置中配置的位置",
+    "customLatitude": "纬度", "customLongitude": "经度",
+    "customLocationDesc": "手动输入坐标",
+    "refreshInterval": "刷新间隔", "refreshIntervalDesc": "更新间隔（分钟）：",
+    "boldText": "粗体文字", "boldTextDesc": "以粗体显示 AQI 数值",
+    "dataSource": "数据来源", "dataSourceDesc": "选择空气质量数据的来源",
+    "dataSourceOpenMeteo": "Open-Meteo（无需密钥）", "dataSourceAqicn": "AQICN（真实站点数据）",
+    "aqicnToken": "AQICN API 令牌", "aqicnTokenDesc": "在 aqicn.org/data-platform/token 获取免费令牌",
+    "aqicnTokenPlaceholder": "在此粘贴您的令牌"
+  },
+  "desktop": {
+    "noData": "无数据", "tipLeft": "左键单击：打开面板",
+    "tipMiddle": "中键单击：刷新", "tipRight": "右键单击：设置"
+  },
+  "context": { "refresh": "刷新", "settings": "设置" }
+}

--- a/air-quality/manifest.json
+++ b/air-quality/manifest.json
@@ -6,7 +6,7 @@
   "author": "adriamartin91",
   "license": "MIT",
   "repository": "https://github.com/noctalia-dev/noctalia-plugins",
-  "description": "Displays real-time air quality data from Open-Meteo with EPA color coding. Shows AQI index and pollutant breakdown.",
+  "description": "Displays real-time air quality data with EPA color coding. Supports Open-Meteo and AQICN data sources. Shows AQI index and pollutant breakdown.",
   "tags": ["Bar", "Desktop", "Panel", "System", "Utility"],
   "entryPoints": {
     "main": "Main.qml",
@@ -21,6 +21,8 @@
   "metadata": {
     "defaultSettings": {
       "aqiScale": "us",
+      "dataSource": "open-meteo",
+      "aqicnToken": "",
       "useNoctaliaLocation": true,
       "customLatitude": "",
       "customLongitude": "",

--- a/air-quality/manifest.json
+++ b/air-quality/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "air-quality",
   "name": "Air Quality",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "minNoctaliaVersion": "3.6.0",
   "author": "adriamartin91",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Adds **AQICN** as an optional data source alongside the existing Open-Meteo integration. Open-Meteo remains the default (no key needed); AQICN provides real monitoring station data and requires a free API token.
- New **Data Source** dropdown in Settings with a conditional AQICN token field. The AQI scale selector is automatically forced to US and disabled when AQICN is selected (AQICN only provides US AQI).
- Station name from AQICN is shown in the location pill instead of the city name.
- Translations added for **de, es, fr, pt, ru, zh-CN**.
- Version bumped to **1.1.0**.