### PR TITLE
Improve slowbongo

### DIFF
--- a/slowbongo/Main.qml
+++ b/slowbongo/Main.qml
@@ -292,9 +292,9 @@ Item {
                 stdout: SplitParser {
                     onRead: data => {
                         if (data.includes("EV_KEY") && data.includes("value 1")) {
-                            // Detect spacebar for double slap (both paws)
-                            const isSpace = data.includes("KEY_SPACE");
-                            root.onKeyPress(isSpace);
+                            // Detect spacebar/enter for double slap (both paws)
+                            const isBigHit = data.includes("KEY_SPACE") || data.includes("KEY_ENTER");
+                            root.onKeyPress(isBigHit);
                         }
                     }
                 }

--- a/slowbongo/Main.qml
+++ b/slowbongo/Main.qml
@@ -425,9 +425,14 @@ Item {
                     if (exitCode === 0) {
                         Logger.i("Slow Bongo", "Device detected, restarting monitoring: " + deviceMonitor.modelData);
                         evtestProc.running = true;
-                    } else if (deviceMonitor.retryCount <= deviceMonitor.retryIntervals.length) {
-                        Logger.i("Slow Bongo", "Device not found, will check again: " + deviceMonitor.modelData);
+                    } else if (deviceMonitor.retryCount < deviceMonitor.retryIntervals.length) {
+                        deviceMonitor.retryCount++;;
+                        const interval = deviceMonitor.retryIntervals[deviceMonitor.retryCount - 1];
+                        Logger.i("Slow Bongo", "Device " + deviceMonitor.modelData + " not found, will retry in " + Math.floor(interval / 1000) + "s (attempt " + deviceMonitor.retryCount + "/" + deviceMonitor.retryIntervals.length + ")");
+                        restartTimer.interval = interval;
                         restartTimer.start();
+                    } else {
+                        Logger.w("Slow Bongo", "Max retries reached for device: " + deviceMonitor.modelData + ". Giving up.");
                     }
                 }
             }

--- a/slowbongo/Main.qml
+++ b/slowbongo/Main.qml
@@ -139,7 +139,7 @@ Item {
                 }
 
                 if (root.useTappyMode) {
-                    root.onKeyPress(root.bassIntensity > root.bigBeatThreshold);
+                    root.musicEvent(root.bassIntensity > root.bigBeatThreshold);
                 }
 
                 beatCooldownTimer.restart();
@@ -168,8 +168,8 @@ Item {
         onTriggered: root.catState = root.pendingCatState
     }
 
-    // === KEY PRESS HANDLER ===
-    function onKeyPress(isBigHit = false) {
+    // === MUSIC HANDLER ===
+    function musicEvent(isBigHit = false) {
         if (root.paused) return;
         root.waiting = false;
 
@@ -192,6 +192,65 @@ Item {
         }
 
         idleTimer.restart();
+        waitingTimer.restart();
+    }
+
+    // === KEY PRESS HANDLER ===
+    function onKeyPress(isBigHit = false) {
+        if (root.paused) return;
+        root.waiting = false;
+
+        let targetState;
+        if (isBigHit) {
+            targetState = 3;
+        } else {
+            if (root.catState !== 0){
+                targetState = 3;
+            } else {
+                root.leftWasLast = !root.leftWasLast;
+                targetState = root.leftWasLast ? 1 : 2;
+            }
+        }
+
+        root.catState = targetState;
+        waitingTimer.restart();
+    }
+
+    function onKeyRelease(isBigHit = false) {
+        if (root.paused) return;
+        root.waiting = false;
+
+        let targetState;
+        if (isBigHit) {
+            targetState = 0;
+        } else {
+            if (root.catState === 3){
+                targetState = root.leftWasLast ? 1 : 2;
+            } else {
+                targetState = 0;
+            }
+        }
+
+        root.catState = targetState;
+        waitingTimer.restart();
+    }
+
+    function onKeyRepeat(isBigHit = false){
+        if (root.paused) return;
+        root.waiting = false;
+
+        let targetState;
+        if (root.catState !== 0) {
+            targetState = root.catState;
+        } else {
+            if (isBigHit){
+                targetState = 3;
+            } else {
+                targetState = root.leftWasLast ? 1 : 2;
+            }
+        }
+
+        root.catState = targetState;
         waitingTimer.restart();
     }
 
@@ -291,10 +350,20 @@ Item {
 
                 stdout: SplitParser {
                     onRead: data => {
-                        if (data.includes("EV_KEY") && data.includes("value 1")) {
+                        if (data.includes("EV_KEY")) {
                             // Detect spacebar/enter for double slap (both paws)
                             const isBigHit = data.includes("KEY_SPACE") || data.includes("KEY_ENTER");
-                            root.onKeyPress(isBigHit);
+                            // Key pressed
+                            // Ignore BTN_TOOL_ events to avoid double events with touchpads
+                            if (data.includes("value 1") && !data.includes("BTN_TOOL_")){
+                                root.onKeyPress(isBigHit);
+                            // Key released
+                            } else if (data.includes("value 0")) {
+                                root.onKeyRelease(isBigHit);
+                            // Key repeat
+                            } else if (data.includes("value 2")) {
+                                root.onKeyRepeat(isBigHit);
+                            }
                         }
                     }
                 }

--- a/slowbongo/Settings.qml
+++ b/slowbongo/Settings.qml
@@ -265,6 +265,72 @@ ColumnLayout {
         Layout.fillWidth: true
     }
 
+    // Widget Color
+    NColorChoice {
+        label: pluginApi?.tr("settings.colours") || "Colours"
+        currentKey: root.editCatColor
+        onSelected: key => { root.editCatColor = key; }
+    }
+
+    // Cat Size Section
+    NValueSlider {
+        Layout.fillWidth: true
+        label: pluginApi?.tr("settings.cat-size") || "Cat Size"
+        value: root.editCatSize
+        from: 0.5
+        to: 1.5
+        stepSize: 0.01
+        defaultValue: 1.0
+        showReset: true
+        text: Math.round(root.editCatSize * 100) + "%"
+        onMoved: value => root.editCatSize = value
+    }
+
+    // Vertical Position Section
+    NValueSlider {
+        Layout.fillWidth: true
+        label: pluginApi?.tr("settings.vertical-position") || "Vertical Position"
+        value: root.editCatOffsetY
+        from: -0.39
+        to: 0.61
+        stepSize: 0.01
+        defaultValue: 0.11
+        showReset: true
+        text: { let v = Math.round(-(root.editCatOffsetY - 0.11) * 100) / 100; return (v > 0 ? "+" : "") + v.toFixed(2) }
+        onMoved: value => root.editCatOffsetY = value
+    }
+
+    // Rave Mode
+    NToggle {
+        label: pluginApi?.tr("settings.rave-mode") || "Rave Mode"
+        description: pluginApi?.tr("settings.rave-mode-desc") || "Change colors to the beat when music is playing"
+        checked: root.editRaveMode
+        onToggled: checked => root.editRaveMode = checked
+        defaultValue: pluginApi?.manifest?.metadata?.defaultSettings?.raveMode ?? false
+    }
+
+    // Tappy Mode
+    NToggle {
+        label: pluginApi?.tr("settings.tappy-mode") || "Tappy Mode"
+        description: pluginApi?.tr("settings.tappy-mode-desc") || "Make the cat tap along to the beat when music is playing"
+        checked: root.editTappyMode
+        onToggled: checked => root.editTappyMode = checked
+        defaultValue: pluginApi?.manifest?.metadata?.defaultSettings?.tappyMode ?? false
+    }
+
+    // MPRIS Filtering
+    NToggle {
+        label: pluginApi?.tr("settings.mpris-filter") || "MPRIS Filtering"
+        description: pluginApi?.tr("settings.mpris-filter-desc") || "Only react to audio when a non-blacklisted media player is playing (uses NoctalisShell audio blacklist)"
+        checked: root.editUseMprisFilter
+        onToggled: checked => root.editUseMprisFilter = checked
+        defaultValue: pluginApi?.manifest?.metadata?.defaultSettings?.useMprisFilter ?? false
+    }
+
+    NDivider {
+        Layout.fillWidth: true
+    }
+
     // Input Devices Section
     Text {
         text: pluginApi?.tr("settings.input-devices") || "Input Devices"
@@ -369,76 +435,6 @@ ColumnLayout {
                 }
             }
         }
-    }
-
-    NDivider {
-        Layout.fillWidth: true
-    }
-
-    // Widget Color
-    NColorChoice {
-        label: pluginApi?.tr("settings.colours") || "Colours"
-        currentKey: root.editCatColor
-        onSelected: key => { root.editCatColor = key; }
-    }
-
-    // Rave Mode
-    NToggle {
-        label: pluginApi?.tr("settings.rave-mode") || "Rave Mode"
-        description: pluginApi?.tr("settings.rave-mode-desc") || "Change colors to the beat when music is playing"
-        checked: root.editRaveMode
-        onToggled: checked => root.editRaveMode = checked
-        defaultValue: pluginApi?.manifest?.metadata?.defaultSettings?.raveMode ?? false
-    }
-
-    // Tappy Mode
-    NToggle {
-        label: pluginApi?.tr("settings.tappy-mode") || "Tappy Mode"
-        description: pluginApi?.tr("settings.tappy-mode-desc") || "Make the cat tap along to the beat when music is playing"
-        checked: root.editTappyMode
-        onToggled: checked => root.editTappyMode = checked
-        defaultValue: pluginApi?.manifest?.metadata?.defaultSettings?.tappyMode ?? false
-    }
-
-    // MPRIS Filtering
-    NToggle {
-        label: pluginApi?.tr("settings.mpris-filter") || "MPRIS Filtering"
-        description: pluginApi?.tr("settings.mpris-filter-desc") || "Only react to audio when a non-blacklisted media player is playing (uses NoctalisShell audio blacklist)"
-        checked: root.editUseMprisFilter
-        onToggled: checked => root.editUseMprisFilter = checked
-        defaultValue: pluginApi?.manifest?.metadata?.defaultSettings?.useMprisFilter ?? false
-    }
-
-    NDivider {
-        Layout.fillWidth: true
-    }
-
-    // Cat Size Section
-    NValueSlider {
-        Layout.fillWidth: true
-        label: pluginApi?.tr("settings.cat-size") || "Cat Size"
-        value: root.editCatSize
-        from: 0.5
-        to: 1.5
-        stepSize: 0.01
-        defaultValue: 1.0
-        showReset: true
-        text: Math.round(root.editCatSize * 100) + "%"
-        onMoved: value => root.editCatSize = value
-    }
-
-    // Vertical Position Section
-    NValueSlider {
-        Layout.fillWidth: true
-        label: pluginApi?.tr("settings.vertical-position") || "Vertical Position"
-        value: root.editCatOffsetY
-        from: -0.39
-        to: 0.61
-        stepSize: 0.01
-        defaultValue: 0.11
-        showReset: true
-        text: { let v = Math.round(-(root.editCatOffsetY - 0.11) * 100) / 100; return (v > 0 ? "+" : "") + v.toFixed(2) }
-        onMoved: value => root.editCatOffsetY = value
     }
 
     function saveSettings() {

--- a/slowbongo/Settings.qml
+++ b/slowbongo/Settings.qml
@@ -209,7 +209,7 @@ ColumnLayout {
 
     // Requirements Section
     Text {
-        text: pluginApi?.tr("settings.requirements") || "Requirements"
+        text: pluginApi?.tr("settings.requirements")
         color: Color.mOnSurface
         font.pointSize: Style.fontSizeM
         font.weight: Font.DemiBold
@@ -236,8 +236,8 @@ ColumnLayout {
                 }
                 Text {
                     text: root.evtestInstalled
-                        ? (pluginApi?.tr("settings.evtest-installed") || "evtest is installed")
-                        : (pluginApi?.tr("settings.evtest-not-installed") || "evtest is not installed")
+                        ? pluginApi?.tr("settings.evtest-installed")
+                        : pluginApi?.tr("settings.evtest-not-installed")
                     color: root.evtestInstalled ? root.statusSuccessColor : root.statusErrorColor
                     font.pointSize: Style.fontSizeM
                 }
@@ -252,8 +252,8 @@ ColumnLayout {
                 }
                 Text {
                     text: root.inInputGroup
-                        ? (pluginApi?.tr("settings.in-input-group") || "User is in the input group")
-                        : (pluginApi?.tr("settings.not-in-input-group") || "User is not in the input group")
+                        ? pluginApi?.tr("settings.in-input-group")
+                        : pluginApi?.tr("settings.not-in-input-group")
                     color: root.inInputGroup ? root.statusSuccessColor : root.statusErrorColor
                     font.pointSize: Style.fontSizeM
                 }
@@ -267,7 +267,7 @@ ColumnLayout {
 
     // Widget Color
     NColorChoice {
-        label: pluginApi?.tr("settings.colours") || "Colours"
+        label: pluginApi?.tr("settings.colours")
         currentKey: root.editCatColor
         onSelected: key => { root.editCatColor = key; }
     }
@@ -275,7 +275,7 @@ ColumnLayout {
     // Cat Size Section
     NValueSlider {
         Layout.fillWidth: true
-        label: pluginApi?.tr("settings.cat-size") || "Cat Size"
+        label: pluginApi?.tr("settings.cat-size")
         value: root.editCatSize
         from: 0.5
         to: 1.5
@@ -289,7 +289,7 @@ ColumnLayout {
     // Vertical Position Section
     NValueSlider {
         Layout.fillWidth: true
-        label: pluginApi?.tr("settings.vertical-position") || "Vertical Position"
+        label: pluginApi?.tr("settings.vertical-position")
         value: root.editCatOffsetY
         from: -0.39
         to: 0.61
@@ -302,8 +302,8 @@ ColumnLayout {
 
     // Rave Mode
     NToggle {
-        label: pluginApi?.tr("settings.rave-mode") || "Rave Mode"
-        description: pluginApi?.tr("settings.rave-mode-desc") || "Change colors to the beat when music is playing"
+        label: pluginApi?.tr("settings.rave-mode")
+        description: pluginApi?.tr("settings.rave-mode-desc")
         checked: root.editRaveMode
         onToggled: checked => root.editRaveMode = checked
         defaultValue: pluginApi?.manifest?.metadata?.defaultSettings?.raveMode ?? false
@@ -311,8 +311,8 @@ ColumnLayout {
 
     // Tappy Mode
     NToggle {
-        label: pluginApi?.tr("settings.tappy-mode") || "Tappy Mode"
-        description: pluginApi?.tr("settings.tappy-mode-desc") || "Make the cat tap along to the beat when music is playing"
+        label: pluginApi?.tr("settings.tappy-mode")
+        description: pluginApi?.tr("settings.tappy-mode-desc")
         checked: root.editTappyMode
         onToggled: checked => root.editTappyMode = checked
         defaultValue: pluginApi?.manifest?.metadata?.defaultSettings?.tappyMode ?? false
@@ -320,8 +320,8 @@ ColumnLayout {
 
     // MPRIS Filtering
     NToggle {
-        label: pluginApi?.tr("settings.mpris-filter") || "MPRIS Filtering"
-        description: pluginApi?.tr("settings.mpris-filter-desc") || "Only react to audio when a non-blacklisted media player is playing (uses NoctalisShell audio blacklist)"
+        label: pluginApi?.tr("settings.mpris-filter")
+        description: pluginApi?.tr("settings.mpris-filter-desc")
         checked: root.editUseMprisFilter
         onToggled: checked => root.editUseMprisFilter = checked
         defaultValue: pluginApi?.manifest?.metadata?.defaultSettings?.useMprisFilter ?? false

--- a/slowbongo/Settings.qml
+++ b/slowbongo/Settings.qml
@@ -19,7 +19,7 @@ ColumnLayout {
     property string editCatColor: {
         let saved = pluginApi?.pluginSettings?.catColor
         if (saved && saved.length > 0) return saved
-        return pluginApi?.manifest?.metadata?.defaultSettings?.catColor ?? "default"
+        return pluginApi?.manifest?.metadata?.defaultSettings?.catColor ?? "none"
     }
 
     property real editCatSize: {
@@ -63,14 +63,6 @@ ColumnLayout {
     // Status colors (with fallback for theme compatibility)
     readonly property color statusSuccessColor: Color.mPrimary
     readonly property color statusErrorColor: Color.mError ?? "#c00202"
-
-    // Configuration data
-    readonly property var colorOptions: [
-        { key: "default",   labelKey: "colors.default",   color: Color.mOnSurface },
-        { key: "primary",   labelKey: "colors.primary",   color: Color.mPrimary },
-        { key: "secondary", labelKey: "colors.secondary", color: Color.mSecondary },
-        { key: "tertiary",  labelKey: "colors.tertiary",  color: Color.mTertiary },
-    ]
 
     property var inputDevices: []
 
@@ -383,100 +375,11 @@ ColumnLayout {
         Layout.fillWidth: true
     }
 
-    // Colours Section
-    Text {
-        text: pluginApi?.tr("settings.colours") || "Colours"
-        color: Color.mOnSurface
-        font.pointSize: Style.fontSizeM
-        font.weight: Font.DemiBold
-    }
-
-    NBox {
-        id: colourBox
-        Layout.fillWidth: true
-        implicitHeight: colourContent.implicitHeight + Style.marginM * 2
-
-        property int circleSize: Math.round(Style.baseWidgetSize * 0.9)
-        property int columnCount: root.colorOptions.length
-        property real availableInner: colourBox.width - Style.marginM * 2
-        property real columnWidth: columnCount > 0 ? availableInner / columnCount : 0
-
-        ColumnLayout {
-            id: colourContent
-            anchors.left: parent.left
-            anchors.right: parent.right
-            anchors.top: parent.top
-            anchors.margins: Style.marginM
-            spacing: 0
-
-            Row {
-                id: colourRow
-                Layout.fillWidth: true
-
-                Repeater {
-                    model: root.colorOptions
-
-                    Item {
-                        required property var modelData
-                        required property int index
-
-                        width: colourBox.columnWidth
-                        height: colorCol.implicitHeight
-
-                        ColumnLayout {
-                            id: colorCol
-                            anchors.horizontalCenter: parent.horizontalCenter
-                            spacing: Style.marginXS
-
-                            Rectangle {
-                                id: colorCircle
-                                property bool isSelected: root.editCatColor === modelData.key
-                                property bool isHovered: circleMouseArea.containsMouse
-
-                                Layout.alignment: Qt.AlignHCenter
-                                implicitWidth: colourBox.circleSize
-                                implicitHeight: implicitWidth
-                                radius: width / 2
-                                color: modelData.color
-                                border.color: isSelected ? Color.mOnSurface : "transparent"
-                                border.width: isSelected ? Style.borderS + 1 : 0
-                                scale: isHovered ? 1.15 : 1.0
-
-                                Behavior on scale {
-                                    NumberAnimation { duration: Style.animationFast; easing.type: Easing.OutCubic }
-                                }
-                                Behavior on border.color {
-                                    ColorAnimation { duration: Style.animationFast }
-                                }
-
-                                MouseArea {
-                                    id: circleMouseArea
-                                    anchors.fill: parent
-                                    hoverEnabled: true
-                                    cursorShape: Qt.PointingHandCursor
-                                    onClicked: root.editCatColor = modelData.key
-                                }
-
-                                NIcon {
-                                    anchors.centerIn: parent
-                                    icon: "check"
-                                    pointSize: Math.max(Style.fontSizeXS, colorCircle.implicitWidth * 0.4)
-                                    color: Color.mOnPrimary
-                                    visible: colorCircle.isSelected
-                                }
-                            }
-
-                            Text {
-                                Layout.alignment: Qt.AlignHCenter
-                                text: pluginApi?.tr(modelData.labelKey) || modelData.key.charAt(0).toUpperCase() + modelData.key.slice(1)
-                                color: Color.mOnSurfaceVariant
-                                font.pointSize: Style.fontSizeS
-                            }
-                        }
-                    }
-                }
-            }
-        }
+    // Widget Color
+    NColorChoice {
+        label: pluginApi?.tr("settings.colours") || "Colours"
+        currentKey: root.editCatColor
+        onSelected: key => { root.editCatColor = key; }
     }
 
     // Rave Mode
@@ -518,6 +421,8 @@ ColumnLayout {
         from: 0.5
         to: 1.5
         stepSize: 0.01
+        defaultValue: 1.0
+        showReset: true
         text: Math.round(root.editCatSize * 100) + "%"
         onMoved: value => root.editCatSize = value
     }
@@ -530,6 +435,8 @@ ColumnLayout {
         from: -0.39
         to: 0.61
         stepSize: 0.01
+        defaultValue: 0.11
+        showReset: true
         text: { let v = Math.round(-(root.editCatOffsetY - 0.11) * 100) / 100; return (v > 0 ? "+" : "") + v.toFixed(2) }
         onMoved: value => root.editCatOffsetY = value
     }

--- a/slowbongo/manifest.json
+++ b/slowbongo/manifest.json
@@ -4,7 +4,6 @@
   "version": "0.8.0",
   "minNoctaliaVersion": "3.6.0",
   "author": "tui",
-  "official": false,
   "description": "A bongo cat that sits in your bar and slaps when you type.",
   "license": "MIT",
   "repository": "https://github.com/noctalia-dev/noctalia-plugins",

--- a/slowbongo/manifest.json
+++ b/slowbongo/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "slowbongo",
   "name": "Slow Bongo",
-  "version": "0.7.9",
+  "version": "0.8.0",
   "minNoctaliaVersion": "3.6.0",
   "author": "tui",
   "official": false,


### PR DESCRIPTION
This PR was originaly on the slowbongo repository but was never merged. Since slowbongo is now part of Noctalia I'm doing it again.

This MR:
- Add Enter as a big hit key
- Reorganize settings a bit (I think it is better this way but debatable)
- Add default values / reset to sliders
- Use NColorChoice widget. When I first saw your plugin I thought it was a better way to chose colors than comboboxes used by Noctalia, so I added a new widget for them. It is simpler than yours but it looks good and it simplifies your code so I went for it
- Fix a bug where slowbongo would check indefinitely for devices instead of stop after 3 fails 
- And the big part: I wanted a way for bongo cat to wait for key release to lift its paws. This is a minimal implementation:
  - I did not touch the music part, which uses the same function than before
  - The behavior is good for keyboard/mouse. I had to block BTN_TOUCH_* to avoid having 2 signals with touch gestures
  - A more accurate way to handle this would be to have counters for the number of (big) key pressed, but this complicates the code a lot so I went for the easy solution.

Thanks