### PR TITLE
i18n (translator): updated german translations

### DIFF
--- a/translator/i18n/de.json
+++ b/translator/i18n/de.json
@@ -104,12 +104,19 @@
     "error": "Übersetzungsfehler",
     "targetLanguage": "Zielsprache: {code}",
     "translating": "Wird übersetzt...",
-    "translation": "Übersetzung ({code})"
+    "translation": "Übersetzung ({code})",
+    "missingApiKey": "API-Schlüssel fehlt",
+    "invalidApiKey": "Ungültiger API-Schlüssel",
+    "pressEnter": "Zum Übersetzen Enter drücken"
   },
   "settings": {
-    "backend": {
-      "description": "Wählen Sie den zu verwendenden Übersetzungsdienst",
-      "label": "Übersetzungsdienst"
-    }
+    "backend-description": "Wählen Sie den zu verwendenden Übersetzungsdienst",
+    "backend-label": "Übersetzungsdienst",
+    "realTime-label": "Echtzeitübersetzung",
+    "realTime-description": "Während der Eingabe übersetzen (kann zu einem erheblichen Token-Verbrauch führen)",
+    "apiKey-placeholder": "Gib deinen API-Schlüssel hier ein",
+    "apiKey-label": "API Schlüssel",
+    "showPreview-label": "Übersetzungsvorschau",
+    "showPreview-description": "Das Übersetzungsergebnis im Vorschaufenster anzeigen"
   }
 }

--- a/translator/i18n/en.json
+++ b/translator/i18n/en.json
@@ -117,6 +117,6 @@
       "apiKey-placeholder": "Enter your API key here",
       "apiKey-label": "API Key",
       "showPreview-label": "Translation Preview",
-      "showPreview-description": "Show the translation result in the preview pane"
+      "showPreview-description": "Show the translation result in the preview panel"
   }
 }

--- a/translator/manifest.json
+++ b/translator/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "translator",
   "name": "Translator",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "minNoctaliaVersion": "4.4.1",
   "author": "Cleboost",
   "license": "MIT",


### PR DESCRIPTION
updated german translations for the `translator` plugin

also fixed a typo in the english translations