### PR TITLE
obs-control: more reliable OBS process search

### DIFF
--- a/obs-control/Main.qml
+++ b/obs-control/Main.qml
@@ -858,7 +858,7 @@ Item {
   Process {
     id: obsProbeProcess
     running: false
-    command: ["pgrep", "-x", "obs"]
+    command: ["pidof", "obs"]
 
     onExited: function(exitCode) {
       const callbacks = root.obsProbeCallbacks


### PR DESCRIPTION
NixOS wraps OBS into `.obs-wrapper`, which `pgrep -x obs` fails to find. since both `.obs-wrapper` and the `obs` command on other Linux distros run the same `obs` binary, `pidof` works more reliably.

I spent more time laying out the reasoning here than fixing this...