### PR TITLE
feat(ip-monitor): change IP fetch API from ipinfo.io to ip-api.com

### DIFF
--- a/ip-monitor/BarWidget.qml
+++ b/ip-monitor/BarWidget.qml
@@ -1,12 +1,12 @@
 import QtQuick
 import QtQuick.Layouts
 import Quickshell
+import "." as Local
 import qs.Commons
 import qs.Modules.Bar.Extras
 import qs.Modules.Panels.Settings
 import qs.Services.UI
 import qs.Widgets
-import "." as Local
 
 Item {
   id: root
@@ -41,8 +41,10 @@ Item {
   readonly property bool isVerticalBar: barPosition === "left" || barPosition === "right"
 
   readonly property string currentIcon: {
-    if (fetchState === "loading") return loadingIconKey;
-    if (fetchState === "error") return errorIconKey;
+    if (fetchState === "loading")
+      return loadingIconKey;
+    if (fetchState === "error")
+      return errorIconKey;
     return successIconKey;
   }
 
@@ -55,11 +57,11 @@ Item {
   onIpMonitorServiceChanged: {
     Logger.d("IpMonitor", "BarWidget ipMonitorService changed:", ipMonitorService !== null);
   }
-  
+
   onCurrentIpChanged: {
     Logger.d("IpMonitor", "BarWidget currentIp changed to:", currentIp);
   }
-  
+
   Component.onCompleted: {
     Logger.d("IpMonitor", "BarWidget completed refresh");
   }
@@ -84,8 +86,10 @@ Item {
         lines.push("");
         if (data.city || data.country) {
           var parts = [];
-          if (data.city) parts.push(data.city);
-          if (data.country) parts.push(data.country);
+          if (data.city)
+            parts.push(data.city);
+          if (data.country)
+            parts.push(data.country);
           lines.push(parts.join(", "));
         }
       }
@@ -144,4 +148,3 @@ Item {
     }
   }
 }
-

--- a/ip-monitor/Main.qml
+++ b/ip-monitor/Main.qml
@@ -1,9 +1,9 @@
 import QtQuick
 import Quickshell
 import Quickshell.Io
+import "." as Local
 import qs.Commons
 import qs.Services.UI
-import "." as Local
 
 Item {
   id: root
@@ -13,46 +13,58 @@ Item {
   // IP Monitor Service
   Item {
     id: service
-    
+
     property var ipData: null
     property string currentIp: "n/a"
     property string fetchState: "idle" // idle, loading, success, error
     property int lastFetchTime: 0
-    
+
     // Increment this to trigger refresh in all listening widgets (for IPC)
     property int refreshTrigger: 0
-    
+
     // Read global settings
     readonly property var cfg: root.pluginApi?.pluginSettings || ({})
     readonly property var defaults: root.pluginApi?.manifest?.metadata?.defaultSettings || ({})
     readonly property int refreshInterval: cfg.refreshInterval ?? defaults.refreshInterval ?? 300
-    
+
     // Process for fetching IP info
     property Process ipFetchProcess: Process {
       running: false
-      command: ["curl", "-s", "-m", "10", "https://ipinfo.io"]
+      command: ["curl", "-s", "-m", "10", "http://ip-api.com/json/?fields=status,continent,country,regionName,city,zip,lat,lon,timezone,currency,org,as,query"]
       stdout: StdioCollector {
         id: stdoutCollector
       }
       stderr: StdioCollector {
         id: stderrCollector
       }
-      
+
       onStarted: {
         service.fetchState = "loading";
         Logger.d("IpMonitor", "Service fetching IP info...");
       }
-      
-      onExited: function(exitCode, exitStatus) {
+
+      onExited: function (exitCode, exitStatus) {
         var output = stdoutCollector.text;
         Logger.d("IpMonitor", "Service process exited:", exitCode, "length:", output.length);
-        
+
         if (exitCode === 0 && output.length > 0) {
           try {
             var data = JSON.parse(output);
-            if (data.ip) {
-              service.ipData = data;
-              service.currentIp = data.ip;
+            if (data.status === "success") {
+              service.ipData = {
+                ip: data.query,
+                city: data.city || "n/a",
+                country: data.country || "n/a",
+                continent: data.continent || "n/a",
+                region: data.regionName || "n/a",
+                postal: data.zip || "n/a",
+                loc: (data.lat && data.lon) ? (data.lat + "," + data.lon) : "n/a",
+                timezone: data.timezone || "n/a",
+                currency: data.currency || "n/a",
+                org: data.org || "n/a",
+                as: data.as || "n/a"
+              };
+              service.currentIp = data.query;
               service.fetchState = "success";
               service.lastFetchTime = Date.now();
               Logger.d("IpMonitor", "Service IP fetched successfully:", service.currentIp);
@@ -73,20 +85,20 @@ Item {
         }
       }
     }
-    
+
     property Timer autoRefreshTimer: Timer {
       interval: service.refreshInterval * 1000
       running: interval > 0
       repeat: true
       onTriggered: service.fetchIp()
     }
-    
+
     Component.onCompleted: {
       Logger.i("IpMonitor", "Service initialized, frist time fetching IP.");
       // Auto-fetch on startup
       Qt.callLater(() => fetchIp());
     }
-    
+
     function fetchIp() {
       if (!service.ipFetchProcess) {
         Logger.e("IpMonitor", "Service ipFetchProcess is null!");
@@ -99,7 +111,7 @@ Item {
         Logger.d("IpMonitor", "Service fetch already in progress");
       }
     }
-    
+
     function triggerRefresh() {
       Logger.d("IpMonitor", "Service triggerRefresh() called");
       refreshTrigger++;
@@ -115,20 +127,19 @@ Item {
   // IPC handlers
   IpcHandler {
     target: "plugin:ip-monitor"
-    
+
     function refreshIp() {
       Logger.i("IpMonitor", "IPC refreshIp() called");
       service.triggerRefresh();
       ToastService.showNotice("Refreshing IP info...");
     }
-    
+
     function toggle() {
       if (pluginApi) {
         pluginApi.withCurrentScreen(screen => {
-          pluginApi.openPanel(screen);
-        });
+					pluginApi.openPanel(screen);
+				});
       }
     }
   }
 }
-

--- a/ip-monitor/Panel.qml
+++ b/ip-monitor/Panel.qml
@@ -18,7 +18,7 @@ Item {
   // SmartPanel
   readonly property var geometryPlaceholder: panelContainer
 
-  property real contentPreferredWidth: 425 * Style.uiScaleRatio
+  property real contentPreferredWidth: 435 * Style.uiScaleRatio
   property real contentPreferredHeight: 530 * Style.uiScaleRatio
 
   readonly property bool allowAttach: true
@@ -150,7 +150,7 @@ Item {
         visible: root.fetchState === "success" && root.ipData
 
         NText {
-          text: "Details"
+          text: pluginApi?.tr("panel.details.title")
           font.pointSize: Style.fontSizeM * Style.uiScaleRatio
           font.weight: Font.Medium
           color: Color.mOnSurface
@@ -172,47 +172,47 @@ Item {
             Repeater {
               model: [
                 {
-                  label: "IP Address",
+                  label: pluginApi?.tr("panel.details.ip"),
                   value: root.ipData?.ip
                 },
                 {
-                  label: "City",
+                  label: pluginApi?.tr("panel.details.city"),
                   value: root.ipData?.city
                 },
                 {
-                  label: "Country",
+                  label: pluginApi?.tr("panel.details.country"),
                   value: root.ipData?.country
                 },
                 {
-                  label: "Region",
+                  label: pluginApi?.tr("panel.details.region"),
                   value: root.ipData?.region
                 },
                 {
-                  label: "Continent",
+                  label: pluginApi?.tr("panel.details.continent"),
                   value: root.ipData?.continent
                 },
                 {
-                  label: "Postal Code",
+                  label: pluginApi?.tr("panel.details.postal-code"),
                   value: root.ipData?.postal
                 },
                 {
-                  label: "Location",
+                  label: pluginApi?.tr("panel.details.location"),
                   value: root.ipData?.loc
                 },
                 {
-                  label: "Timezone",
+                  label: pluginApi?.tr("panel.details.timezone"),
                   value: root.ipData?.timezone
                 },
                 {
-                  label: "Currency",
+                  label: pluginApi?.tr("panel.details.currency"),
                   value: root.ipData?.currency
                 },
                 {
-                  label: "Organization",
+                  label: pluginApi?.tr("panel.details.org"),
                   value: root.ipData?.org
                 },
                 {
-                  label: "AS Name",
+                  label: pluginApi?.tr("panel.details.as-name"),
                   value: root.ipData?.as
                 },
               ]
@@ -225,7 +225,7 @@ Item {
                   text: modelData.label + ":"
                   font.pointSize: Style.fontSizeS * Style.uiScaleRatio
                   color: Color.mOnSurfaceVariant
-                  Layout.preferredWidth: 90
+                  Layout.preferredWidth: 100
                 }
 
                 NText {

--- a/ip-monitor/Panel.qml
+++ b/ip-monitor/Panel.qml
@@ -17,8 +17,8 @@ Item {
   // SmartPanel
   readonly property var geometryPlaceholder: panelContainer
 
-  property real contentPreferredWidth: 440 * Style.uiScaleRatio
-  property real contentPreferredHeight: 640 * Style.uiScaleRatio
+  property real contentPreferredWidth: 425 * Style.uiScaleRatio
+  property real contentPreferredHeight: 530 * Style.uiScaleRatio
 
   readonly property bool allowAttach: true
 
@@ -160,15 +160,17 @@ Item {
 
             Repeater {
               model: [
-                { label: "IP Address", value: root.ipData?.ip ?? "n/a" },
-                { label: "Hostname", value: root.ipData?.hostname ?? "n/a" },
-                { label: "City", value: root.ipData?.city ?? "n/a" },
-                { label: "Region", value: root.ipData?.region ?? "n/a" },
-                { label: "Country", value: root.ipData?.country ?? "n/a" },
-                { label: "Location", value: root.ipData?.loc ?? "n/a" },
-                { label: "Postal Code", value: root.ipData?.postal ?? "n/a" },
-                { label: "Timezone", value: root.ipData?.timezone ?? "n/a" },
-                { label: "Organization", value: root.ipData?.org ?? "n/a" },
+                { label: "IP Address", value: root.ipData?.ip },
+								{ label: "City", value: root.ipData?.city },
+								{ label: "Country", value: root.ipData?.country },
+								{ label: "Region", value: root.ipData?.region },
+								{ label: "Continent", value: root.ipData?.continent },
+								{ label: "Postal Code", value: root.ipData?.postal },
+                { label: "Location", value: root.ipData?.loc },
+                { label: "Timezone", value: root.ipData?.timezone },
+								{ label: "Currency", value: root.ipData?.currency },
+                { label: "Organization", value: root.ipData?.org },
+								{ label: "AS Name", value: root.ipData?.as },
               ]
 
               RowLayout {
@@ -179,7 +181,7 @@ Item {
                   text: modelData.label + ":"
                   font.pointSize: Style.fontSizeS * Style.uiScaleRatio
                   color: Color.mOnSurfaceVariant
-                  Layout.preferredWidth: 120
+                  Layout.preferredWidth: 90
                 }
 
                 NText {
@@ -191,49 +193,6 @@ Item {
                   elide: Text.ElideRight
                 }
               }
-            }
-          }
-        }
-
-        // IPC Examples
-        NText {
-          text: "IPC Commands"
-          font.pointSize: Style.fontSizeM * Style.uiScaleRatio
-          font.weight: Font.Medium
-          color: Color.mOnSurface
-          Layout.topMargin: Style.marginM
-        }
-
-        Rectangle {
-          Layout.fillWidth: true
-          Layout.preferredHeight: examplesColumn.implicitHeight + Style.marginM * 2
-          color: Color.mSurfaceVariant
-          radius: Style.radiusM
-
-          ColumnLayout {
-            id: examplesColumn
-            anchors {
-              fill: parent
-              margins: Style.marginM
-            }
-            spacing: Style.marginS
-
-            NText {
-              text: "$ qs -c noctalia-shell ipc call plugin:ip-monitor refreshIp"
-              font.pointSize: Style.fontSizeS * Style.uiScaleRatio
-              font.family: Settings.data.ui.fontFixed
-              color: Color.mPrimary
-              Layout.fillWidth: true
-              wrapMode: Text.WrapAnywhere
-            }
-
-            NText {
-              text: "$ qs -c noctalia-shell ipc call plugin:ip-monitor toggle"
-              font.pointSize: Style.fontSizeS * Style.uiScaleRatio
-              font.family: Settings.data.ui.fontFixed
-              color: Color.mPrimary
-              Layout.fillWidth: true
-              wrapMode: Text.WrapAnywhere
             }
           }
         }

--- a/ip-monitor/Panel.qml
+++ b/ip-monitor/Panel.qml
@@ -1,10 +1,11 @@
 import QtQuick
 import QtQuick.Layouts
+import Quickshell
 import Quickshell.Io
+import "." as Local
 import qs.Commons
 import qs.Services.UI
 import qs.Widgets
-import "." as Local
 
 // Panel Component
 Item {
@@ -37,7 +38,8 @@ Item {
   // Trigger refresh via service
   function refreshIp() {
     Logger.d("IpMonitor", "Panel triggering service refresh");
-    if (ipMonitorService) ipMonitorService.fetchIp();
+    if (ipMonitorService)
+      ipMonitorService.fetchIp();
   }
 
   Rectangle {
@@ -89,15 +91,19 @@ Item {
 
           NIcon {
             icon: {
-              if (root.fetchState === "loading") return "loader";
-              if (root.fetchState === "error") return "alert-circle";
+              if (root.fetchState === "loading")
+                return "loader";
+              if (root.fetchState === "error")
+                return "alert-circle";
               return "network";
             }
             Layout.alignment: Qt.AlignHCenter
             pointSize: Style.fontSizeXXL * 2 * Style.uiScaleRatio
             color: {
-              if (root.fetchState === "success") return Color.mPrimary;
-              if (root.fetchState === "error") return Color.mError;
+              if (root.fetchState === "success")
+                return Color.mPrimary;
+              if (root.fetchState === "error")
+                return Color.mError;
               return Color.mOnSurfaceVariant;
             }
           }
@@ -105,9 +111,12 @@ Item {
           NText {
             Layout.alignment: Qt.AlignHCenter
             text: {
-              if (root.fetchState === "loading") return "Fetching IP...";
-              if (root.fetchState === "error") return "Failed to fetch IP";
-              if (root.ipData?.ip) return root.ipData.ip;
+              if (root.fetchState === "loading")
+                return "Fetching IP...";
+              if (root.fetchState === "error")
+                return "Failed to fetch IP";
+              if (root.ipData?.ip)
+                return root.ipData.ip;
               return "n/a";
             }
             font.pointSize: Style.fontSizeXXL * Style.uiScaleRatio
@@ -121,8 +130,10 @@ Item {
             Layout.alignment: Qt.AlignHCenter
             text: {
               var parts = [];
-              if (root.ipData?.city) parts.push(root.ipData.city);
-              if (root.ipData?.country) parts.push(root.ipData.country);
+              if (root.ipData?.city)
+                parts.push(root.ipData.city);
+              if (root.ipData?.country)
+                parts.push(root.ipData.country);
               return parts.join(", ");
             }
             font.pointSize: Style.fontSizeM * Style.uiScaleRatio
@@ -160,17 +171,50 @@ Item {
 
             Repeater {
               model: [
-                { label: "IP Address", value: root.ipData?.ip },
-								{ label: "City", value: root.ipData?.city },
-								{ label: "Country", value: root.ipData?.country },
-								{ label: "Region", value: root.ipData?.region },
-								{ label: "Continent", value: root.ipData?.continent },
-								{ label: "Postal Code", value: root.ipData?.postal },
-                { label: "Location", value: root.ipData?.loc },
-                { label: "Timezone", value: root.ipData?.timezone },
-								{ label: "Currency", value: root.ipData?.currency },
-                { label: "Organization", value: root.ipData?.org },
-								{ label: "AS Name", value: root.ipData?.as },
+                {
+                  label: "IP Address",
+                  value: root.ipData?.ip
+                },
+                {
+                  label: "City",
+                  value: root.ipData?.city
+                },
+                {
+                  label: "Country",
+                  value: root.ipData?.country
+                },
+                {
+                  label: "Region",
+                  value: root.ipData?.region
+                },
+                {
+                  label: "Continent",
+                  value: root.ipData?.continent
+                },
+                {
+                  label: "Postal Code",
+                  value: root.ipData?.postal
+                },
+                {
+                  label: "Location",
+                  value: root.ipData?.loc
+                },
+                {
+                  label: "Timezone",
+                  value: root.ipData?.timezone
+                },
+                {
+                  label: "Currency",
+                  value: root.ipData?.currency
+                },
+                {
+                  label: "Organization",
+                  value: root.ipData?.org
+                },
+                {
+                  label: "AS Name",
+                  value: root.ipData?.as
+                },
               ]
 
               RowLayout {
@@ -189,8 +233,34 @@ Item {
                   font.pointSize: Style.fontSizeS * Style.uiScaleRatio
                   font.family: Settings.data.ui.fontFixed
                   color: Color.mOnSurface
-                  Layout.fillWidth: true
+                  Layout.fillWidth: index !== 0
                   elide: Text.ElideRight
+                }
+
+                NIcon {
+                  id: copyIcon
+                  visible: index === 0 && root.fetchState === "success"
+                  icon: "copy"
+                  pointSize: Style.fontSizeS * Style.uiScaleRatio
+                  color: copyHover.containsMouse ? Color.mOnSurfaceVariant : Color.mPrimary
+                  Layout.alignment: Qt.AlignVCenter
+
+                  MouseArea {
+                    id: copyHover
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: {
+                      var ip = root.ipData?.ip;
+                      if (ip && ip !== "n/a") {
+                        Quickshell.execDetached(["sh", "-c", `printf '%s' '${ip}' | wl-copy`]);
+                        ToastService.showNotice("IP copied to clipboard: " + ip);
+                        Logger.d("IpMonitor", "Copied IP to clipboard:", ip);
+                      } else {
+                        ToastService.showNotice("No IP to copy");
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -200,4 +270,3 @@ Item {
     }
   }
 }
-

--- a/ip-monitor/Settings.qml
+++ b/ip-monitor/Settings.qml
@@ -164,6 +164,66 @@ ColumnLayout {
         }
       }
     }
+
+		// IPC keybinding
+		NText {
+      text: pluginApi?.tr("settings.commands.title")
+      font.pointSize: Style.fontSizeM * Style.uiScaleRatio
+      font.weight: Font.Medium
+      color: Color.mOnSurface
+      Layout.topMargin: Style.marginM
+    }
+
+		Rectangle {
+			Layout.fillWidth: true
+			Layout.preferredHeight: infoCol.implicitHeight + Style.marginM * 2
+			color: Color.mSurfaceVariant
+			radius: Style.radiusM
+
+			ColumnLayout {
+				id: infoCol
+				anchors {
+					fill: parent
+					margins: Style.marginM
+				}
+				spacing: Style.marginS
+
+				RowLayout {
+					spacing: Style.marginS
+
+					NIcon {
+						icon: "info-circle"
+						pointSize: Style.fontSizeS
+						color: Color.mPrimary
+					}
+
+					NText {
+						text: pluginApi?.tr("settings.ipcCommands.title")
+						pointSize: Style.fontSizeS
+						font.weight: Font.Medium
+						color: Color.mOnSurface
+					}
+				}
+
+				NText {
+					Layout.fillWidth: true
+					text: pluginApi?.tr("settings.ipcCommands.refreshIp") + ": qs -c noctalia-shell ipc call plugin:ip-monitor refreshIp"
+					pointSize: Style.fontSizeXS
+					font.family: Settings.data.ui.fontFixed
+					color: Color.mOnSurfaceVariant
+					wrapMode: Text.WrapAnywhere
+				}
+
+				NText {
+					Layout.fillWidth: true
+					text: pluginApi?.tr("settings.ipcCommands.togglePanel") + ": qs -c noctalia-shell ipc call plugin:ip-monitor toggle"
+					pointSize: Style.fontSizeXS
+					font.family: Settings.data.ui.fontFixed
+					color: Color.mOnSurfaceVariant
+					wrapMode: Text.WrapAnywhere
+				}
+			}
+		}
   }
 
   signal settingsChanged(var settings)

--- a/ip-monitor/i18n/de.json
+++ b/ip-monitor/i18n/de.json
@@ -3,8 +3,20 @@
     "settings": "Widget-Einstellungen"
   },
   "panel": {
-    "test": "Diese Zeichenfolge wird über die Plugin-API übersetzt",
-    "open-settings": "Plugin-Einstellungen öffnen"
+    "details": {
+      "title": "Details",
+      "ip": "IP-Adresse",
+      "city": "Stadt",
+      "country": "Land",
+      "region": "Region",
+      "continent": "Kontinent",
+      "postal-code": "Postleitzahl",
+      "location": "Standort",
+      "timezone": "Zeitzone",
+      "currency": "Währung",
+      "org": "Organisation",
+      "as-name": "AS-Name"
+    }
   },
   "settings": {
     "appearance": {

--- a/ip-monitor/i18n/de.json
+++ b/ip-monitor/i18n/de.json
@@ -37,6 +37,14 @@
       "desc": "Wie oft die IP-Informationen automatisch aktualisiert werden sollen. Auf 0 setzen, um die automatische Aktualisierung zu deaktivieren.",
       "label": "Automatisches Aktualisierungsintervall (Sekunden)",
       "placeholder": "300"
+    },
+    "commands": {
+      "title": "Befehle"
+    },
+    "ipcCommands": {
+      "title": "IPC-Befehle",
+      "refreshIp": "IP-Adresse aktualisieren",
+      "togglePanel": "Panel ein-/ausblenden"
     }
   }
 }

--- a/ip-monitor/i18n/en.json
+++ b/ip-monitor/i18n/en.json
@@ -3,8 +3,20 @@
     "settings": "Widget settings"
   },
   "panel": {
-    "test": "This string is translated via the plugin API",
-    "open-settings": "Open Plugin Settings"
+    "details": {
+      "title": "Details",
+      "ip": "IP Address",
+      "city": "City",
+      "country": "Country",
+      "region": "Region",
+      "continent": "Continent",
+      "postal-code": "Postal Code",
+      "location": "Location",
+      "timezone": "Timezone",
+      "currency": "Currency",
+      "org": "Organization",
+      "as-name": "AS Name"
+    }
   },
   "settings": {
     "appearance": {

--- a/ip-monitor/i18n/en.json
+++ b/ip-monitor/i18n/en.json
@@ -37,6 +37,14 @@
       "desc": "How often to automatically refresh IP info. Set to 0 to disable auto-refresh.",
       "label": "Auto-refresh Interval (seconds)",
       "placeholder": "300"
+    },
+    "commands": {
+      "title": "Commands"
+    },
+    "ipcCommands": {
+      "title": "IPC Commands",
+      "refreshIp": "Refresh IP",
+      "togglePanel": "Toggle panel"
     }
   }
 }

--- a/ip-monitor/i18n/fr.json
+++ b/ip-monitor/i18n/fr.json
@@ -3,8 +3,20 @@
     "settings": "Paramètres du widget"
   },
   "panel": {
-    "test": "Cette chaîne est traduite via l'API du plugin",
-    "open-settings": "Ouvrir les paramètres du plugin"
+    "details": {
+      "title": "Détails",
+      "ip": "Adresse IP",
+      "city": "Ville",
+      "country": "Pays",
+      "region": "Région",
+      "continent": "Continent",
+      "postal-code": "Code postal",
+      "location": "Emplacement",
+      "timezone": "Fuseau horaire",
+      "currency": "Devise",
+      "org": "Organisation",
+      "as-name": "Nom AS"
+    }
   },
   "settings": {
     "appearance": {

--- a/ip-monitor/i18n/fr.json
+++ b/ip-monitor/i18n/fr.json
@@ -37,6 +37,14 @@
       "desc": "Fréquence de rafraîchissement automatique des informations IP. Mettre à 0 pour désactiver le rafraîchissement automatique.",
       "label": "Intervalle de rafraîchissement automatique (secondes)",
       "placeholder": "300"
+    },
+    "commands": {
+      "title": "Commandes"
+    },
+    "ipcCommands": {
+      "title": "Commandes IPC",
+      "refreshIp": "Actualiser l'adresse IP",
+      "togglePanel": "Afficher/Masquer le panneau"
     }
   }
 }

--- a/ip-monitor/i18n/pl.json
+++ b/ip-monitor/i18n/pl.json
@@ -3,8 +3,20 @@
     "settings": "Ustawienia widżetu"
   },
   "panel": {
-    "test": "Ten ciąg jest tłumaczony przez API wtyczki",
-    "open-settings": "Otwórz ustawienia wtyczki"
+    "details": {
+      "title": "Szczegóły",
+      "ip": "Adres IP",
+      "city": "Miasto",
+      "country": "Kraj",
+      "region": "Region",
+      "continent": "Kontynent",
+      "postal-code": "Kod pocztowy",
+      "location": "Lokalizacja",
+      "timezone": "Strefa czasowa",
+      "currency": "Waluta",
+      "org": "Organizacja",
+      "as-name": "Nazwa AS"
+    }
   },
   "settings": {
     "appearance": {

--- a/ip-monitor/i18n/pl.json
+++ b/ip-monitor/i18n/pl.json
@@ -37,6 +37,14 @@
       "desc": "Jak często automatycznie odświeżać informacje o IP. Ustaw na 0, aby wyłączyć automatyczne odświeżanie.",
       "label": "Interwał automatycznego odświeżania (sekundy)",
       "placeholder": "300"
+    },
+    "commands": {
+      "title": "Polecenia"
+    },
+    "ipcCommands": {
+      "title": "Polecenia IPC",
+      "refreshIp": "Odśwież adres IP",
+      "togglePanel": "Pokaż/ukryj panel"
     }
   }
 }

--- a/ip-monitor/i18n/vi.json
+++ b/ip-monitor/i18n/vi.json
@@ -3,8 +3,20 @@
     "settings": "Cài đặt tiện ích"
   },
   "panel": {
-    "test": "Chuỗi này được dịch thông qua API plugin",
-    "open-settings": "Mở cài đặt plugin"
+    "details": {
+      "title": "Chi tiết",
+      "ip": "Địa chỉ IP",
+      "city": "Thành phố",
+      "country": "Quốc gia",
+      "region": "Vùng",
+      "continent": "Châu lục",
+      "postal-code": "Mã bưu chính",
+      "location": "Vị trí",
+      "timezone": "Múi giờ",
+      "currency": "Tiền tệ",
+      "org": "Tổ chức",
+      "as-name": "Tên AS"
+    }
   },
   "settings": {
     "appearance": {

--- a/ip-monitor/i18n/vi.json
+++ b/ip-monitor/i18n/vi.json
@@ -1,0 +1,50 @@
+{
+  "menu": {
+    "settings": "Cài đặt tiện ích"
+  },
+  "panel": {
+    "test": "Chuỗi này được dịch thông qua API plugin",
+    "open-settings": "Mở cài đặt plugin"
+  },
+  "settings": {
+    "appearance": {
+      "title": "Giao diện"
+    },
+    "iconColor": {
+      "desc": "Màu của biểu tượng khi lấy IP thành công",
+      "label": "Màu biểu tượng"
+    },
+    "stateIcons": {
+      "title": "Biểu tượng trạng thái"
+    },
+    "successIcon": {
+      "desc": "Biểu tượng hiển thị khi lấy IP thành công",
+      "label": "Biểu tượng thành công"
+    },
+    "errorIcon": {
+      "desc": "Biểu tượng hiển thị khi lấy IP thất bại",
+      "label": "Biểu tượng thất bại"
+    },
+    "loadingIcon": {
+      "desc": "Biểu tượng hiển thị trong khi đang lấy IP",
+      "label": "Biểu tượng đang tải"
+    },
+    "browseIcons": "Tìm biểu tượng",
+    "behavior": {
+      "title": "Hành vi"
+    },
+    "refreshInterval": {
+      "desc": "Tần suất tự động làm mới thông tin IP. Đặt 0 để tắt tự động làm mới.",
+      "label": "Khoảng thời gian tự động làm mới (giây)",
+      "placeholder": "300"
+    },
+    "commands": {
+      "title": "Các lệnh"
+    },
+    "ipcCommands": {
+      "title": "Lệnh IPC",
+      "refreshIp": "Làm mới IP",
+      "togglePanel": "Bật/tắt bảng"
+    }
+  }
+}

--- a/ip-monitor/manifest.json
+++ b/ip-monitor/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "ip-monitor",
   "name": "IP Monitor",
-  "version": "0.0.2",
+  "version": "0.1.2",
   "minNoctaliaVersion": "4.4.3",
   "author": "deepalpha",
   "official": false,

--- a/ip-monitor/manifest.json
+++ b/ip-monitor/manifest.json
@@ -4,7 +4,6 @@
   "version": "0.1.2",
   "minNoctaliaVersion": "4.4.3",
   "author": "deepalpha",
-  "official": false,
   "license": "MIT",
   "repository": "https://github.com/noctalia-dev/noctalia-plugins",
   "description": "Plugin showing current external IP",

--- a/tailscale/Main.qml
+++ b/tailscale/Main.qml
@@ -502,6 +502,12 @@ Item {
       toggleTailscale()
     }
 
+		function togglePanel() {
+			pluginApi.withCurrentScreen(screen => {
+				pluginApi.togglePanel(screen);
+			});
+		}
+
     function status() {
       return {
         "installed": root.tailscaleInstalled,

--- a/tailscale/README.md
+++ b/tailscale/README.md
@@ -87,6 +87,7 @@ qs -c noctalia-shell ipc call plugin:tailscale <command>
 | Command | Description | Example |
 |---|---|---|
 | `toggle` | Toggle Tailscale connection (connect/disconnect) | `qs -c noctalia-shell ipc call plugin:tailscale toggle` |
+| `togglePanel` | Toggle Tailscale panel | `qs -c noctalia-shell ipc call plugin:tailscale togglePanel` |
 | `status` | Get current Tailscale status | `qs -c noctalia-shell ipc call plugin:tailscale status` |
 | `refresh` | Force refresh Tailscale status | `qs -c noctalia-shell ipc call plugin:tailscale refresh` |
 | `receive` | Fetch any pending Taildrop files | `qs -c noctalia-shell ipc call plugin:tailscale receive` |

--- a/tailscale/manifest.json
+++ b/tailscale/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "tailscale",
   "name": "Tailscale",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "minNoctaliaVersion": "4.0.0",
   "author": "nineluj",
   "license": "MIT",


### PR DESCRIPTION
@deep4lpha I changed the IP fetch API in the plugin to support when you connect to Warp or VPN, the one were used isn't fetched when connecting to Warp or VPN because of the rates limit.

I also removed the IPC commands from the Panel.qml and added it into Settings.qml instead, I think users would prefer seeing it inside Settings instead of Panel. Also little adjustment on the IP details since the new API doesn't provide some of the old datas.

Hope this new one helps with the Warp and VPN connection failed to fetch IP issue when using ipinfo.io.

If you have time please review these and tell me if there's anything that should be changed, really thanks for this cool plugin :).