### PR TITLE
fix(privacy-indicator): resolve QML crash from undeclared appName variable

### DIFF
--- a/privacy-indicator/Main.qml
+++ b/privacy-indicator/Main.qml
@@ -57,7 +57,7 @@ Item {
 
         var appNames = [];
         for (var i = 0; i < apps.length; i++) {
-            appName = apps[i];
+            var appName = apps[i];
             if (filterRegex && appName && filterRegex.test(appName)) continue;
             if (appName && appNames.indexOf(appName) === -1) appNames.push(appName);
         }

--- a/privacy-indicator/manifest.json
+++ b/privacy-indicator/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "privacy-indicator",
   "name": "Privacy Indicator",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "minNoctaliaVersion": "3.6.0",
   "author": "Noctalia Team",
   "official": true,


### PR DESCRIPTION
### Description
This PR fixes a runtime crash in the `privacy-indicator` plugin that prevents the camera indicator from appearing in the bar. 

In `Main.qml`, inside the camera detection loop, the `appName` variable was being assigned without a `var` or `let` declaration. Because QML executes in strict mode, this triggers a fatal `Invalid write to global property "appName"` error, causing the function to abort before updating the UI state. 

### Changes Made
- Added `var` declaration to `appName` in `Main.qml` (around line 60).

**Error Log Resolved:**
`WARN scene: file:///[...]/plugins/privacy-indicator/Main.qml?v=0[60:-1]: Error: Invalid write to global property "appName"`

### Testing
- [x] Triggered camera via `mpv av://v4l2:/dev/video0` and browser webcams.
- [x] Verified the `privacy-indicator` successfully displays the camera icon and tooltip without throwing QML runtime warnings. 