### PR TITLE
fix(tailscale): use Tailscale DNS name for taildrop send

### DIFF
--- a/tailscale/Main.qml
+++ b/tailscale/Main.qml
@@ -80,6 +80,13 @@ Item {
     return label || hostName
   }
 
+  // Extract the Tailscale short name from DNSName (e.g. "tp-g6.tail68e513.ts.net." → "tp-g6").
+  // This is what `tailscale file cp` and other commands expect as a target.
+  function tailscaleName(dnsName) {
+    if (!dnsName) return ""
+    return dnsName.split(".")[0] || ""
+  }
+
   Process {
     id: whichProcess
     stdout: StdioCollector {}

--- a/tailscale/Panel.qml
+++ b/tailscale/Panel.qml
@@ -33,7 +33,9 @@ Item {
     initialPath: Quickshell.env("HOME") ?? ""
     onAccepted: function(paths) {
       if (!mainInstance || !root.sendTargetPeer || paths.length === 0) return
-      var target = root.sendTargetPeer.HostName + ":"
+      // Use Tailscale DNS name (not system HostName) to avoid LAN DNS resolution
+      var tsName = mainInstance.tailscaleName(root.sendTargetPeer.DNSName)
+      var target = (tsName || root.sendTargetPeer.TailscaleIPs[0]) + ":"
       mainInstance.sendFilesViaTaildrop(paths, target)
     }
   }
@@ -510,7 +512,7 @@ Item {
                   Layout.fillWidth: true
                   Layout.preferredWidth: peerFlickable.width
                   implicitWidth: peerFlickable.width
-                  height: 48
+                  implicitHeight: contentItem.implicitHeight + topPadding + bottomPadding
                   topPadding: Style.marginS
                   bottomPadding: Style.marginS
                   leftPadding: Style.marginL
@@ -519,6 +521,7 @@ Item {
                   readonly property var peerData: modelData
                   readonly property string peerIp: filterIPv4(peerData.TailscaleIPs)[0] || ""
                   readonly property string peerHostname: peerData.HostName || normalizeFqdn(peerData.DNSName) || "Unknown"
+                  readonly property string peerTsName: mainInstance ? mainInstance.tailscaleName(peerData.DNSName) : ""
                   readonly property bool peerOnline: peerData.Online || false
 
                   background: Rectangle {
@@ -538,12 +541,26 @@ Item {
                       color: peerDelegate.peerOnline ? Color.mPrimary : Color.mOnSurfaceVariant
                     }
 
-                    NText {
-                      text: peerDelegate.peerHostname
-                      color: Color.mOnSurface
-                      font.weight: Style.fontWeightMedium
-                      elide: Text.ElideRight
+                    ColumnLayout {
+                      spacing: 0
                       Layout.fillWidth: true
+
+                      NText {
+                        text: peerDelegate.peerHostname
+                        color: Color.mOnSurface
+                        font.weight: Style.fontWeightMedium
+                        elide: Text.ElideRight
+                        Layout.fillWidth: true
+                      }
+
+                      NText {
+                        text: peerDelegate.peerTsName
+                        pointSize: Style.fontSizeXS
+                        color: Color.mOnSurfaceVariant
+                        elide: Text.ElideRight
+                        Layout.fillWidth: true
+                        visible: peerDelegate.peerTsName !== "" && peerDelegate.peerTsName !== peerDelegate.peerHostname
+                      }
                     }
 
                     NIcon {


### PR DESCRIPTION
## Problem

Taildrop file send fails with:

```
can't send to <hostname>: unknown target; <ipv6-addr> is not a Tailscale IP address
```

The plugin uses the system `HostName` (e.g. `thinkpad-p14s-g6`) as the target for `tailscale file cp`. System DNS resolves it to a LAN IPv6 address, which Tailscale rejects since it's not a Tailscale IP.

## Fix

- Use the Tailscale DNS name (first label of `DNSName`, e.g. `tp-g6`) as the send target, falling back to `TailscaleIPs[0]` if unavailable
- Add `tailscaleName()` helper to extract the short name from `DNSName`

## Bonus: show Tailscale DNS name in peer list

When the system hostname differs from the Tailscale DNS name, show the DNS name as a subtitle under the hostname. This helps users identify the correct Tailscale name for CLI use.

```
[icon] thinkpad-p14s-g6          100.85.9.46
       tp-g6
```

Row height auto-sizes to fit.