### PR TITLE
Add management URL configuration and update manifest properties

### DIFF
--- a/netbird/Main.qml
+++ b/netbird/Main.qml
@@ -29,6 +29,15 @@ Item {
     property bool compactMode: _computeCompactMode()
     property bool showIpAddress: _computeShowIpAddress()
     property bool showPing: _computeShowPing()
+    property string configuredManagementUrl: _computeConfiguredManagementUrl()
+    readonly property string adminConsoleUrl: {
+        var configured = normalizeManagementUrl(configuredManagementUrl);
+        if (configured !== "")
+            return configured;
+        if (managementUrlDetected !== "")
+            return managementUrlDetected;
+        return normalizeManagementUrl(pluginApi?.manifest?.metadata?.defaultSettings?.managementUrl || "https://app.netbird.io/");
+    }
 
     function _computeRefreshInterval() {
         return pluginApi?.pluginSettings?.refreshInterval ?? 5000;
@@ -42,12 +51,55 @@ Item {
     function _computeShowPing() {
         return pluginApi?.pluginSettings?.showPing ?? false;
     }
+    function _computeConfiguredManagementUrl() {
+        return pluginApi?.pluginSettings?.managementUrl ?? "";
+    }
+
+    function normalizeManagementUrl(rawUrl) {
+        var url = String(rawUrl || "").trim();
+        if (url === "")
+            return "";
+
+        if (url.indexOf("://") === -1) {
+            if (url.indexOf("localhost") === 0 || url.indexOf("127.0.0.1") === 0 || url.indexOf("[::1]") === 0) {
+                return "http://" + url;
+            }
+            return "https://" + url;
+        }
+
+        return url;
+    }
+
+    function extractManagementUrl(data) {
+        if (!data)
+            return "";
+
+        var management = data.management || ({});
+        var candidates = [
+            management.url,
+            management.managementUrl,
+            management.fqdn,
+            management.address,
+            management.endpoint,
+            management.domain,
+            data.managementUrl
+        ];
+
+        for (var i = 0; i < candidates.length; i++) {
+            var normalized = normalizeManagementUrl(candidates[i]);
+            if (normalized !== "")
+                return normalized;
+        }
+
+        return "";
+    }
 
     onSettingsVersionChanged: {
         refreshInterval = _computeRefreshInterval();
         compactMode = _computeCompactMode();
         showIpAddress = _computeShowIpAddress();
         showPing = _computeShowPing();
+        configuredManagementUrl = _computeConfiguredManagementUrl();
         updateTimer.interval = refreshInterval;
     }
 
@@ -63,6 +115,8 @@ Item {
     property var peerList: []
     property bool managementConnected: false
     property bool signalConnected: false
+    property string managementFqdn: ""
+    property string managementUrlDetected: ""
 
     property var peerPings: ({})
     property var pingQueue: []
@@ -147,6 +201,8 @@ Item {
 
                     root.managementConnected = data.management?.connected ?? false;
                     root.signalConnected = data.signal?.connected ?? false;
+                    root.managementUrlDetected = root.extractManagementUrl(data);
+                    root.managementFqdn = root.managementUrlDetected;
 
                     root.netbirdRunning = root.managementConnected;
 
@@ -187,12 +243,16 @@ Item {
                         root.peerCount = 0;
                         root.peerConnected = 0;
                         root.peerList = [];
+                        root.managementUrlDetected = "";
+                        root.managementFqdn = "";
                     }
                 } catch (e) {
                     Logger.e("NetBird", "Failed to parse status: " + e);
                     root.netbirdRunning = false;
                     root.netbirdStatus = "Error";
                     root.peerList = [];
+                    root.managementUrlDetected = "";
+                    root.managementFqdn = "";
                 }
             } else {
                 root.netbirdRunning = false;
@@ -202,6 +262,8 @@ Item {
                 root.peerCount = 0;
                 root.peerConnected = 0;
                 root.peerList = [];
+                root.managementUrlDetected = "";
+                root.managementFqdn = "";
             }
         }
     }
@@ -348,7 +410,8 @@ Item {
                 "fqdn": root.netbirdFqdn,
                 "status": root.netbirdStatus,
                 "peers": root.peerCount,
-                "peersConnected": root.peerConnected
+                "peersConnected": root.peerConnected,
+                "managementUrl": root.adminConsoleUrl
             };
         }
 

--- a/netbird/Main.qml
+++ b/netbird/Main.qml
@@ -55,20 +55,15 @@ Item {
         return pluginApi?.pluginSettings?.managementUrl ?? "";
     }
 
-    function normalizeManagementUrl(rawUrl) {
-        var url = String(rawUrl || "").trim();
-        if (url === "")
-            return "";
-
-        if (url.indexOf("://") === -1) {
-            if (url.indexOf("localhost") === 0 || url.indexOf("127.0.0.1") === 0 || url.indexOf("[::1]") === 0) {
-                return "http://" + url;
-            }
-            return "https://" + url;
-        }
-
-        return url;
-    }
+	function normalizeManagementUrl(rawUrl) {
+	  const url = String(rawUrl || "").trim();
+	  if (!url) return "";
+	
+	  if (/^https?:\/\//i.test(url)) return url;
+	
+	  const isLocal = /^(localhost|127\.0\.0\.1|\[::1\])(?::|\/|$)/i.test(url);
+	  return `${isLocal ? "http" : "https"}://${url}`;
+	}
 
     function extractManagementUrl(data) {
         if (!data)

--- a/netbird/Main.qml
+++ b/netbird/Main.qml
@@ -115,7 +115,6 @@ Item {
     property var peerList: []
     property bool managementConnected: false
     property bool signalConnected: false
-    property string managementFqdn: ""
     property string managementUrlDetected: ""
 
     property var peerPings: ({})
@@ -202,7 +201,6 @@ Item {
                     root.managementConnected = data.management?.connected ?? false;
                     root.signalConnected = data.signal?.connected ?? false;
                     root.managementUrlDetected = root.extractManagementUrl(data);
-                    root.managementFqdn = root.managementUrlDetected;
 
                     root.netbirdRunning = root.managementConnected;
 
@@ -244,7 +242,6 @@ Item {
                         root.peerConnected = 0;
                         root.peerList = [];
                         root.managementUrlDetected = "";
-                        root.managementFqdn = "";
                     }
                 } catch (e) {
                     Logger.e("NetBird", "Failed to parse status: " + e);
@@ -252,7 +249,6 @@ Item {
                     root.netbirdStatus = "Error";
                     root.peerList = [];
                     root.managementUrlDetected = "";
-                    root.managementFqdn = "";
                 }
             } else {
                 root.netbirdRunning = false;
@@ -263,7 +259,6 @@ Item {
                 root.peerConnected = 0;
                 root.peerList = [];
                 root.managementUrlDetected = "";
-                root.managementFqdn = "";
             }
         }
     }

--- a/netbird/Panel.qml
+++ b/netbird/Panel.qml
@@ -169,6 +169,8 @@ Item {
 
     readonly property string defaultPeerAction: pluginApi?.pluginSettings?.defaultPeerAction || pluginApi?.manifest?.metadata?.defaultSettings?.defaultPeerAction || "copy-ip"
 
+    readonly property string adminConsoleUrl: mainInstance?.adminConsoleUrl || ""
+
     readonly property bool isTerminalConfigured: terminalCommand !== ""
 
     readonly property var sortedPeerList: {
@@ -484,8 +486,11 @@ Item {
                 visible: mainInstance?.netbirdRunning ?? false
                 text: pluginApi?.tr("panel.admin-console") || "Admin Console"
                 icon: "external-link"
+                enabled: root.adminConsoleUrl !== ""
                 onClicked: {
-                    Qt.openUrlExternally("https://app.netbird.io/");
+                    if (root.adminConsoleUrl !== "") {
+                        Qt.openUrlExternally(root.adminConsoleUrl);
+                    }
                 }
             }
 

--- a/netbird/Settings.qml
+++ b/netbird/Settings.qml
@@ -24,6 +24,8 @@ ColumnLayout {
 
     property string editTerminalCommand: pluginApi?.pluginSettings?.terminalCommand || pluginApi?.manifest?.metadata?.defaultSettings?.terminalCommand || ""
 
+    property string editManagementUrl: pluginApi?.pluginSettings?.managementUrl ?? pluginApi?.manifest?.metadata?.defaultSettings?.managementUrl ?? ""
+
     property string editDefaultPeerAction: pluginApi?.pluginSettings?.defaultPeerAction || pluginApi?.manifest?.metadata?.defaultSettings?.defaultPeerAction || "copy-ip"
 
     spacing: Style.marginM
@@ -147,6 +149,15 @@ ColumnLayout {
         onTextChanged: root.editTerminalCommand = text
     }
 
+    NTextInput {
+        Layout.fillWidth: true
+        label: pluginApi?.tr("settings.management-url") || "Management URL"
+        description: pluginApi?.tr("settings.management-url-desc") || "Override the Admin Console URL. Leave empty to auto-detect from NetBird status."
+        placeholderText: pluginApi?.manifest?.metadata?.defaultSettings?.managementUrl || "https://app.netbird.io/"
+        text: root.editManagementUrl
+        onTextChanged: root.editManagementUrl = text
+    }
+
     NLabel {
         label: pluginApi?.tr("settings.ping-count") || "Ping Count"
         description: (pluginApi?.tr("settings.ping-count-desc") || "Number of ping packets to send when testing connectivity") + " (" + root.editPingCount + ")"
@@ -207,6 +218,7 @@ ColumnLayout {
         pluginApi.pluginSettings.hideDisconnected = root.editHideDisconnected;
         pluginApi.pluginSettings.showPing = root.editShowPing;
         pluginApi.pluginSettings.terminalCommand = root.editTerminalCommand;
+        pluginApi.pluginSettings.managementUrl = root.editManagementUrl;
         pluginApi.pluginSettings.pingCount = root.editPingCount;
         pluginApi.pluginSettings.defaultPeerAction = root.editDefaultPeerAction;
 

--- a/netbird/Settings.qml
+++ b/netbird/Settings.qml
@@ -151,9 +151,9 @@ ColumnLayout {
 
     NTextInput {
         Layout.fillWidth: true
-        label: pluginApi?.tr("settings.management-url") || "Management URL"
-        description: pluginApi?.tr("settings.management-url-desc") || "Override the Admin Console URL. Leave empty to auto-detect from NetBird status."
-        placeholderText: pluginApi?.manifest?.metadata?.defaultSettings?.managementUrl || "https://app.netbird.io/"
+        label: pluginApi?.tr("settings.management-url")
+        description: pluginApi?.tr("settings.management-url-desc")
+        placeholderText: pluginApi?.manifest?.metadata?.defaultSettings?.managementUrl
         text: root.editManagementUrl
         onTextChanged: root.editManagementUrl = text
     }

--- a/netbird/i18n/de.json
+++ b/netbird/i18n/de.json
@@ -16,6 +16,8 @@
     "show-ping-desc": "Alle verbundenen Peers anpingen und die Latenz (ms) anzeigen. Die Aktualisierung erfolgt im gleichen Intervall wie der Status",
     "show-ping-warning": "Diese Funktion sendet bei jedem Aktualisierungsintervall ICMP-Pakete an jeden verbundenen Peer. Dies kann zu einer erhöhten Netzwerkauslastung und CPU-Belastung führen.",
     "terminal": "Terminal Konfiguration",
+    "management-url": "Management URL",
+    "management-url-desc": "Überschreibt die URL der Admin Konsole. Leer lassen für automatische Erkennung über den NetBird Status.",
     "terminal-detected": "Automatisch erkanntes Terminal",
     "terminal-none": "Es wurde kein Terminalemulator erkannt",
     "ping-count": "Anzahl der Pings",

--- a/netbird/i18n/en.json
+++ b/netbird/i18n/en.json
@@ -16,6 +16,8 @@
 		"show-ping-desc": "Ping all connected peers and display latency (ms). Refreshes at the same interval as status.",
 		"show-ping-warning": "This feature sends ICMP packets to each connected peer at every refresh interval. It may increase network usage and CPU load.",
 		"terminal": "Terminal Configuration",
+		"management-url": "Management URL",
+		"management-url-desc": "Override the Admin Console URL. Leave empty to auto-detect from NetBird status.",
 		"terminal-detected": "Auto-detected terminal",
 		"terminal-none": "No terminal emulator detected",
 		"ping-count": "Ping Count",

--- a/netbird/i18n/fr.json
+++ b/netbird/i18n/fr.json
@@ -16,6 +16,8 @@
 		"show-ping-desc": "Ping tous les pairs connectés et affiche la latence (ms). Se rafraîchit au même intervalle que le statut.",
 		"show-ping-warning": "Cette fonctionnalité envoie des paquets ICMP à chaque pair connecté à chaque intervalle de rafraîchissement. Cela peut augmenter l'utilisation du réseau et la charge CPU.",
 		"terminal": "Configuration du terminal",
+		"management-url": "URL de management",
+		"management-url-desc": "Remplace l'URL de la console d'administration. Laissez vide pour la détecter automatiquement depuis le statut NetBird.",
 		"terminal-detected": "Terminal auto-détecté",
 		"terminal-none": "Aucun émulateur de terminal détecté",
 		"ping-count": "Nombre de pings",

--- a/netbird/manifest.json
+++ b/netbird/manifest.json
@@ -24,7 +24,7 @@
       "terminalCommand": "",
       "pingCount": 5,
       "defaultPeerAction": "copy-ip",
-      "managementUrl": "https://app.netbird.io/"
+      "managementUrl": ""
     }
   }
 }

--- a/netbird/manifest.json
+++ b/netbird/manifest.json
@@ -23,7 +23,8 @@
       "showPing": false,
       "terminalCommand": "",
       "pingCount": 5,
-      "defaultPeerAction": "copy-ip"
+      "defaultPeerAction": "copy-ip",
+      "managementUrl": "https://app.netbird.io/"
     }
   }
 }

--- a/netbird/manifest.json
+++ b/netbird/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "netbird",
   "name": "NetBird",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "minNoctaliaVersion": "4.0.0",
   "author": "Cleboost",
   "license": "MIT",


### PR DESCRIPTION
Adds support for a configurable Admin Console URL in the NetBird plugin, with automatic URL detection from NetBird status output.

Also resolves the final URL with a clear priority: user-defined setting first, auto-detected management URL second, and default fallback last.

Changes:

- Add support for storing a custom managementUrl setting in `manifest.json` and `Settings.qml`.
- Update status parsing in `Main.qml` to detect management URL fields from NetBird JSON output.
- Add URL normalization in `Main.qml` so host-only values are converted into valid URLs.
- Update the Admin Console button in `Panel.qml` to open the resolved URL instead of a hardcoded one.
- Add new translation keys for the settings field in `en.json`, `de.json`, and `fr.json`