### PR TITLE
i18n(arch-updater): update French translations

### DIFF
--- a/arch-updater/i18n/fr.json
+++ b/arch-updater/i18n/fr.json
@@ -1,0 +1,78 @@
+{
+    "tooltip": {
+        "availableUpdates": "Mises à jour disponibles",
+        "noctaliaUpdates": "Mises à jour Noctalia disponibles"
+    },
+    "context": {
+        "refresh": "Actualiser",
+        "update": "Mettre à jour",
+        "settings": "Paramètres"
+    },
+    "panel": {
+        "name": "Nom",
+        "oldVer": "Ancienne version",
+        "newVer": "Nouvelle version",
+        "refresh": "Actualiser",
+        "update": "Mettre à jour",
+        "settings": "Paramètres"
+    },
+    "toast": {
+        "refreshed": "Mises à jour disponibles actualisées !"
+    },
+    "settings": {
+        "commands": "Commandes",
+        "checkCmd": "Commande de vérification",
+        "checkCmdDesc": "Commande pour vérifier les mises à jour (format de sortie : nom oldver -> newver)",
+        "updateCmd": "Commande de mise à jour",
+        "updateCmdDesc": "Commande pour mettre à jour",
+        "flatpak": "Flatpak",
+        "flatpakDesc": "Activer la vérification des mises à jour Flatpak",
+        "noctalia": "Noctalia",
+        "noctaliaDesc": "Activer la mise en évidence si les composants Noctalia ont une mise à jour",
+        "boldVer": "Nouvelle version en gras",
+        "boldVerDesc": "Mettre en gras la colonne de la nouvelle version",
+        "toast": "Notification",
+        "toastDesc": "Activer la notification d'actualisation des mises à jour",
+        "desktopTip": "Astuce au survol du bureau",
+        "desktopTipDesc": "Activer l'astuce au survol pour le widget de bureau",
+        "hideOnEmpty": "Masquer si vide",
+        "hideOnEmptyDesc": "Masquer s'il n'y a pas de mises à jour disponibles",
+        "refreshTimer": "Actualisation périodique",
+        "refreshTimerDesc": "Actualiser selon une minuterie",
+        "interval": "Intervalle d'actualisation",
+        "intervalDesc": "Intervalle d'actualisation en minutes : ",
+        "appearance": "Apparence",
+        "boldText": "Texte en gras",
+        "boldTextDesc": "Afficher le nombre de mises à jour en gras",
+        "tooltip": "Bulle d'aide",
+        "tooltipDesc": "Afficher la bulle d'aide au survol du widget",
+        "useDistroLogo": "Utiliser le logo de la distro",
+        "useDistroLogoDesc": "Utiliser le logo de votre distribution comme icône du widget",
+        "enableColorization": "Activer la colorisation",
+        "enableColorizationDesc": "Coloriser l'icône avec une couleur personnalisée",
+        "iconColor": "Couleur de l'icône",
+        "iconColorDesc": "Choisir la couleur de l'icône",
+        "iconName": "Icône",
+        "iconNameDesc": "Choisir l'icône du widget de la barre",
+        "browseLibrary": "Parcourir la bibliothèque",
+        "browseFile": "Parcourir le fichier",
+        "selectCustomIcon": "Sélectionner une icône personnalisée"
+    },
+    "launcher": {
+        "refreshDesc": "Actualiser les mises à jour disponibles",
+        "updateDesc": "Mettre à jour le système"
+    },
+    "ccw": {
+        "tooltip": "Ouvrir le panneau des mises à jour"
+    },
+    "desktop": {
+        "header": "mise à jour disponible",
+        "header-plural": "mises à jour disponibles",
+        "name": "Nom",
+        "oldVer": "Ancienne version",
+        "newVer": "Nouvelle version",
+        "tipLeft": "Clic gauche pour actualiser",
+        "tipMiddle": "Clic milieu pour mettre à jour",
+        "tipRight": "Clic droit pour ouvrir les paramètres"
+    }
+}

--- a/arch-updater/manifest.json
+++ b/arch-updater/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "arch-updater",
   "name": "Arch Updater",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "minNoctaliaVersion": "3.6.0",
   "author": "Ast",
   "license": "MIT",


### PR DESCRIPTION
This pull request introduces French localization support for the Arch Updater widget and updates the extension version. The most significant changes are the addition of a French translation file and a version bump in the manifest.

Localization:

* Added a new `fr.json` file with French translations for tooltip, context menu, panel, settings, launcher and desktop widget strings.

Version update:

* Bumped the extension version from `1.2.0` to `1.2.1` in manifest.json.