### PR TITLE
Refactor screenshot logic and remove fallback translation text

### DIFF
--- a/screenshot/BarWidget.qml
+++ b/screenshot/BarWidget.qml
@@ -6,7 +6,6 @@ import qs.Services.UI
 import qs.Services.System
 import qs.Services.Compositor
 import qs.Widgets
-import Quickshell.Io
 
 NIconButton {
     id: root
@@ -36,44 +35,13 @@ NIconButton {
         pluginApi?.manifest?.metadata?.defaultSettings?.mode || 
         "region"
 
-    Process {
-        id: screenshotProcess
-        onExited: code => {
-            if (code === 0) {
-                ToastService.showNotice(pluginApi?.tr("notification.title"), pluginApi?.tr("notification.success"), "camera", 3000);
-            }
-        }
-    }
-
-    function takeScreenshot(customArgs = null) {
-        if (screenshotProcess.running) return;
-
-        var args = [];
-        if (customArgs) {
-            args = customArgs;
-        } else if (CompositorService.isHyprland) {
-            args = ["hyprshot", "--freeze", "--clipboard-only", "--mode", screenshotMode, "--silent"];
-        } else if (CompositorService.isNiri) {
-            args = ["niri", "msg", "action", "screenshot"];
-        } else if (CompositorService.isSway) {
-            args = ["grimshot", "copy", "area"];
-
-            if (screenshotMode === "screen" || screenshotMode === "fullscreen") {
-                args = ["grimshot", "copy", "output"];
-            } else if (screenshotMode === "window") {
-                args = ["grimshot", "copy", "window"];
-            }
-        } else {
-            // Fallback to hyprshot for other compositors
-            args = ["hyprshot", "--freeze", "--clipboard-only", "--mode", screenshotMode, "--silent"];
-        }
-
-        screenshotProcess.command = args;
-        screenshotProcess.running = true;
+    ScreenshotHelper {
+        id: helper
+        pluginApi: root.pluginApi
     }
 
     onClicked: {
-        takeScreenshot();
+        helper.takeScreenshot(root.screenshotMode);
     }
 
     onRightClicked: {
@@ -120,11 +88,11 @@ NIconButton {
             PanelService.closeContextMenu(screen);
 
             if (action === "take-screenshot") {
-                root.takeScreenshot();
+                helper.takeScreenshot(root.screenshotMode);
             } else if (action === "take-screenshot-active-window") {
-                root.takeScreenshot(["hyprshot", "-m", "window", "-m", "active", "--clipboard-only"]);
+                helper.takeScreenshot("active-window");
             } else if (action === "take-screenshot-active-screen") {
-                root.takeScreenshot(["hyprshot", "-m", "output", "-m", "active", "--clipboard-only"]);
+                helper.takeScreenshot("active-screen");
             } else if (action === "widget-settings") {
                 BarService.openPluginSettings(screen, pluginApi.manifest);
             }

--- a/screenshot/Main.qml
+++ b/screenshot/Main.qml
@@ -1,62 +1,24 @@
 import QtQuick
 import Quickshell
-import Quickshell.Io
 import qs.Commons
 import qs.Services.UI
 import qs.Services.Noctalia
-import qs.Services.Compositor
 
 Item {
+    id: root
+
     property var pluginApi: null
 
-    Process {
-        id: screenshotProcess
-        onExited: code => {
-            if (code === 0) {
-                ToastService.showNotice(pluginApi?.tr("notification.title"), pluginApi?.tr("notification.success"), "camera", 3000)
-            }
-        }
+    ScreenshotHelper {
+        id: helper
+        pluginApi: root.pluginApi
     }
 
     IpcHandler {
         target: "plugin:screenshot"
 
         function takeScreenshot(mode: string): bool {
-            if (screenshotProcess.running) return false;
-            
-            var args = [];
-            if (CompositorService.isHyprland) {
-                args = [
-                    "hyprshot",
-                    "--freeze",
-                    "--clipboard-only",
-                    "--mode", mode,
-                    "--silent"
-                ]
-            } else if (CompositorService.isNiri) {
-                args = [
-                    "niri", "msg", "action", "screenshot"
-                ]
-            } else if (CompositorService.isSway) {
-                args = ["grimshot"]
-
-                if (mode === "screen") {
-                    args.push("copy", "output")
-                } else if (mode === "region") {
-                    args.push("copy", "area")
-                } else {
-                    args.push("copy", "area")
-                }
-            } else {
-                // Fallback: notify user that screenshots are unsupported
-                ToastService.showError(pluginApi?.tr("notification.title"), pluginApi?.tr("notification.unsupported-compositor"), 3000)
-                return false
-            }
-
-            screenshotProcess.command = args
-            screenshotProcess.running = true
-
-            return true
+            return helper.takeScreenshot(mode);
         }
     }
 }

--- a/screenshot/Main.qml
+++ b/screenshot/Main.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import Quickshell
+import Quickshell.Io
 import qs.Commons
 import qs.Services.UI
 import qs.Services.Noctalia

--- a/screenshot/ScreenshotHelper.qml
+++ b/screenshot/ScreenshotHelper.qml
@@ -1,0 +1,53 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.Commons
+import qs.Services.UI
+import qs.Services.Compositor
+
+Item {
+    id: root
+
+    property var pluginApi: null
+
+    Process {
+        id: screenshotProcess
+        onExited: code => {
+            if (code === 0) {
+                ToastService.showNotice(pluginApi?.tr("notification.title"), pluginApi?.tr("notification.success"), "camera", 3000);
+            }
+        }
+    }
+
+    function takeScreenshot(mode) {
+        if (screenshotProcess.running) return false;
+
+        var args = [];
+        if (CompositorService.isHyprland) {
+            if (mode === "active-window") {
+                args = ["hyprshot", "-m", "window", "-m", "active", "--clipboard-only", "--silent"];
+            } else if (mode === "active-screen") {
+                args = ["hyprshot", "-m", "output", "-m", "active", "--clipboard-only", "--silent"];
+            } else {
+                args = ["hyprshot", "--freeze", "--clipboard-only", "--mode", mode, "--silent"];
+            }
+        } else if (CompositorService.isNiri) {
+            args = ["niri", "msg", "action", "screenshot"];
+        } else if (CompositorService.isSway) {
+            if (mode === "screen" || mode === "fullscreen" || mode === "active-screen") {
+                args = ["grimshot", "copy", "output"];
+            } else if (mode === "window" || mode === "active-window") {
+                args = ["grimshot", "copy", "active"];
+            } else {
+                args = ["grimshot", "copy", "area"];
+            }
+        } else {
+            ToastService.showError(pluginApi?.tr("notification.title"), pluginApi?.tr("notification.unsupported-compositor"), 3000);
+            return false;
+        }
+
+        screenshotProcess.command = args;
+        screenshotProcess.running = true;
+        return true;
+    }
+}

--- a/screenshot/Settings.qml
+++ b/screenshot/Settings.qml
@@ -16,16 +16,16 @@ ColumnLayout {
     spacing: Style.marginM
 
     NComboBox {
-        label: pluginApi?.tr("settings.mode.label") || "Screenshot Mode"
-        description: pluginApi?.tr("settings.mode.description") || "Choose between region selection or direct screen capture"
+        label: pluginApi?.tr("settings.mode.label")
+        description: pluginApi?.tr("settings.mode.description")
         model: [
             {
                 "key": "region",
-                "name": pluginApi?.tr("settings.mode.region") || "Region Selection"
+                "name": pluginApi?.tr("settings.mode.region")
             },
             {
                 "key": "screen",
-                "name": pluginApi?.tr("settings.mode.screen") || "Full Screen"
+                "name": pluginApi?.tr("settings.mode.screen")
             }
         ]
         currentKey: root.editMode

--- a/screenshot/manifest.json
+++ b/screenshot/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "screenshot",
   "name": "Screenshot",
-  "version": "1.1.1",
+  "version": "1.2.1",
   "minNoctaliaVersion": "3.6.0",
   "author": "Cleboost",
   "license": "MIT",


### PR DESCRIPTION
This pull request refactors the screenshot functionality to centralize the logic for taking screenshots into a new `ScreenshotHelper` component, improving maintainability and reducing code duplication. It also cleans up translation usage in the settings UI and bumps the plugin version.

Refactoring and code organization:

* Extracted all screenshot logic from `BarWidget.qml` and `Main.qml` into a new reusable `ScreenshotHelper.qml` component, which handles compositor detection, command construction, and notifications. All screenshot actions now delegate to this helper. [[1]](diffhunk://#diff-66726a0034892b7f2cc2fdf84f8f23ec6abedc671619d08911442bd2a252a918L39-R44) [[2]](diffhunk://#diff-66726a0034892b7f2cc2fdf84f8f23ec6abedc671619d08911442bd2a252a918L123-R95) [[3]](diffhunk://#diff-57d33d1a99615b056e6037b19381990cf6e070c443bdb06d1206ea4a8364706bL3-R21) [[4]](diffhunk://#diff-117c133d864be08fed7d4437a837fc2ba0e6161c4eff9195ad8a0eae4fe9e6e6R1-R53)
* Removed direct imports of `Quickshell.Io` and `qs.Services.Compositor` from files that no longer need them, as this logic is now encapsulated in `ScreenshotHelper.qml`. [[1]](diffhunk://#diff-66726a0034892b7f2cc2fdf84f8f23ec6abedc671619d08911442bd2a252a918L9) [[2]](diffhunk://#diff-57d33d1a99615b056e6037b19381990cf6e070c443bdb06d1206ea4a8364706bL3-R21)

User interface and translations:

* Updated `Settings.qml` to remove fallback strings for labels and descriptions, ensuring that only translated strings are shown in the settings UI.

Versioning:

* Bumped the plugin version in `manifest.json` from `1.1.1` to `1.2.1` to reflect these changes.