### PR TITLE
i18n(privacy-indicator): update French translations

### DIFF
--- a/privacy-indicator/i18n/fr.json
+++ b/privacy-indicator/i18n/fr.json
@@ -30,6 +30,10 @@
     "micFilterRegex": {
       "desc": "Motif Regex pour filtrer les applications de microphone. Les applications correspondantes sont complètement exclues de la détection.",
       "label": "Regex de filtrage du microphone"
+    },
+    "camFilterRegex": {
+      "desc": "Motif Regex pour filtrer les applications de caméra. Les applications correspondantes sont complètement exclues de la détection.",
+      "label": "Regex de filtrage de la caméra"
     }
   },
   "tooltip": {

--- a/privacy-indicator/manifest.json
+++ b/privacy-indicator/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "privacy-indicator",
   "name": "Privacy Indicator",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "minNoctaliaVersion": "3.6.0",
   "author": "Noctalia Team",
   "official": true,


### PR DESCRIPTION
This pull request introduces a minor update to the `privacy-indicator` extension, primarily adding new French translations for a camera filter regex setting and incrementing the version number.

Localization improvements:

* Added French translations for the camera filter regex setting (`camFilterRegex`) in `fr.json`.

Version update:

* Bumped the extension version from `1.2.10` to `1.2.11` in `manifest.json`.