### PR TITLE
fix(obs-control): use `pidof` instead of `pgrep`

### DIFF
--- a/obs-control/Main.qml
+++ b/obs-control/Main.qml
@@ -858,7 +858,7 @@ Item {
   Process {
     id: obsProbeProcess
     running: false
-    command: ["pgrep", "-x", "obs"]
+    command: ["pidof", "obs"]
 
     onExited: function(exitCode) {
       const callbacks = root.obsProbeCallbacks

--- a/obs-control/manifest.json
+++ b/obs-control/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "obs-control",
   "name": "OBS Control",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": "ayagmar",
   "description": "OBS recording, replay, and stream status widget for Noctalia.",
   "tags": [


### PR DESCRIPTION
NixOS wraps OBS into `.obs-wrapper`, which `pgrep -x obs` fails to find. since both `.obs-wrapper` and the `obs` command on other Linux distros run the same `obs` binary, `pidof` works more reliably

I spent more time laying out the reasoning here than fixing this...

---

UPD: for some reason GitHub decided to rename this branch to `patch-1` although I gave it a different name. closing #672 and reopening here.