### PR TITLE
chore: ignore CLAUDE.local.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 # OS
 .DS_Store
 Thumbs.db
+
+# AI / agents
+CLAUDE.local.md


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.local.md` to `.gitignore` so local Claude Code project instructions are not accidentally committed.