### PR TITLE
i18n(port-monitor): update French translations

### DIFF
--- a/port-monitor/i18n/fr.json
+++ b/port-monitor/i18n/fr.json
@@ -1,0 +1,33 @@
+{
+  "widget": {
+    "tooltip": "Moniteur de ports"
+  },
+  "bar": {
+    "noPorts": "Aucun port en écoute",
+    "ports": "{count} port en écoute",
+    "ports-plural": "{count} ports en écoute"
+  },
+  "panel": {
+    "noPorts": "Aucun port en écoute",
+    "refresh": "Rafraîchir",
+    "portNumber": ":{port}",
+    "processInfo": "{name} (PID {pid})",
+    "unknownProcess": "\u2014",
+    "confirmKill": "Tuer le processus sur le port {port} ?",
+    "confirmKillSystem": "Tuer le processus système sur le port {port} ? Cela ouvrira un terminal avec sudo.",
+    "confirm": "Confirmer",
+    "cancel": "Annuler"
+  },
+  "settings": {
+    "refreshInterval": "Intervalle de rafraîchissement",
+    "refreshIntervalDesc": "Secondes entre les scans de ports : {value}",
+    "hideSystemPorts": "Masquer les ports système",
+    "hideSystemPortsDesc": "Exclure les ports inférieurs à 1024",
+    "hideWhenEmpty": "Masquer quand vide",
+    "hideWhenEmptyDesc": "Masquer le widget de barre quand aucun port n'est en écoute"
+  },
+  "context": {
+    "refresh": "Rafraîchir",
+    "settings": "Paramètres"
+  }
+}

--- a/port-monitor/manifest.json
+++ b/port-monitor/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "port-monitor",
   "name": "Port Monitor",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "minNoctaliaVersion": "3.6.0",
   "author": "adriamartin91",
   "license": "MIT",


### PR DESCRIPTION
This pull request introduces French localization support for the Port Monitor widget and updates the extension version. The most significant changes are the addition of a French translation file and a version bump in the manifest.

Localization:

* Added a new `fr.json` file with French translations for port monitoring, process information, and settings.

Version update:

* Bumped the extension version from `1.0.0` to `1.0.1` in manifest.json.