### PR TITLE
feat(github-feed): add support for self-hosted GitHub URLs and update settings UI

### DIFF
--- a/github-feed/Main.qml
+++ b/github-feed/Main.qml
@@ -26,6 +26,20 @@ Item {
 
     readonly property string username: pluginApi?.pluginSettings?.username || ""
     readonly property string token: pluginApi?.pluginSettings?.token || ""
+    readonly property string githubUrl: pluginApi?.pluginSettings?.githubUrl || ""
+
+    // Derived URL properties, empty githubUrl means use github.com; otherwise treat
+    // githubUrl as the web base URL of a GitHub Enterprise Server instance.
+    // The scheme is stripped from user input and always rebuilt as https://, so both
+    // "github.mycompany.com" and "https://github.mycompany.com" produce identical URLs.
+    readonly property string _githubHost: {
+        if (!githubUrl || githubUrl.trim() === "") return ""
+        return githubUrl.trim().replace(/^https?:\/\//, "").replace(/\/+$/, "")
+    }
+    readonly property string githubWebUrl: _githubHost ? "https://" + _githubHost : "https://github.com"
+    readonly property string githubRestApiUrl: _githubHost ? "https://" + _githubHost + "/api/v3" : "https://api.github.com"
+    readonly property string githubGraphqlUrl: _githubHost ? "https://" + _githubHost + "/api/graphql" : "https://api.github.com/graphql"
+
     readonly property int refreshInterval: pluginApi?.pluginSettings?.refreshInterval || 1800
     readonly property int maxEvents: pluginApi?.pluginSettings?.maxEvents || 50
 
@@ -68,21 +82,21 @@ Item {
     readonly property var urlResolvers: ({
         "PullRequest": function(url, repo, title) {
             var match = url.match(/\/pulls\/(\d+)$/);
-            return match ? "https://github.com/" + repo + "/pull/" + match[1] : "https://github.com/" + repo;
+            return match ? root.githubWebUrl + "/" + repo + "/pull/" + match[1] : root.githubWebUrl + "/" + repo;
         },
         "Issue": function(url, repo, title) {
             var match = url.match(/\/issues\/(\d+)$/);
-            return match ? "https://github.com/" + repo + "/issues/" + match[1] : "https://github.com/" + repo;
+            return match ? root.githubWebUrl + "/" + repo + "/issues/" + match[1] : root.githubWebUrl + "/" + repo;
         },
         "Release": function(url, repo, title) {
-            return "https://github.com/" + repo + "/releases/tag/" + encodeURIComponent(title);
+            return root.githubWebUrl + "/" + repo + "/releases/tag/" + encodeURIComponent(title);
         },
         "Discussion": function(url, repo, title) {
             var match = url.match(/\/discussions\/(\d+)$/);
-            return match ? "https://github.com/" + repo + "/discussions/" + match[1] : "https://github.com/" + repo + "/discussions";
+            return match ? root.githubWebUrl + "/" + repo + "/discussions/" + match[1] : root.githubWebUrl + "/" + repo + "/discussions";
         },
         "Default": function(url, repo, title) {
-            return url.replace("https://api.github.com/repos/", "https://github.com/");
+            return url.replace(root.githubRestApiUrl + "/repos/", root.githubWebUrl + "/");
         }
         // FIXME: Notifications API does not include subject.url for CheckSuite events
         //        it is unclear how to construct the check-run url from the CheckSuite notification
@@ -109,7 +123,7 @@ Item {
         var cmd = ["notify-send", "-a", "GitHub Feed", "--action=default=Open", "--wait", title, message]
         var process = notificationProcessComponent.createObject(root, {
             "command": cmd,
-            "targetUrl": url || "https://github.com"
+            "targetUrl": url || root.githubWebUrl
         })
         process.running = true
         logDebug("Sending system notification: " + title + " - " + message + " (URL: " + url + ")")
@@ -249,7 +263,7 @@ Item {
             "curl", "-s", "--max-time", "30",
             "-H", "Authorization: Bearer " + root.token,
             "-H", "Accept: application/vnd.github.v3+json",
-            "https://api.github.com/users/" + root.username + "/following?per_page=100&page=" + page
+            root.githubRestApiUrl + "/users/" + root.username + "/following?per_page=100&page=" + page
         ] : ["echo", "[]"]
 
         stdout: StdioCollector {
@@ -378,7 +392,7 @@ Item {
         return [
             "curl", "-s", "--max-time", "20",
             "-X", "POST",
-            "https://api.github.com/graphql",
+            root.githubGraphqlUrl,
             "-H", "Authorization: Bearer " + root.token,
             "-H", "Content-Type: application/json",
             "-d", payload
@@ -633,7 +647,7 @@ Item {
         myReposProcess.command = [
             "curl", "-s", "--max-time", "20",
             "-X", "POST",
-            "https://api.github.com/graphql",
+            root.githubGraphqlUrl,
             "-H", "Authorization: Bearer " + root.token,
             "-H", "Content-Type: application/json",
             "-d", payload
@@ -780,7 +794,7 @@ Item {
             "curl", "-s", "--max-time", "10",
             "-H", "Authorization: Bearer " + root.token,
             "-H", "Accept: application/vnd.github.v3+json",
-            "https://api.github.com/notifications"
+            root.githubRestApiUrl + "/notifications"
         ]
         notificationsProcess.running = true
     }
@@ -806,7 +820,7 @@ Item {
                     if (n.subject && n.subject.url) {
                         url = resolver(n.subject.url, repo, title);
                     } else {
-                        url = "https://github.com/" + repo;
+                        url = root.githubWebUrl + "/" + repo;
                     }
 
                     list.push({
@@ -878,11 +892,11 @@ Item {
                     if (shouldNotify) {
                         var title = "GitHub Activity"
                         var msg = e.actor.login + " "
-                        var eventUrl = "https://github.com/" + e.repo.name
+                        var eventUrl = root.githubWebUrl + "/" + e.repo.name
                         if (e.type === "WatchEvent") msg += "starred " + e.repo.name
                         else if (e.type === "ForkEvent") {
                             msg += "forked " + (e.payload.forkee ? e.payload.forkee.full_name : e.repo.name)
-                            if (e.payload.forkee) eventUrl = "https://github.com/" + e.payload.forkee.full_name
+                            if (e.payload.forkee) eventUrl = root.githubWebUrl + "/" + e.payload.forkee.full_name
                         }
                         else if (e.type === "PullRequestEvent") {
                             msg += "opened/merged PR: " + e.payload.pull_request.title
@@ -1136,6 +1150,16 @@ Item {
     onUsernameChanged: {
         if (root.username && root.token) {
             Logger.i("GitHubFeed", "Username changed, fetching new data")
+            root.rawEvents = []
+            root.followingList = []
+            root.lastFetchTimestamp = 0
+            fetchFromGitHub()
+        }
+    }
+
+    onGithubUrlChanged: {
+        if (root.username && root.token) {
+            Logger.i("GitHubFeed", "GitHub URL changed to: " + (root.githubWebUrl))
             root.rawEvents = []
             root.followingList = []
             root.lastFetchTimestamp = 0

--- a/github-feed/Panel.qml
+++ b/github-feed/Panel.qml
@@ -96,7 +96,7 @@ Item {
         if (event.type === "PullRequestEvent" && event.payload?.pull_request?.html_url) {
             return event.payload.pull_request.html_url
         }
-        return "https://github.com/" + repo
+        return (root.mainInstance?.githubWebUrl || "https://github.com") + "/" + repo
     }
 
     function getNotificationIcon(type) {

--- a/github-feed/Settings.qml
+++ b/github-feed/Settings.qml
@@ -11,6 +11,7 @@ ColumnLayout {
 
     property string editUsername: ""
     property string editToken: ""
+    property string editGithubUrl: ""
     property int editRefreshInterval: 1800
     property int editMaxEvents: 50
     property bool editShowStars: true
@@ -57,6 +58,15 @@ ColumnLayout {
         placeholderText: "ghp_xxxxxxxxxxxx"
         text: root.editToken
         onTextChanged: root.editToken = text
+    }
+
+    NTextInput {
+        Layout.fillWidth: true
+        label: pluginApi?.tr("settings.githubUrl.label")
+        description: pluginApi?.tr("settings.githubUrl.description")
+        placeholderText: "https://github.mycompany.com"
+        text: root.editGithubUrl
+        onTextChanged: root.editGithubUrl = text
     }
 
     NDivider {
@@ -446,6 +456,7 @@ ColumnLayout {
 
         pluginApi.pluginSettings.username = root.editUsername.trim()
         pluginApi.pluginSettings.token = root.editToken.trim()
+        pluginApi.pluginSettings.githubUrl = root.editGithubUrl.trim()
         pluginApi.pluginSettings.refreshInterval = root.editRefreshInterval
         pluginApi.pluginSettings.maxEvents = root.editMaxEvents
         pluginApi.pluginSettings.showStars = root.editShowStars
@@ -484,6 +495,7 @@ ColumnLayout {
 
         root.editUsername = settings?.username || defaults?.username || ""
         root.editToken = settings?.token || defaults?.token || ""
+        root.editGithubUrl = settings?.githubUrl || defaults?.githubUrl || ""
         root.editRefreshInterval = settings?.refreshInterval || defaults?.refreshInterval || 1800
         root.editMaxEvents = settings?.maxEvents || defaults?.maxEvents || 50
         root.editShowStars = settings?.showStars ?? defaults?.showStars ?? true

--- a/github-feed/i18n/de.json
+++ b/github-feed/i18n/de.json
@@ -77,6 +77,10 @@
       "title": "Einstellungen aktualisieren"
     },
     "saved": "GitHub-Feed-Einstellungen gespeichert",
+    "githubUrl": {
+      "description": "Leer lassen für github.com. Für GitHub Enterprise Server die Basis-URL eingeben, z. B. https://github.meinfirma.com",
+      "label": "GitHub-Instanz-URL (Optional)"
+    },
     "token": {
       "description": "Erhöht die Ratenbegrenzung von 60 auf 5000 Anfragen/Stunde",
       "label": "Persönlicher Zugriffstoken (Optional)",

--- a/github-feed/i18n/en.json
+++ b/github-feed/i18n/en.json
@@ -77,6 +77,10 @@
       "title": "Refresh Settings"
     },
     "saved": "GitHub Feed settings saved",
+    "githubUrl": {
+      "description": "Leave empty for github.com. For GitHub Enterprise Server enter the base URL, e.g. https://github.mycompany.com",
+      "label": "GitHub Instance URL (Optional)"
+    },
     "token": {
       "description": "Increases rate limit from 60 to 5000 requests/hour",
       "label": "Personal Access Token (Optional)",

--- a/github-feed/i18n/es.json
+++ b/github-feed/i18n/es.json
@@ -77,6 +77,10 @@
       "title": "Actualizar configuración"
     },
     "saved": "Configuración del feed de GitHub guardada",
+    "githubUrl": {
+      "description": "Dejar vacío para github.com. Para GitHub Enterprise Server, ingrese la URL base, p. ej. https://github.miempresa.com",
+      "label": "URL de instancia de GitHub (Opcional)"
+    },
     "token": {
       "description": "Aumenta el límite de velocidad de 60 a 5000 solicitudes por hora.",
       "label": "Token de acceso personal (opcional)",

--- a/github-feed/i18n/fr.json
+++ b/github-feed/i18n/fr.json
@@ -77,6 +77,10 @@
       "title": "Actualiser les paramètres"
     },
     "saved": "Paramètres du flux GitHub enregistrés.",
+    "githubUrl": {
+      "description": "Laisser vide pour github.com. Pour GitHub Enterprise Server, entrez l'URL de base, ex. https://github.monentreprise.com",
+      "label": "URL de l'instance GitHub (Facultatif)"
+    },
     "token": {
       "description": "Augmentation de la limite de débit de 60 à 5000 requêtes par heure.",
       "label": "Jeton d'accès personnel (facultatif)",

--- a/github-feed/i18n/hu.json
+++ b/github-feed/i18n/hu.json
@@ -77,6 +77,10 @@
       "title": "Beállítások frissítése"
     },
     "saved": "A GitHub-hírcsatorna beállításai mentve",
+    "githubUrl": {
+      "description": "Hagyja üresen github.com esetén. GitHub Enterprise Server esetén adja meg az alap URL-t, pl. https://github.cegem.com",
+      "label": "GitHub-példány URL-je (Opcionális)"
+    },
     "token": {
       "description": "Növeli a sebességkorlátozást 60-ról 5000 kérésre/óra",
       "label": "Személyes hozzáférési token (opcionális)",

--- a/github-feed/i18n/it.json
+++ b/github-feed/i18n/it.json
@@ -77,6 +77,10 @@
       "title": "Ricarica impostazioni"
     },
     "saved": "Impostazioni feed GitHub salvate",
+    "githubUrl": {
+      "description": "Lasciare vuoto per github.com. Per GitHub Enterprise Server inserire l'URL base, es. https://github.miazienda.com",
+      "label": "URL istanza GitHub (Opzionale)"
+    },
     "token": {
       "description": "Cresce il limite di frequenza da 60 a 5000 richieste/ora",
       "label": "Token Akses Pribadi (Opsional)",

--- a/github-feed/i18n/ja.json
+++ b/github-feed/i18n/ja.json
@@ -77,6 +77,10 @@
       "title": "設定を更新"
     },
     "saved": "GitHubフィードの設定を保存しました。",
+    "githubUrl": {
+      "description": "github.com の場合は空欄のままにしてください。GitHub Enterprise Server の場合はベース URL を入力してください（例：https://github.mycompany.com）",
+      "label": "GitHub インスタンス URL（任意）"
+    },
     "token": {
       "description": "リクエスト制限を1時間あたり60回から5000回に引き上げます。",
       "label": "個人アクセストークン（任意）",

--- a/github-feed/i18n/ku.json
+++ b/github-feed/i18n/ku.json
@@ -77,6 +77,10 @@
       "title": "Nûkirina Mîhengan"
     },
     "saved": "Mîhengên xwarina GitHubê hatin tomarkirin",
+    "githubUrl": {
+      "description": "Ji bo github.com vala bihêle. Ji bo GitHub Enterprise Server URL-a bingehê têkeve, mînak https://github.mycompany.com",
+      "label": "URL-a Nimûneya GitHubê (Bijare)"
+    },
     "token": {
       "description": "Rêjeya sînorê ji 60 daxwazan bo 5000 daxwazên/saetê zêde dike",
       "label": "Tokena Gihîştina Kesane (Bijare)",

--- a/github-feed/i18n/nl.json
+++ b/github-feed/i18n/nl.json
@@ -77,6 +77,10 @@
       "title": "Instellingen vernieuwen"
     },
     "saved": "GitHub Feed instellingen opgeslagen",
+    "githubUrl": {
+      "description": "Leeg laten voor github.com. Voor GitHub Enterprise Server de basis-URL invoeren, bijv. https://github.mijnbedrijf.com",
+      "label": "GitHub-instantie URL (Optioneel)"
+    },
     "token": {
       "description": "Verhoogt de snelheidslimiet van 60 naar 5000 verzoeken per uur.",
       "label": "Persoonlijke toegangstoken (optioneel)",

--- a/github-feed/i18n/pl.json
+++ b/github-feed/i18n/pl.json
@@ -77,6 +77,10 @@
       "title": "Odśwież ustawienia"
     },
     "saved": "Ustawienia kanału GitHub zapisane",
+    "githubUrl": {
+      "description": "Zostaw puste dla github.com. Dla GitHub Enterprise Server wpisz bazowy URL, np. https://github.mojafirma.com",
+      "label": "URL instancji GitHub (Opcjonalny)"
+    },
     "token": {
       "description": "Zwiększa limit szybkości z 60 do 5000 żądań/godzinę",
       "label": "Osobisty token dostępu (opcjonalny)",

--- a/github-feed/i18n/pt.json
+++ b/github-feed/i18n/pt.json
@@ -77,6 +77,10 @@
       "title": "Atualizar Configurações"
     },
     "saved": "Configurações do Feed do GitHub salvas.",
+    "githubUrl": {
+      "description": "Deixe vazio para github.com. Para GitHub Enterprise Server insira a URL base, ex. https://github.minhaempresa.com",
+      "label": "URL da instância GitHub (Opcional)"
+    },
     "token": {
       "description": "Aumenta o limite de taxa de 60 para 5000 requisições/hora.",
       "label": "Token de Acesso Pessoal (Opcional)",

--- a/github-feed/i18n/ru.json
+++ b/github-feed/i18n/ru.json
@@ -77,6 +77,10 @@
       "title": "Обновить настройки"
     },
     "saved": "Настройки ленты GitHub сохранены.",
+    "githubUrl": {
+      "description": "Оставьте пустым для github.com. Для GitHub Enterprise Server введите базовый URL, например https://github.mycompany.com",
+      "label": "URL экземпляра GitHub (Необязательно)"
+    },
     "token": {
       "description": "Увеличение лимита запросов с 60 до 5000 в час.",
       "label": "Персональный токен доступа (необязательно)",

--- a/github-feed/i18n/tr.json
+++ b/github-feed/i18n/tr.json
@@ -77,6 +77,10 @@
       "title": "Ayarları Yenile"
     },
     "saved": "GitHub Akışı ayarları kaydedildi",
+    "githubUrl": {
+      "description": "github.com için boş bırakın. GitHub Enterprise Server için temel URL'yi girin, örn. https://github.sirketim.com",
+      "label": "GitHub Örnek URL'si (İsteğe Bağlı)"
+    },
     "token": {
       "description": "Saatlik istek sınırını 60'tan 5000'e yükseltir.",
       "label": "Kişisel Erişim Belirteci (İsteğe Bağlı)",

--- a/github-feed/i18n/uk-UA.json
+++ b/github-feed/i18n/uk-UA.json
@@ -77,6 +77,10 @@
       "title": "Оновити налаштування"
     },
     "saved": "Налаштування стрічки GitHub збережено",
+    "githubUrl": {
+      "description": "Залиште порожнім для github.com. Для GitHub Enterprise Server введіть базовий URL, наприклад https://github.mycompany.com",
+      "label": "URL екземпляра GitHub (Необов'язково)"
+    },
     "token": {
       "description": "Збільшує ліміт швидкості з 60 до 5000 запитів на годину",
       "label": "Персональний токен доступу (необов'язково)",

--- a/github-feed/i18n/zh-CN.json
+++ b/github-feed/i18n/zh-CN.json
@@ -77,6 +77,10 @@
       "title": "刷新设置"
     },
     "saved": "GitHub Feed 设置已保存",
+    "githubUrl": {
+      "description": "使用 github.com 时留空。使用 GitHub Enterprise Server 时输入基础 URL，例如 https://github.mycompany.com",
+      "label": "GitHub 实例 URL（可选）"
+    },
     "token": {
       "description": "将速率限制从每小时 60 个请求提高到 5000 个请求",
       "label": "个人访问令牌（可选）",

--- a/github-feed/manifest.json
+++ b/github-feed/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "github-feed",
   "name": "GitHub Feed",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "minNoctaliaVersion": "3.6.0",
   "author": "linuxmobile",
   "license": "MIT",
@@ -26,6 +26,7 @@
     "defaultSettings": {
       "username": "",
       "token": "",
+      "githubUrl": "",
       "refreshInterval": 1800,
       "maxEvents": 50,
       "showStars": true,


### PR DESCRIPTION
### Changes
- Added support for self-hosted GitHub urls.
- Added translations with the help of AI.

### Motivation
I would like to be able configure github url to fetch feed from my self hosted GitHub.