### PR TITLE
i18n (calibre-provider): updated german translations

### DIFF
--- a/calibre-provider/i18n/de.json
+++ b/calibre-provider/i18n/de.json
@@ -7,6 +7,10 @@
     "forcegrid": {
       "label": "Rasteransicht erzwingen",
       "description": "Verwende immer die Rasteransicht, um Ergebnisse anzuzeigen. Wenn deaktiviert, verwende die aktuelle Launcher-Konfiguration"
+    },
+    "recentlyOpened": {
+      "label": "Anzahl der kürzlich geöffneten",
+      "description": "Die Anzahl der zuletzt geöffneten Einträge, die gespeichert werden sollen"
     }
   }
 }

--- a/calibre-provider/manifest.json
+++ b/calibre-provider/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "calibre-provider",
     "name": "Calibre Provider",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "description": "Search for books in your Calibre library",
     "tags": ["Launcher"],
     "minNoctaliaVersion": "4.6.1",

--- a/calibre-provider/manifest.json
+++ b/calibre-provider/manifest.json
@@ -6,7 +6,6 @@
     "tags": ["Launcher"],
     "minNoctaliaVersion": "4.6.1",
     "author": "Krendil",
-    "official": false,
     "license": "MIT",
     "repository": "https://github.com/noctalia-dev/noctalia-plugins",
     "entryPoints": {


### PR DESCRIPTION
updated german translations for the `calibre-provider` plugin