### PR TITLE
i18n (screenshot): updated german translations

### DIFF
--- a/screenshot/i18n/de.json
+++ b/screenshot/i18n/de.json
@@ -6,6 +6,10 @@
     "error-grimshot": "Grimshot konnte nicht ausgeführt werden. Bitte stelle sicher, dass Grimshot installiert ist und sich im PATH befindet.",
     "unsupported-compositor": "Screenshots werden in diesem Compositor nicht unterstützt."
   },
+  "actions": {
+    "active-window": "Aktives Fenster erfassen",
+    "active-screen": "Aktiven Bildschirm erfassen"
+  },
   "settings": {
     "mode": {
       "label": "Screenshot-Modus",

--- a/screenshot/manifest.json
+++ b/screenshot/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "screenshot",
   "name": "Screenshot",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "minNoctaliaVersion": "3.6.0",
   "author": "Cleboost",
   "license": "MIT",


### PR DESCRIPTION
updated german translations for the `screenshot` plugin