### PR TITLE
fix(web-search): Fix protocols other than http/https not recognized as URL

### DIFF
--- a/web-search/LauncherProvider.qml
+++ b/web-search/LauncherProvider.qml
@@ -39,24 +39,29 @@ Item {
     function isUrl(text) {
         if (!text || text.includes(" ")) return false;
 
-        if (/^https?:\/\//i.test(text)) return true;
+        const protocolPattern = /^[a-z0-9]+:\/\/\S+/i;
+        if (protocolPattern.test(text)) return true;
 
-        const localhostPattern = /^localhost(:[0-9]+)?(\/\S*)?$/i;
+        const localhostPattern = /^localhost(\/\S*)?$/i;
         const ipPattern = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(:[0-9]+)?(\/\S*)?$/;
-        const domainPattern = /^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z]{2,})+(:[0-9]+)?(\/\S*)?$/;
+        const domainPattern = /^([a-zA-Z0-9-]{1,63}\.)+[a-zA-Z]{2,}(:[0-9]+)?(\/\S*)?$/i;
+        const hostPortPattern = /^[a-zA-Z0-9-]+:[0-9]+(\/\S*)?$/i;
 
-        return localhostPattern.test(text) || ipPattern.test(text) || domainPattern.test(text);
+        return localhostPattern.test(text) || ipPattern.test(text) || domainPattern.test(text) || hostPortPattern.test(text);
     }
 
     function normalizeUrl(text) {
         text = text.trim();
         if (!text) return "";
-        if (/^[a-z0-9]+:\/\//i.test(text)) return text;
 
-        const isLocal = /^localhost(:[0-9]+)?(\/\S*)?$/i.test(text) || 
-                        /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(:[0-9]+)?(\/\S*)?$/.test(text);
+        const protocolPattern = /^[a-z0-9]+:\/\/\S+/i;
+        if (protocolPattern.test(text)) return text;
+
+        const localhostPattern = /^localhost(\/\S*)?$/i;
+        const ipPattern = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(:[0-9]+)?(\/\S*)?$/;
+        const hostPortPattern = /^[a-zA-Z0-9-]+:[0-9]+(\/\S*)?$/i;
         
-        if (isLocal) {
+        if (localhostPattern.test(text) || ipPattern.test(text) || hostPortPattern.test(text)) {
             return "http://" + text;
         }
 

--- a/web-search/README.md
+++ b/web-search/README.md
@@ -73,6 +73,12 @@ You can configure the plugin directly via Noctalia's Plugin Settings:
 
 ## Changelog
 
+### 1.1.1
+- Fix protocols other than http/https not recognized as URL
+- Support for middle domain with only one character (e.g., www.a.com)
+- Support for hostname without dot with port (e.g., hostname:8080)
+    - If you want to enter hostname without port and dot, you have to type the protocol manually
+
 ### 1.1.0
 - Added Direct URL Opening. Automatically detects URLs, IP addresses, and localhost and opens them directly in the browser
 - Added configurable toggle for the Direct URL feature

--- a/web-search/manifest.json
+++ b/web-search/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "web-search",
     "name": "Web Search",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "author": "Rigelyon",
     "license": "MIT",
     "description": "Search the Internet from the Launcher.",


### PR DESCRIPTION
Other Changes:
### 1.1.1
- Fix protocols other than http/https not recognized as URL
- Support for middle domain with only one character (e.g., www.a.com)
- Support for hostname without dot with port (e.g., hostname:8080)
    - If you want to enter hostname without port and dot, you have to type the protocol manually