### PR TITLE
i18n(sys-info-widget): update French translations

### DIFF
--- a/sys-info-widget/i18n/fr.json
+++ b/sys-info-widget/i18n/fr.json
@@ -1,0 +1,15 @@
+{
+  "widget": {
+    "distribution": "Système",
+    "kernel": "Noyau",
+    "uptime": "Disponibilité",
+    "cpu": "Processeur",
+    "separator_at": "@",
+    "memory": "Mémoire",
+    "disk_root": "Disque /",
+    "disk_home": "Disque /home",
+    "ipaddress": "IP publique",
+    "lanaddress": "IP locale",
+    "loading": "Chargement..."
+  }
+}

--- a/sys-info-widget/manifest.json
+++ b/sys-info-widget/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "sys-info-widget",
   "name": "System Info",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "minNoctaliaVersion": "4.6.6",
   "author": "Simon",
   "license": "MIT",


### PR DESCRIPTION
This pull request introduces French localization support for the System Info widget and updates the extension version. The most significant changes are the addition of a French translation file and a version bump in the manifest.

Localization:

* Added a new `fr.json` file with French translations for system info labels (distribution, kernel, uptime, etc.).

Version update:

* Bumped the extension version from `1.0.6` to `1.0.7` in manifest.json.