### PR TITLE
feat(tailscale): add login/authentication support with custom login server

### DIFF
--- a/tailscale/BarWidget.qml
+++ b/tailscale/BarWidget.qml
@@ -90,12 +90,19 @@ Item {
 
     model: [
       {
+        "label": pluginApi?.tr("context.login"),
+        "action": "login",
+        "icon": "login",
+        "visible": mainInstance?.needsLogin ?? false
+      },
+      {
         "label": (mainInstance?.tailscaleRunning ?? false)
           ? pluginApi?.tr("context.disconnect")
           : pluginApi?.tr("context.connect"),
         "action": "toggle-tailscale",
         "icon": (mainInstance?.tailscaleRunning ?? false) ? "plug-x" : "plug",
-        "enabled": mainInstance?.tailscaleInstalled ?? false
+        "enabled": mainInstance?.tailscaleInstalled ?? false,
+        "visible": !(mainInstance?.needsLogin ?? false)
       },
       {
         "label": pluginApi?.tr("actions.widget-settings"),
@@ -113,6 +120,10 @@ Item {
       } else if (action === "toggle-tailscale") {
         if (mainInstance) {
           mainInstance.toggleTailscale()
+        }
+      } else if (action === "login") {
+        if (mainInstance) {
+          mainInstance.loginTailscale()
         }
       }
     }

--- a/tailscale/Main.qml
+++ b/tailscale/Main.qml
@@ -55,6 +55,7 @@ Item {
   property bool tailscaleRunning: false
   property string tailscaleIp: ""
   property string tailscaleStatus: ""
+  property bool needsLogin: false
   property int peerCount: 0
   property bool isRefreshing: false
   property string lastToggleAction: ""
@@ -153,8 +154,15 @@ Item {
         try {
           var data = JSON.parse(stdout);
           root.tailscaleRunning = data.BackendState === "Running";
+          root.needsLogin = data.BackendState === "NeedsLogin";
 
-          if (root.tailscaleRunning && data.Self && data.Self.TailscaleIPs && data.Self.TailscaleIPs.length > 0) {
+          if (root.needsLogin) {
+            root.tailscaleIp = "";
+            root.tailscaleStatus = "NeedsLogin";
+            root.peerCount = 0;
+            root._realPeerList = [];
+            root.exitNodeStatus = null;
+          } else if (root.tailscaleRunning && data.Self && data.Self.TailscaleIPs && data.Self.TailscaleIPs.length > 0) {
             root.tailscaleIp = filterIPv4(data.Self.TailscaleIPs)[0] || data.Self.TailscaleIPs[0];
             root.tailscaleStatus = "Connected";
 
@@ -198,11 +206,13 @@ Item {
         } catch (e) {
           Logger.e("Tailscale", "Failed to parse status: " + e);
           root.tailscaleRunning = false;
+          root.needsLogin = false;
           root.tailscaleStatus = "Error";
           root._realPeerList = [];
         }
       } else {
         root.tailscaleRunning = false;
+        root.needsLogin = false;
         root.tailscaleStatus = "Disconnected";
         root.tailscaleIp = "";
         root.peerCount = 0;
@@ -235,6 +245,50 @@ Item {
   }
 
   property string lastExitNodeAction: ""
+
+  property bool _loginUrlOpened: false
+
+  Process {
+    id: loginProcess
+
+    function _handleLine(data) {
+      if (root._loginUrlOpened) return;
+      var line = data.trim();
+      Logger.d("Tailscale", "Login output: " + line);
+      var urlMatch = line.match(/https?:\/\/\S+/);
+      if (urlMatch) {
+        root._loginUrlOpened = true;
+        Qt.openUrlExternally(urlMatch[0]);
+        ToastService.showNotice(
+          pluginApi?.tr("toast.title"),
+          pluginApi?.tr("toast.login-browser-opened"),
+          "external-link"
+        );
+      }
+    }
+
+    stdout: SplitParser {
+      onRead: data => loginProcess._handleLine(data)
+    }
+
+    stderr: SplitParser {
+      onRead: data => loginProcess._handleLine(data)
+    }
+
+    onExited: function (exitCode, exitStatus) {
+      Logger.d("Tailscale", "Login exited (code " + exitCode + "), urlOpened=" + root._loginUrlOpened);
+      if (exitCode !== 0 && !root._loginUrlOpened) {
+        ToastService.showError(
+          pluginApi?.tr("toast.title"),
+          pluginApi?.tr("toast.login-failed"),
+          "alert-circle"
+        );
+        Logger.e("Tailscale", "Login failed (exit " + exitCode + ")");
+      }
+      root._loginUrlOpened = false;
+      statusDelayTimer.start();
+    }
+  }
 
   // ─── Taildrop state ──────────────────────────────────────────────────────
 
@@ -455,6 +509,7 @@ Item {
   function updateTailscaleStatus() {
     if (!root.tailscaleInstalled) {
       root.tailscaleRunning = false;
+      root.needsLogin = false;
       root.tailscaleIp = "";
       root.tailscaleStatus = "Not installed";
       root.peerCount = 0;
@@ -478,6 +533,18 @@ Item {
       toggleProcess.command = ["tailscale", "up"];
     }
     toggleProcess.running = true;
+  }
+
+  function loginTailscale() {
+    if (!root.tailscaleInstalled)
+      return;
+    var loginServer = pluginApi?.pluginSettings?.loginServer || "";
+    var cmd = ["tailscale", "up", "--accept-routes"];
+    if (loginServer.trim() !== "") {
+      cmd.push("--login-server=" + loginServer.trim());
+    }
+    loginProcess.command = cmd;
+    loginProcess.running = true;
   }
 
   Timer {
@@ -519,12 +586,17 @@ Item {
         "running": root.tailscaleRunning,
         "ip": root.tailscaleIp,
         "status": root.tailscaleStatus,
-        "peers": root.peerCount
+        "peers": root.peerCount,
+        "needsLogin": root.needsLogin
       };
     }
 
     function refresh() {
       updateTailscaleStatus();
+    }
+
+    function login() {
+      loginTailscale();
     }
 
     // Taildrop IPC: qs ipc call plugin:tailscale receive

--- a/tailscale/Main.qml
+++ b/tailscale/Main.qml
@@ -56,6 +56,7 @@ Item {
   property string tailscaleIp: ""
   property string tailscaleStatus: ""
   property bool needsLogin: false
+  property string authUrl: ""
   property int peerCount: 0
   property bool isRefreshing: false
   property string lastToggleAction: ""
@@ -162,9 +163,27 @@ Item {
             root.peerCount = 0;
             root._realPeerList = [];
             root.exitNodeStatus = null;
+            // Capture the pending authentication URL exposed by the daemon.
+            var newAuthUrl = data.AuthURL || "";
+            root.authUrl = newAuthUrl;
+            // If a login attempt is in progress and the daemon has surfaced a
+            // URL that differs from the one cached at click-time, it means the
+            // URL was regenerated (fresh) — open it immediately.
+            if (root._loginInProgress
+                && !root._loginUrlOpened
+                && newAuthUrl.length > 0
+                && newAuthUrl !== root._preLoginAuthUrl) {
+              root._openAuthUrl(newAuthUrl);
+            }
           } else if (root.tailscaleRunning && data.Self && data.Self.TailscaleIPs && data.Self.TailscaleIPs.length > 0) {
             root.tailscaleIp = filterIPv4(data.Self.TailscaleIPs)[0] || data.Self.TailscaleIPs[0];
             root.tailscaleStatus = "Connected";
+            root.authUrl = "";
+            // Login flow settled — reset flags so the next attempt starts clean
+            root._loginInProgress = false;
+            root._loginUrlOpened = false;
+            root._preLoginAuthUrl = "";
+            loginTimeoutTimer.stop();
 
             var peers = [];
             if (data.Peer) {
@@ -202,6 +221,7 @@ Item {
             root.peerCount = 0;
             root._realPeerList = [];
             root.exitNodeStatus = null;
+            root.authUrl = "";
           }
         } catch (e) {
           Logger.e("Tailscale", "Failed to parse status: " + e);
@@ -209,6 +229,7 @@ Item {
           root.needsLogin = false;
           root.tailscaleStatus = "Error";
           root._realPeerList = [];
+          root.authUrl = "";
         }
       } else {
         root.tailscaleRunning = false;
@@ -217,6 +238,7 @@ Item {
         root.tailscaleIp = "";
         root.peerCount = 0;
         root._realPeerList = [];
+        root.authUrl = "";
       }
     }
   }
@@ -246,7 +268,61 @@ Item {
 
   property string lastExitNodeAction: ""
 
+  // ─── Login flow state ────────────────────────────────────────────────────
+  // A login attempt is tracked across two asynchronous sources that may deliver
+  // a fresh AuthURL: (1) stdout/stderr of `tailscale up` and (2) the periodic
+  // `tailscale status --json` poll. Whichever arrives first wins; the other is
+  // deduped via `_loginUrlOpened`.
   property bool _loginUrlOpened: false
+  property bool _loginInProgress: false
+  // Snapshot of authUrl taken at click-time. Used to detect when the daemon
+  // has regenerated the URL so we never open a stale/expired one.
+  property string _preLoginAuthUrl: ""
+
+  /**
+   * Open an authentication URL in the default browser, with anti-double-open
+   * protection. Resets login-flow state.
+   *
+   * @param {string} url Authentication URL to open
+   */
+  function _openAuthUrl(url) {
+    if (root._loginUrlOpened) return;
+    if (!url || url.length === 0) return;
+    root._loginUrlOpened = true;
+    root._loginInProgress = false;
+    loginTimeoutTimer.stop();
+    Logger.d("Tailscale", "Opening auth URL: " + url);
+    Qt.openUrlExternally(url);
+    ToastService.showNotice(
+      pluginApi?.tr("toast.title"),
+      pluginApi?.tr("toast.login-browser-opened"),
+      "external-link"
+    );
+  }
+
+  // Safety net: if no fresh AuthURL surfaces within 10s after a login click,
+  // either open whatever is cached (best effort) or show an error toast.
+  Timer {
+    id: loginTimeoutTimer
+    interval: 10000
+    repeat: false
+    onTriggered: {
+      if (!root._loginInProgress || root._loginUrlOpened) return;
+      root._loginInProgress = false;
+      Logger.w("Tailscale", "Login timeout: no fresh AuthURL received within 10s");
+      if (root.authUrl && root.authUrl.length > 0) {
+        // Last resort: open the cached URL (may be the stale one)
+        Logger.w("Tailscale", "Falling back to cached (possibly stale) AuthURL");
+        root._openAuthUrl(root.authUrl);
+      } else {
+        ToastService.showError(
+          pluginApi?.tr("toast.title"),
+          pluginApi?.tr("toast.login-failed"),
+          "alert-circle"
+        );
+      }
+    }
+  }
 
   Process {
     id: loginProcess
@@ -257,13 +333,7 @@ Item {
       Logger.d("Tailscale", "Login output: " + line);
       var urlMatch = line.match(/https?:\/\/\S+/);
       if (urlMatch) {
-        root._loginUrlOpened = true;
-        Qt.openUrlExternally(urlMatch[0]);
-        ToastService.showNotice(
-          pluginApi?.tr("toast.title"),
-          pluginApi?.tr("toast.login-browser-opened"),
-          "external-link"
-        );
+        root._openAuthUrl(urlMatch[0]);
       }
     }
 
@@ -278,14 +348,11 @@ Item {
     onExited: function (exitCode, exitStatus) {
       Logger.d("Tailscale", "Login exited (code " + exitCode + "), urlOpened=" + root._loginUrlOpened);
       if (exitCode !== 0 && !root._loginUrlOpened) {
-        ToastService.showError(
-          pluginApi?.tr("toast.title"),
-          pluginApi?.tr("toast.login-failed"),
-          "alert-circle"
-        );
-        Logger.e("Tailscale", "Login failed (exit " + exitCode + ")");
+        Logger.e("Tailscale", "tailscale up failed (exit " + exitCode + "), waiting on status poll for fresh AuthURL");
       }
-      root._loginUrlOpened = false;
+      // Do NOT reset _loginUrlOpened here — the status poll may still deliver
+      // the fresh URL after process exit. The flag is reset by _openAuthUrl
+      // and by the login-state transitions in statusProcess.
       statusDelayTimer.start();
     }
   }
@@ -535,16 +602,46 @@ Item {
     toggleProcess.running = true;
   }
 
+  /**
+   * Trigger the Tailscale authentication flow.
+   *
+   * @description
+   * Always runs `tailscale up --force-reauth` to force the daemon to generate
+   * a fresh AuthURL (any cached one may be expired). The fresh URL is then
+   * opened from whichever channel delivers it first:
+   *  - stdout/stderr of `tailscale up` (parsed by loginProcess)
+   *  - the next `tailscale status --json` poll (via statusProcess)
+   * Deduped through `_openAuthUrl` / `_loginUrlOpened`.
+   *
+   * Guard: no-op when not in NeedsLogin state to avoid disconnecting an
+   * already-authenticated session.
+   */
   function loginTailscale() {
     if (!root.tailscaleInstalled)
       return;
+    if (!root.needsLogin) {
+      Logger.w("Tailscale", "Login requested but backend is not in NeedsLogin state — ignoring");
+      return;
+    }
+
+    // Start a fresh login attempt
+    root._loginInProgress = true;
+    root._loginUrlOpened = false;
+    root._preLoginAuthUrl = root.authUrl;
+
+    // --force-reauth forces the daemon to regenerate the AuthURL even if a
+    // (possibly expired) one is still cached in its session state.
     var loginServer = pluginApi?.pluginSettings?.loginServer || "";
-    var cmd = ["tailscale", "up", "--accept-routes"];
+    var cmd = ["tailscale", "up", "--accept-routes", "--force-reauth"];
     if (loginServer.trim() !== "") {
       cmd.push("--login-server=" + loginServer.trim());
     }
     loginProcess.command = cmd;
     loginProcess.running = true;
+
+    // Arm the safety-net timeout and kick an early status refresh
+    loginTimeoutTimer.restart();
+    statusDelayTimer.start();
   }
 
   Timer {

--- a/tailscale/Panel.qml
+++ b/tailscale/Panel.qml
@@ -353,7 +353,7 @@ Item {
             NText {
               text: mainInstance?.tailscaleRunning
                 ? (mainInstance?.peerList?.length || 0) + " " + (pluginApi?.tr("panel.peers"))
-                : pluginApi?.tr("panel.not-connected")
+                : (mainInstance?.needsLogin ? pluginApi?.tr("panel.not-authenticated") : pluginApi?.tr("panel.not-connected"))
               pointSize: Style.fontSizeS
               color: Color.mOnSurfaceVariant
             }
@@ -625,7 +625,23 @@ Item {
 
       NButton {
         Layout.fillWidth: true
-        text: mainInstance?.tailscaleRunning 
+        visible: mainInstance?.needsLogin ?? false
+        text: pluginApi?.tr("context.login")
+        icon: "login"
+        backgroundColor: Color.mPrimary
+        textColor: Color.mOnPrimary
+        enabled: mainInstance?.tailscaleInstalled ?? false
+        onClicked: {
+          if (mainInstance) {
+            mainInstance.loginTailscale()
+          }
+        }
+      }
+
+      NButton {
+        Layout.fillWidth: true
+        visible: !(mainInstance?.needsLogin ?? false)
+        text: mainInstance?.tailscaleRunning
           ? pluginApi?.tr("context.disconnect")
           : pluginApi?.tr("context.connect")
         icon: mainInstance?.tailscaleRunning ? "plug-x" : "plug"

--- a/tailscale/README.md
+++ b/tailscale/README.md
@@ -72,6 +72,7 @@ Right-click any online peer in the panel and choose **Send File**. A file picker
 | `taildropEnabled` | `true` | Enable Taildrop send/receive. When false, hides the Receive button and Send File option. |
 | `taildropDownloadDir` | `"~/Downloads"` | Directory where received files are saved |
 | `taildropReceiveMode` | `"operator"` | Taildrop receive mode: `operator` or `pkexec` |
+| `loginServer` | `""` | Custom login server URL (e.g. Headscale). Leave empty for default Tailscale. |
 
 ## IPC Commands
 
@@ -90,6 +91,7 @@ qs -c noctalia-shell ipc call plugin:tailscale <command>
 | `togglePanel` | Toggle Tailscale panel | `qs -c noctalia-shell ipc call plugin:tailscale togglePanel` |
 | `status` | Get current Tailscale status | `qs -c noctalia-shell ipc call plugin:tailscale status` |
 | `refresh` | Force refresh Tailscale status | `qs -c noctalia-shell ipc call plugin:tailscale refresh` |
+| `login` | Trigger Tailscale login (opens browser) | `qs -c noctalia-shell ipc call plugin:tailscale login` |
 | `receive` | Fetch any pending Taildrop files | `qs -c noctalia-shell ipc call plugin:tailscale receive` |
 
 ## Usage

--- a/tailscale/Settings.qml
+++ b/tailscale/Settings.qml
@@ -75,6 +75,11 @@ ColumnLayout {
     pluginApi?.manifest?.metadata?.defaultSettings?.taildropReceiveMode ||
     "operator"
 
+  property string editLoginServer:
+    pluginApi?.pluginSettings?.loginServer ||
+    pluginApi?.manifest?.metadata?.defaultSettings?.loginServer ||
+    ""
+
   spacing: Style.marginM
 
   // Title section
@@ -183,6 +188,26 @@ ColumnLayout {
     description: pluginApi?.tr("settings.hide-mullvad-exit-nodes-desc")
     checked: root.editHideMullvadExitNodes
     onToggled: checked => root.editHideMullvadExitNodes = checked
+  }
+
+  // Authentication section
+  NDivider {
+    Layout.fillWidth: true
+    Layout.topMargin: Style.marginM
+    Layout.bottomMargin: Style.marginM
+  }
+
+  NLabel {
+    label: pluginApi?.tr("settings.authentication")
+  }
+
+  NTextInput {
+    Layout.fillWidth: true
+    label: pluginApi?.tr("settings.login-server")
+    description: pluginApi?.tr("settings.login-server-desc")
+    placeholderText: "https://login.tailscale.com"
+    text: root.editLoginServer
+    onTextChanged: root.editLoginServer = text
   }
 
   // Terminal section
@@ -316,6 +341,7 @@ ColumnLayout {
     pluginApi.pluginSettings.taildropEnabled = root.editTaildropEnabled
     pluginApi.pluginSettings.taildropDownloadDir = root.editTaildropDownloadDir
     pluginApi.pluginSettings.taildropReceiveMode = root.editTaildropReceiveMode
+    pluginApi.pluginSettings.loginServer = root.editLoginServer
 
     pluginApi.saveSettings()
 

--- a/tailscale/i18n/de.json
+++ b/tailscale/i18n/de.json
@@ -34,7 +34,10 @@
     "taildrop-receive-mode": "Empfangsmodus",
     "taildrop-receive-mode-desc": "Wie 'tailscale file get' ausgeführt wird. Der Operator-Modus erfordert keine Eingabeaufforderung, wenn 'sudo tailscale set --operator $USER' ausgeführt wurde.",
     "taildrop-receive-mode-operator": "Operator (keine Eingabeaufforderung)",
-    "taildrop-receive-mode-pkexec": "pkexec (jedes Mal Eingabeaufforderung)"
+    "taildrop-receive-mode-pkexec": "pkexec (jedes Mal Eingabeaufforderung)",
+    "authentication": "Authentifizierung",
+    "login-server": "Anmeldeserver",
+    "login-server-desc": "Benutzerdefinierte Anmeldeserver-URL (z. B. Headscale). Leer lassen für den Standard-Tailscale-Server."
   },
   "actions": {
     "widget-settings": "Widget Einstellungen"
@@ -49,7 +52,8 @@
     "ssh": "SSH zum Host",
     "ping": "Host anpingen",
     "use-exit-node": "Als Ausgangsknoten verwenden",
-    "send-file": "Datei senden"
+    "send-file": "Datei senden",
+    "login": "Anmelden"
   },
   "toast": {
     "title": "Tailscale",
@@ -66,12 +70,15 @@
     "terminal-not-configured": {
       "title": "Terminal nicht konfiguriert",
       "message": "Bitte leg einen Terminalbefehl in den Plugin Einstellungen fest"
-    }
+    },
+    "login-browser-opened": "Authentifizierungsseite im Browser geöffnet",
+    "login-failed": "Anmeldung fehlgeschlagen"
   },
   "panel": {
     "title": "Tailscale Netzwerk",
     "peers": "Peers",
     "not-connected": "Nicht verbunden",
+    "not-authenticated": "Nicht authentifiziert",
     "no-peers": "Keine verbundenen Peers",
     "admin-console": "Admin Konsole",
     "terminal-warning": {

--- a/tailscale/i18n/en.json
+++ b/tailscale/i18n/en.json
@@ -34,7 +34,10 @@
     "taildrop-receive-mode": "Receive Mode",
     "taildrop-receive-mode-desc": "How to run 'tailscale file get'. Operator mode requires no prompts if you have run 'sudo tailscale set --operator $USER'.",
     "taildrop-receive-mode-operator": "Operator (no prompt)",
-    "taildrop-receive-mode-pkexec": "pkexec (prompt each time)"
+    "taildrop-receive-mode-pkexec": "pkexec (prompt each time)",
+    "authentication": "Authentication",
+    "login-server": "Login Server",
+    "login-server-desc": "Custom login server URL (e.g. Headscale). Leave empty for default Tailscale server."
   },
   "actions": {
     "widget-settings": "Widget Settings"
@@ -49,7 +52,8 @@
     "ssh": "SSH to host",
     "ping": "Ping host",
     "use-exit-node": "Use as Exit Node",
-    "send-file": "Send File"
+    "send-file": "Send File",
+    "login": "Login"
   },
   "toast": {
     "title": "Tailscale",
@@ -66,12 +70,15 @@
     "terminal-not-configured": {
       "title": "Terminal Not Configured",
       "message": "Please set a terminal command in plugin settings"
-    }
+    },
+    "login-browser-opened": "Authentication page opened in browser",
+    "login-failed": "Login failed"
   },
   "panel": {
     "title": "Tailscale Network",
     "peers": "peers",
     "not-connected": "Not connected",
+    "not-authenticated": "Not authenticated",
     "no-peers": "No connected peers",
     "admin-console": "Admin Console",
     "terminal-warning": {

--- a/tailscale/i18n/fr.json
+++ b/tailscale/i18n/fr.json
@@ -34,7 +34,10 @@
     "taildrop-receive-mode": "Mode de réception",
     "taildrop-receive-mode-desc": "Comment exécuter 'tailscale file get'. Le mode opérateur ne nécessite pas de confirmation si vous avez exécuté 'sudo tailscale set --operator $USER'.",
     "taildrop-receive-mode-operator": "Opérateur (sans confirmation)",
-    "taildrop-receive-mode-pkexec": "pkexec (confirmation à chaque fois)"
+    "taildrop-receive-mode-pkexec": "pkexec (confirmation à chaque fois)",
+    "authentication": "Authentification",
+    "login-server": "Serveur de connexion",
+    "login-server-desc": "URL du serveur de connexion personnalisé (ex. Headscale). Laisser vide pour le serveur Tailscale par défaut."
   },
   "actions": {
     "widget-settings": "Paramètres du widget"
@@ -49,7 +52,8 @@
     "ssh": "SSH vers l'hôte",
     "ping": "Ping l'hôte",
     "use-exit-node": "Utiliser comme nœud de sortie",
-    "send-file": "Envoyer un fichier"
+    "send-file": "Envoyer un fichier",
+    "login": "Se connecter"
   },
   "toast": {
     "title": "Tailscale",
@@ -66,12 +70,15 @@
     "terminal-not-configured": {
       "title": "Terminal non configuré",
       "message": "Veuillez définir une commande de terminal dans les paramètres du plugin"
-    }
+    },
+    "login-browser-opened": "Page d'authentification ouverte dans le navigateur",
+    "login-failed": "Échec de la connexion"
   },
   "panel": {
     "title": "Réseau Tailscale",
     "peers": "pairs",
     "not-connected": "Non connecté",
+    "not-authenticated": "Non authentifié",
     "no-peers": "Aucun pair connecté",
     "admin-console": "Console d'administration",
     "terminal-warning": {

--- a/tailscale/i18n/sv.json
+++ b/tailscale/i18n/sv.json
@@ -34,7 +34,10 @@
     "taildrop-receive-mode": "Mottagningsläge",
     "taildrop-receive-mode-desc": "Hur 'tailscale file get' körs. Operatörsläget kräver ingen bekräftelse om du har kört 'sudo tailscale set --operator $USER'.",
     "taildrop-receive-mode-operator": "Operatör (ingen bekräftelse)",
-    "taildrop-receive-mode-pkexec": "pkexec (bekräftelse varje gång)"
+    "taildrop-receive-mode-pkexec": "pkexec (bekräftelse varje gång)",
+    "authentication": "Autentisering",
+    "login-server": "Inloggningsserver",
+    "login-server-desc": "Anpassad inloggningsserver-URL (t.ex. Headscale). Lämna tomt för standard Tailscale-server."
   },
   "actions": {
     "widget-settings": "Widgetinställningar"
@@ -49,7 +52,8 @@
     "ssh": "SSH till värd",
     "ping": "Pinga värd",
     "use-exit-node": "Använd som utgångsnod",
-    "send-file": "Skicka fil"
+    "send-file": "Skicka fil",
+    "login": "Logga in"
   },
   "toast": {
     "title": "Tailscale",
@@ -66,12 +70,15 @@
     "terminal-not-configured": {
       "title": "Terminal ej konfigurerad",
       "message": "Ange ett terminalkommando i plugin-inställningarna"
-    }
+    },
+    "login-browser-opened": "Autentiseringssida öppnad i webbläsaren",
+    "login-failed": "Inloggning misslyckades"
   },
   "panel": {
     "title": "Tailscale-nätverk",
     "peers": "peers",
     "not-connected": "Ej ansluten",
+    "not-authenticated": "Ej autentiserad",
     "no-peers": "Inga anslutna peers",
     "admin-console": "Administrationskonsol",
     "terminal-warning": {

--- a/tailscale/i18n/vi.json
+++ b/tailscale/i18n/vi.json
@@ -34,7 +34,10 @@
     "taildrop-receive-mode": "Chế độ nhận",
     "taildrop-receive-mode-desc": "Cách chạy 'tailscale file get'. Chế độ operator không cần xác nhận nếu đã chạy 'sudo tailscale set --operator $USER'.",
     "taildrop-receive-mode-operator": "Operator (không cần xác nhận)",
-    "taildrop-receive-mode-pkexec": "pkexec (xác nhận mỗi lần)"
+    "taildrop-receive-mode-pkexec": "pkexec (xác nhận mỗi lần)",
+    "authentication": "Xác thực",
+    "login-server": "Máy chủ đăng nhập",
+    "login-server-desc": "URL máy chủ đăng nhập tùy chỉnh (ví dụ: Headscale). Để trống để sử dụng máy chủ Tailscale mặc định."
   },
   "actions": {
     "widget-settings": "Cài đặt tiện ích"
@@ -49,7 +52,8 @@
     "ssh": "SSH tới máy",
     "ping": "Ping máy",
     "use-exit-node": "Dùng làm exit node",
-    "send-file": "Gửi tệp"
+    "send-file": "Gửi tệp",
+    "login": "Đăng nhập"
   },
   "toast": {
     "title": "Tailscale",
@@ -66,12 +70,15 @@
     "terminal-not-configured": {
       "title": "Chưa cấu hình terminal",
       "message": "Vui lòng thiết lập lệnh terminal trong cài đặt plugin"
-    }
+    },
+    "login-browser-opened": "Trang xác thực đã mở trong trình duyệt",
+    "login-failed": "Đăng nhập thất bại"
   },
   "panel": {
     "title": "Mạng Tailscale",
     "peers": "thiết bị",
     "not-connected": "Chưa kết nối",
+    "not-authenticated": "Chưa xác thực",
     "no-peers": "Không có thiết bị nào đang kết nối",
     "admin-console": "Bảng điều khiển quản trị",
     "terminal-warning": {

--- a/tailscale/i18n/zh-CN.json
+++ b/tailscale/i18n/zh-CN.json
@@ -34,7 +34,10 @@
     "taildrop-receive-mode": "接收模式",
     "taildrop-receive-mode-desc": "运行'tailscale file get'的方式。如果已运行'sudo tailscale set --operator $USER'，操作员模式无需提示。",
     "taildrop-receive-mode-operator": "操作员（无需提示）",
-    "taildrop-receive-mode-pkexec": "pkexec（每次提示）"
+    "taildrop-receive-mode-pkexec": "pkexec（每次提示）",
+    "authentication": "身份验证",
+    "login-server": "登录服务器",
+    "login-server-desc": "自定义登录服务器URL（例如Headscale）。留空使用默认Tailscale服务器。"
   },
   "actions": {
     "widget-settings": "部件设置"
@@ -49,7 +52,8 @@
     "ssh": "SSH到主机",
     "ping": "Ping主机",
     "use-exit-node": "用作出口节点",
-    "send-file": "发送文件"
+    "send-file": "发送文件",
+    "login": "登录"
   },
   "toast": {
     "title": "Tailscale",
@@ -66,12 +70,15 @@
     "terminal-not-configured": {
       "title": "终端未配置",
       "message": "请在插件设置中设置终端命令"
-    }
+    },
+    "login-browser-opened": "身份验证页面已在浏览器中打开",
+    "login-failed": "登录失败"
   },
   "panel": {
     "title": "Tailscale网络",
     "peers": "对等设备",
     "not-connected": "未连接",
+    "not-authenticated": "未认证",
     "no-peers": "没有连接的对等设备",
     "admin-console": "管理控制台",
     "terminal-warning": {

--- a/tailscale/manifest.json
+++ b/tailscale/manifest.json
@@ -35,7 +35,8 @@
       "defaultPeerAction": "copy-ip",
       "taildropEnabled": true,
       "taildropDownloadDir": "~/Downloads",
-      "taildropReceiveMode": "operator"
+      "taildropReceiveMode": "operator",
+      "loginServer": ""
     }
   }
 }

--- a/tailscale/manifest.json
+++ b/tailscale/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "tailscale",
   "name": "Tailscale",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "minNoctaliaVersion": "4.0.0",
   "author": "nineluj",
   "license": "MIT",


### PR DESCRIPTION
  ## Summary                                                                              
                                                                                          
  - Add login/authentication support to the Tailscale plugin, detecting the `NeedsLogin`  
  backend state and providing a one-click login flow that opens the auth URL in the
  browser                                                                                 
  - Add support for custom login servers (e.g. Headscale) via a new `loginServer` setting
  - Fully localized across all 6 languages (en, fr, de, sv, vi, zh-CN)

  ## Changes

  ### Login flow (`Main.qml`)                                                             
  - New `needsLogin` property tracks `BackendState === "NeedsLogin"` from `tailscale
  status --json`                                                                          
  - New `loginProcess` uses `SplitParser` to stream stdout/stderr, parse the auth URL, and
   open it in the browser via `Qt.openUrlExternally()`                                    
  - New `loginTailscale()` function runs `tailscale up --accept-routes` with optional
  `--login-server=` flag                                                                  
  - New `login` IPC command; `status` IPC now includes `needsLogin` field        
                                                                                          
  ### UI (`BarWidget.qml`, `Panel.qml`)
  - Bar widget context menu shows "Login" when authentication is needed, hides            
  connect/disconnect                                                             
  - Panel header shows "Not authenticated" instead of "Not connected" when `needsLogin`
  - Panel shows a Login button (replaces connect/disconnect) when authentication is needed
   
  ### Settings (`Settings.qml`, `manifest.json`)                                          
  - New "Authentication" section with `loginServer` text input for custom login server
  URLs (e.g. Headscale)                                                                   
  - Setting is persisted and passed to `tailscale up --login-server=` during login
                                                                                          
  ### i18n                                                                       
  - Added keys: `settings.authentication`, `settings.login-server`,
  `settings.login-server-desc`, `context.login`, `toast.login-browser-opened`,            
  `toast.login-failed`, `panel.not-authenticated`
                                                                                          
  ### Documentation (`README.md`)                                                
  - Documented `loginServer` setting and `login` IPC command