### PR TITLE
MimeApp GUI

### DIFF
--- a/mimeapp-gui/BarWidget.qml
+++ b/mimeapp-gui/BarWidget.qml
@@ -1,26 +1,63 @@
 import Quickshell
 import qs.Commons
+import qs.Services.UI
 import qs.Widgets
 
 NIconButton {
-  id: root
+	id: root
 
-  property var pluginApi: null
-  property ShellScreen screen
-  property string widgetId: ""
-  property string section: ""
-  property int sectionWidgetIndex: -1
-  property int sectionWidgetsCount: 0
+	property var pluginApi: null
 
-  readonly property string screenName: screen?.name ?? ""
+	property ShellScreen screen
+	property string widgetId: ""
+	property string section: ""
+	property int sectionWidgetIndex: -1
+	property int sectionWidgetsCount: 0
 
-  baseSize: Style.getCapsuleHeightForScreen(screenName)
-  applyUiScale: false
-  customRadius: Style.radiusL
-  icon: "file-text"
-  tooltipText: pluginApi?.tr("bar.tooltip")
+	property var cfg: pluginApi?.pluginSettings || ({})
+	property var defaults: pluginApi?.manifest?.metadata?.defaultSettings || ({})
 
-  onClicked: {
-    pluginApi?.openPanel(root.screen, root)
-  }
+	readonly property string iconColorKey: cfg.iconColor ?? defaults.iconColor
+
+	icon: "file-dots"
+	tooltipText: pluginApi?.tr("bar.tooltip")
+	tooltipDirection: BarService.getTooltipDirection(screen?.name)
+	baseSize: Style.getCapsuleHeightForScreen(screen?.name)
+	applyUiScale: false
+	customRadius: Style.radiusL
+	colorBg: Style.capsuleColor
+	colorFg: Color.resolveColorKey(iconColorKey)
+
+	border.color: Style.capsuleBorderColor
+	border.width: Style.capsuleBorderWidth
+
+	onClicked: {
+		if (pluginApi) {
+			pluginApi.togglePanel(root.screen, this);
+		}
+	}
+
+	onRightClicked: {
+		PanelService.showContextMenu(contextMenu, root, screen);
+	}
+
+	NPopupContextMenu {
+		id: contextMenu
+
+		model: [
+			{
+				"label": pluginApi?.tr("contextMenu.widget-settings"),
+				"action": "widgetSettings",
+				"icon": "settings"
+			}
+		]
+
+		onTriggered: function (action) {
+			contextMenu.close();
+			PanelService.closeContextMenu(screen);
+			if (action === "widgetSettings") {
+				BarService.openPluginSettings(root.screen, pluginApi.manifest);
+			}
+		}
+	}
 }

--- a/mimeapp-gui/Main.qml
+++ b/mimeapp-gui/Main.qml
@@ -3,20 +3,19 @@ import Quickshell
 import Quickshell.Io
 
 Item {
-  id: root
+	id: root
 
-  property var pluginApi: null
+	property var pluginApi: null
 
-  IpcHandler {
-    target: "plugin:mimeapp-gui"
+	IpcHandler {
+		target: "plugin:mimeapp-gui"
 
-    function open() {
-      if (root.pluginApi) {
-        root.pluginApi.withCurrentScreen(screen => {
-          root.pluginApi.openPanel(screen)
-        })
-      }
-    }
-
-  }
+		function openPanel() {
+			if (root.pluginApi) {
+				root.pluginApi.withCurrentScreen(screen => {
+					root.pluginApi.openPanel(screen)
+				})
+			}
+		}
+	}
 }

--- a/mimeapp-gui/README.md
+++ b/mimeapp-gui/README.md
@@ -24,23 +24,25 @@ This plugin exposes an IPC target so the panel can be opened from keybinds, scri
 
 ```txt
 target plugin:mimeapp-gui
-	function open(): void
+  function openPanel(): void
 ```
 
 Example commands:
 
 ```bash
-qs -c noctalia-shell ipc call plugin:mimeapp-gui open
+qs -c noctalia-shell ipc call plugin:mimeapp-gui openPanel
 ```
 
 Example `.desktop` `Exec` line:
 
 ```txt
-Exec=qs -c noctalia-shell ipc call plugin:mimeapp-gui open
+Exec=qs -c noctalia-shell ipc call plugin:mimeapp-gui openPanel
 ```
 
 ## Features
 
 - The "Common" tab visually groups common types (browsers, images, music, video, archives, etc.) and displays typical file extensions beside each group. 
 - Changing a default updates only the selected MIME type in `~/.config/mimeapps.list`.
+- Changing the BarWidget icon colors inside plugin's settings panel
 - `ControlCenterWidget` for Control Center shortcuts
+- Copy the IPC Command directly inside the plugin's settings panel

--- a/mimeapp-gui/Settings.qml
+++ b/mimeapp-gui/Settings.qml
@@ -1,0 +1,73 @@
+import QtQuick
+import QtQuick.Layouts
+import qs.Commons
+import qs.Widgets
+
+ColumnLayout {
+	id: root
+
+	property var pluginApi: null
+
+	property var cfg: pluginApi?.pluginSettings || ({})
+	property var defaults: pluginApi?.manifest?.metadata?.defaultSettings || ({})
+
+	property string valueIconColor: cfg.iconColor ?? defaults.iconColor
+
+	spacing: Style.marginM
+
+	NColorChoice {
+		label: pluginApi?.tr("settings.iconColor.label")
+		description: pluginApi?.tr("settings.iconColor.desc")
+		currentKey: root.valueIconColor
+		onSelected: key => root.valueIconColor = key
+	}
+
+	NDivider {
+		Layout.fillWidth: true
+		Layout.topMargin: Style.marginS
+		Layout.bottomMargin: Style.marginS
+	}
+
+	ColumnLayout {
+		Layout.fillWidth: true
+
+		NLabel {
+			label: pluginApi?.tr("settings.ipcCommands.label")
+			description: pluginApi?.tr("settings.ipcCommands.desc")
+		}
+
+		Rectangle {
+			Layout.fillWidth: true
+			Layout.preferredHeight: commandText.implicitHeight + Style.marginM * 2
+			color: Color.mSurfaceVariant
+			radius: Style.radiusM
+
+			TextEdit {
+				id: commandText
+				anchors.fill: parent
+				anchors.margins: Style.marginM
+				text: "qs -c noctalia-shell ipc call plugin:mimeapp-gui openPanel"
+				font.pointSize: Style.fontSizeS
+				font.family: Settings.data.ui.fontFixed
+				color: Color.mPrimary
+				wrapMode: TextEdit.WrapAnywhere
+				readOnly: true
+				selectByMouse: true
+				selectionColor: Color.mPrimary
+				selectedTextColor: Color.mOnPrimary
+			}
+		}
+	}
+
+	function saveSettings() {
+		if (!pluginApi) {
+			Logger.e("MimeApp GUI", "Cannot save settings: pluginApi is null");
+			return;
+		}
+
+		pluginApi.pluginSettings.iconColor = root.valueIconColor;
+		pluginApi.saveSettings();
+
+		Logger.d("MimeApp GUI", "Settings saved");
+	}
+}

--- a/mimeapp-gui/i18n/en.json
+++ b/mimeapp-gui/i18n/en.json
@@ -3,35 +3,35 @@
     "tooltip": "MIME App Defaults"
   },
   "panel": {
-        "status": {
-          "backendNotReady": "Backend path not ready yet.",
-          "noConflicts": "No MIME types with multiple handlers were found.",
-          "noHandlers": "No MIME handlers were found from installed desktop files.",
-          "updatedDefaultParseError": "Default updated, but response parsing failed: {error}",
-          "updatedDefault": "Updated default for {mimeType}."
-        },
-        "error": {
-          "parseScanResult": "Failed to parse scan result: {error}",
-          "scanFailed": "Failed to scan MIME handlers. Ensure python3 is installed and available in PATH.",
-          "scanFailedGeneric": "Scan failed.",
-          "saveFailed": "Failed to save default application. Ensure python3 is installed and available in PATH.",
-          "saveFailedGeneric": "Failed to save default application."
-        },
-        "current": "Current: ",
-        "none": "(none)",
-        "source": "Source: ",
-        "notConfigured": "(not configured)",
-      "tab": {
-        "all": "All",
-        "common": "Common",
-        "audio": "Audio",
-        "video": "Video",
-        "application": "Application",
-        "image": "Image",
-        "text": "Text",
-        "inode": "Filesystem",
-        "other": "Other"
-      },
+    "status": {
+      "backendNotReady": "Backend path not ready yet.",
+      "noConflicts": "No MIME types with multiple handlers were found.",
+      "noHandlers": "No MIME handlers were found from installed desktop files.",
+      "updatedDefaultParseError": "Default updated, but response parsing failed: {error}",
+      "updatedDefault": "Updated default for {mimeType}."
+    },
+    "error": {
+      "parseScanResult": "Failed to parse scan result: {error}",
+      "scanFailed": "Failed to scan MIME handlers. Ensure python3 is installed and available in PATH.",
+      "scanFailedGeneric": "Scan failed.",
+      "saveFailed": "Failed to save default application. Ensure python3 is installed and available in PATH.",
+      "saveFailedGeneric": "Failed to save default application."
+    },
+    "current": "Current: ",
+    "none": "(none)",
+    "source": "Source: ",
+    "notConfigured": "(not configured)",
+    "tab": {
+      "all": "All",
+      "common": "Common",
+      "audio": "Audio",
+      "video": "Video",
+      "application": "Application",
+      "image": "Image",
+      "text": "Text",
+      "inode": "Filesystem",
+      "other": "Other"
+    },
     "title": "MimeApp GUI",
     "refresh": "Refresh",
     "subtitle": "Select a default application for each MIME type. Changes are written to ~/.config/mimeapps.list.",
@@ -44,6 +44,19 @@
       "button": "Apply",
       "saving": "Saving..."
     }
+  },
+  "settings": {
+    "iconColor": {
+      "label": "Icon color",
+      "desc": "Color of the bar widget icon."
+    },
+    "ipcCommands": {
+      "label": "IPC Command",
+      "desc": "Toggle the plugin panel via IPC command"
+    }
+  },
+  "contextMenu": {
+    "widget-settings": "Widget settings"
   },
   "mime": {
     "http": "Web browser",

--- a/mimeapp-gui/manifest.json
+++ b/mimeapp-gui/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "mimeapp-gui",
   "name": "MimeApp GUI",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "minNoctaliaVersion": "4.1.2",
   "author": "Mathew-D",
   "license": "MIT",
@@ -16,11 +16,16 @@
   "entryPoints": {
     "main": "Main.qml",
     "barWidget": "BarWidget.qml",
+    "controlCenterWidget": "ControlCenterWidget.qml",
     "panel": "Panel.qml",
-    "controlCenterWidget": "ControlCenterWidget.qml"
+    "settings": "Settings.qml"
   },
   "dependencies": {
     "plugins": []
   },
-  "metadata": {}
+  "metadata": {
+    "defaultSettings": {
+      "iconColor": "none"
+    }
+  }
 }


### PR DESCRIPTION
@Mathew-D sorry for the sudden of alot of changes on the MimeApp GUI plugin like this but below is the brief change logs for the plugin and hope that it'll help with the user's experience more

### Change logs for MimeApp GUI:
1. Added `Settings.qml` with options to change BarWidget icon colors and copy IPC command directly inside the settings panel
2. Improve the BarWidget icon by removing the uneccessary background behind the icon and to follow the development guidelines of Noctalia plugin creation
3. Change BarWidget icon from "file-text" to "file-dots" to avoid having the same icon type with `notes-scratchpad` plugin
4. Changed the IPC command from "open" to "openPanel" for a more clarification on the IPC command's purpose
5. Added some new translations for the new stuff added above
6. Changed the default icon color from mPrimary to mOnSurface and users have option to choose their own icon color inside settings panel
7. Added default metadata settings of the icon color inside `manifest.json` and bumping version up