### PR TITLE
fix(world-clock): remove fallback text for translation

### DIFF
--- a/world-clock/Settings.qml
+++ b/world-clock/Settings.qml
@@ -335,7 +335,7 @@ ColumnLayout {
     // Info text
     NText {
       Layout.fillWidth: true
-      text: `${root.availableTimezones.length} ${pluginApi?.tr("world-clock.available-timezones") || "timezones available"}`
+      text: `${root.availableTimezones.length} ${pluginApi?.tr("world-clock.available-timezones")}`
       pointSize: Style.fontSizeXS
       color: Color.mOnSurfaceVariant
     }


### PR DESCRIPTION
This pull request makes a minor improvement to the display of the available timezones info text in the `Settings.qml` file. The redundant fallback string ("timezones available") has been removed, ensuring that the translation key is always used.

* Removed the unnecessary fallback string from the info text, so only the translated label for available timezones is shown. (`world-clock/Settings.qml`)