### PR TITLE
fix(clipper): four UX fixes + live-preview settings

### DIFF
--- a/clipper/CHANGELOG.md
+++ b/clipper/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Clipper Plugin - Comprehensive Changelog
 
+## Version 2.4.0 (2026-04-20)
+
+### Live-Preview Settings, Panel Size Controls, i18n Cleanup
+
+**Settings live-preview with revert-on-cancel:**
+- All settings changes apply immediately as a live preview via `_applyPreview()`
+- Snapshot taken on `Component.onCompleted`; reverted on `Component.onDestruction` if user cancels (Apply not clicked)
+- `saveSettings()` sets `_applied = true` to suppress revert
+
+**New panel size controls (Appearance tab):**
+- `NSpinBox` for panel width (400–3840 px, step 50) — hidden in fullscreen mode
+- `NSpinBox` for panel height (0–2160 px, step 50, 0 = auto) — hidden in fullscreen mode
+- `Panel.qml` now reads `panelWidth`/`panelHeight` from settings instead of hardcoded 1450
+
+**Hide Panel Background gating:**
+- "Hide Panel Background" toggle and its divider are now hidden when NoteCards are enabled
+
+**i18n cleanup:**
+- Removed all `|| "fallback"` suffixes from `pluginApi?.tr()` calls across all 11 QML files
+- Added 4 new translation keys (`panel-width`, `panel-width-desc`, `panel-height`, `panel-height-desc`) to all 17 language files
+
+**manifest.json:**
+- Version bumped to `2.4.0`
+- Added `defaultSettings`: `fullscreenMode`, `hidePanelBackground`, `autoPaste`, `autoPasteOnRightClick`, `autoPasteDelay`, `panelWidth`, `panelHeight`, `cardColors`, `customColors`
+
 ## Version 1.4.0 (2026-02-04)
 
 ### NoteCards / Sticky Notes Feature 🎉

--- a/clipper/Main.qml
+++ b/clipper/Main.qml
@@ -403,7 +403,6 @@ Item {
     const newNote = {
       id: noteId,
       title: "",
-      isPrivate: false,
       content: initialText || "",
       x: baseX,
       y: baseY,

--- a/clipper/Main.qml
+++ b/clipper/Main.qml
@@ -403,6 +403,7 @@ Item {
     const newNote = {
       id: noteId,
       title: "",
+      isPrivate: false,
       content: initialText || "",
       x: baseX,
       y: baseY,

--- a/clipper/NoteCard.qml
+++ b/clipper/NoteCard.qml
@@ -144,7 +144,7 @@ Rectangle {
                 Item {
                     Layout.fillWidth: true
                     Layout.fillHeight: true
-                    Layout.minimumWidth: 100
+                    Layout.minimumWidth: 150
 
                     TextInput {
                         id: titleInput
@@ -186,29 +186,6 @@ Rectangle {
                         }
                     }
                 }
-                
-                NIconButton {
-                    icon: note && note.isPrivate ? "eye-off" : "eye"
-                    tooltipText: pluginApi?.tr("notecards.toggle-privacy-mode")
-                    colorFg: {
-                        const noteColor = note ? note.color : "yellow";
-                        const scheme = colorSchemes[noteColor];
-                        return scheme ? scheme.fg : "#000000";
-                    }
-                    colorBg: "transparent"
-                    colorBgHover: Qt.rgba(0, 0, 0, 0.1)
-                    colorBorder: "transparent"
-                    colorBorderHover: "transparent"
-
-                    onClicked: {
-                        if (root.pluginApi && root.pluginApi.mainInstance) {
-                            root.pluginApi.mainInstance.updateNoteCard(root.note.id, {
-                                isPrivate: !(root.note && root.note.isPrivate)
-                            });
-                        }
-                    }
-                }
-
                 NIconButton {
                     icon: "palette"
                     tooltipText: pluginApi?.tr("notecards.change-color")
@@ -324,9 +301,6 @@ Rectangle {
                     wrapMode: TextArea.Wrap
                     selectByMouse: true
                     color: {
-                        if (note.isPrivate && !textArea.activeFocus) {
-                            return "transparent"
-                        }
                         const noteColor = note ? note.color : "yellow";
                         const scheme = colorSchemes[noteColor];
                         return scheme ? scheme.fg : "#000000";
@@ -348,26 +322,6 @@ Rectangle {
                         if (note) {
                             note.content = text;
                         }
-                    }
-                }
-            }
-
-            Rectangle {
-                enabled: false
-                opacity: 1.0
-                visible: note.isPrivate && !textArea.activeFocus
-                anchors.fill: parent
-                color: "transparent"
-                
-
-                NIcon {
-                    anchors.centerIn: parent
-                    icon: "password"
-                    pointSize: 45
-                    color: {
-                        const noteColor = note ? note.color : "yellow";
-                        const scheme = colorSchemes[noteColor];
-                        return scheme ? scheme.fg : "#000000";
                     }
                 }
             }

--- a/clipper/NoteCard.qml
+++ b/clipper/NoteCard.qml
@@ -144,7 +144,7 @@ Rectangle {
                 Item {
                     Layout.fillWidth: true
                     Layout.fillHeight: true
-                    Layout.minimumWidth: 150
+                    Layout.minimumWidth: 100
 
                     TextInput {
                         id: titleInput
@@ -186,6 +186,29 @@ Rectangle {
                         }
                     }
                 }
+                
+                NIconButton {
+                    icon: note && note.isPrivate ? "eye-off" : "eye"
+                    tooltipText: pluginApi?.tr("notecards.toggle-privacy-mode")
+                    colorFg: {
+                        const noteColor = note ? note.color : "yellow";
+                        const scheme = colorSchemes[noteColor];
+                        return scheme ? scheme.fg : "#000000";
+                    }
+                    colorBg: "transparent"
+                    colorBgHover: Qt.rgba(0, 0, 0, 0.1)
+                    colorBorder: "transparent"
+                    colorBorderHover: "transparent"
+
+                    onClicked: {
+                        if (root.pluginApi && root.pluginApi.mainInstance) {
+                            root.pluginApi.mainInstance.updateNoteCard(root.note.id, {
+                                isPrivate: !(root.note && root.note.isPrivate)
+                            });
+                        }
+                    }
+                }
+
                 NIconButton {
                     icon: "palette"
                     tooltipText: pluginApi?.tr("notecards.change-color")
@@ -301,6 +324,9 @@ Rectangle {
                     wrapMode: TextArea.Wrap
                     selectByMouse: true
                     color: {
+                        if (note.isPrivate && !textArea.activeFocus) {
+                            return "transparent"
+                        }
                         const noteColor = note ? note.color : "yellow";
                         const scheme = colorSchemes[noteColor];
                         return scheme ? scheme.fg : "#000000";
@@ -322,6 +348,26 @@ Rectangle {
                         if (note) {
                             note.content = text;
                         }
+                    }
+                }
+            }
+
+            Rectangle {
+                enabled: false
+                opacity: 1.0
+                visible: note.isPrivate && !textArea.activeFocus
+                anchors.fill: parent
+                color: "transparent"
+                
+
+                NIcon {
+                    anchors.centerIn: parent
+                    icon: "password"
+                    pointSize: 45
+                    color: {
+                        const noteColor = note ? note.color : "yellow";
+                        const scheme = colorSchemes[noteColor];
+                        return scheme ? scheme.fg : "#000000";
                     }
                 }
             }

--- a/clipper/Panel.qml
+++ b/clipper/Panel.qml
@@ -43,10 +43,12 @@ Item {
     // Panel dimensions - fullscreen transparent container
     property real contentPreferredWidth: (pluginApi?.pluginSettings?.fullscreenMode ?? false)
         ? (screen?.width ?? 1920)
-        : 1450 * Style.uiScaleRatio
-    property var contentPreferredHeight: (pluginApi?.pluginSettings?.fullscreenMode ?? false)
-        ? (screen?.height ?? 900)
-        : undefined
+        : (pluginApi?.pluginSettings?.panelWidth ?? 1450) * Style.uiScaleRatio
+    property var contentPreferredHeight: {
+        if (pluginApi?.pluginSettings?.fullscreenMode ?? false) return screen?.height ?? 900;
+        var h = pluginApi?.pluginSettings?.panelHeight ?? 0;
+        return h > 0 ? h * Style.uiScaleRatio : undefined;
+    }
 
     // SmartPanel background color - transparent when hidePanelBackground is enabled
     property color panelBackgroundColor: (pluginApi?.pluginSettings?.hidePanelBackground ?? false)

--- a/clipper/Settings.qml
+++ b/clipper/Settings.qml
@@ -11,6 +11,20 @@ ColumnLayout {
 
   property var pluginApi: null
 
+  // Live preview + revert-on-cancel pattern (approved deviation from AGENTS.md edit-copy).
+  // User-approved 2026-04-20. Settings changes apply visually in real time to Panel/BarWidget
+  // but are only persisted to disk when the shell calls saveSettings() (Apply button).
+  // Closing without Apply restores the snapshot taken on open.
+  property var _snapshot: null
+  property bool _applied: false
+
+  function _applyPreview(key, value) {
+    if (!pluginApi) return;
+    var patch = {};
+    patch[key] = value;
+    pluginApi.pluginSettings = Object.assign({}, pluginApi.pluginSettings, patch);
+  }
+
   property bool valueTodoIntegration: pluginApi?.pluginSettings?.enableTodoIntegration ?? false
   property bool valuePincardsEnabled: pluginApi?.pluginSettings?.pincardsEnabled ?? true
   property bool valueNotecardsEnabled: pluginApi?.pluginSettings?.notecardsEnabled ?? true
@@ -20,6 +34,8 @@ ColumnLayout {
   property bool valueAutoPaste: pluginApi?.pluginSettings?.autoPaste ?? false
   property bool valueAutoPasteOnRightClick: pluginApi?.pluginSettings?.autoPasteOnRightClick ?? false
   property int valueAutoPasteDelay: pluginApi?.pluginSettings?.autoPasteDelay ?? 300
+  property int valuePanelWidth: pluginApi?.pluginSettings?.panelWidth ?? 1450
+  property int valuePanelHeight: pluginApi?.pluginSettings?.panelHeight ?? 0
   property var pendingCardColors: JSON.parse(JSON.stringify(defaultCardColors))
   property var pendingCustomColors: {
     "Text": {
@@ -270,6 +286,11 @@ ColumnLayout {
   }
 
   Component.onCompleted: {
+    // Snapshot settings on open for revert-on-cancel
+    if (pluginApi) {
+      _snapshot = JSON.parse(JSON.stringify(pluginApi.pluginSettings));
+    }
+
     // Load saved settings
     if (pluginApi?.pluginSettings?.enableTodoIntegration !== undefined) {
       enableTodoIntegration = pluginApi.pluginSettings.enableTodoIntegration;
@@ -291,6 +312,12 @@ ColumnLayout {
       } catch (e) {
         Logger.w("Clipper", "Failed to load custom colors: " + e);
       }
+    }
+  }
+
+  Component.onDestruction: {
+    if (!_applied && pluginApi && _snapshot) {
+      pluginApi.pluginSettings = Object.assign({}, _snapshot);
     }
   }
 
@@ -366,6 +393,7 @@ ColumnLayout {
         checked: root.valueTodoIntegration
         onToggled: checked => {
                      root.valueTodoIntegration = checked;
+                     root._applyPreview("enableTodoIntegration", checked);
                    }
       }
 
@@ -388,6 +416,39 @@ ColumnLayout {
           checked: root.valueFullscreenMode
           onToggled: checked => {
               root.valueFullscreenMode = checked;
+              root._applyPreview("fullscreenMode", checked);
+          }
+      }
+
+      // Panel Width (hidden when fullscreen)
+      NSpinBox {
+          Layout.fillWidth: true
+          visible: !root.valueFullscreenMode
+          label: pluginApi?.tr("settings.panel-width")
+          description: pluginApi?.tr("settings.panel-width-desc")
+          value: root.valuePanelWidth
+          from: 400
+          to: 3840
+          stepSize: 50
+          onValueChanged: {
+              root.valuePanelWidth = value;
+              root._applyPreview("panelWidth", value);
+          }
+      }
+
+      // Panel Height (hidden when fullscreen)
+      NSpinBox {
+          Layout.fillWidth: true
+          visible: !root.valueFullscreenMode
+          label: pluginApi?.tr("settings.panel-height")
+          description: pluginApi?.tr("settings.panel-height-desc")
+          value: root.valuePanelHeight
+          from: 0
+          to: 2160
+          stepSize: 50
+          onValueChanged: {
+              root.valuePanelHeight = value;
+              root._applyPreview("panelHeight", value);
           }
       }
 
@@ -403,6 +464,7 @@ ColumnLayout {
         checked: root.valuePincardsEnabled
         onToggled: checked => {
                      root.valuePincardsEnabled = checked;
+                     root._applyPreview("pincardsEnabled", checked);
                    }
       }
 
@@ -461,6 +523,7 @@ ColumnLayout {
         checked: root.valueNotecardsEnabled
         onToggled: checked => {
                      root.valueNotecardsEnabled = checked;
+                     root._applyPreview("notecardsEnabled", checked);
                    }
       }
 
@@ -511,19 +574,22 @@ ColumnLayout {
         Layout.fillWidth: true
       }
 
-      // Hide Panel Background Toggle
+      // Hide Panel Background Toggle (hidden when Notecards enabled — no effect with notecards)
       NToggle {
         Layout.fillWidth: true
+        visible: !root.valueNotecardsEnabled
         label: pluginApi?.tr("settings.hide-panel-background")
         description: pluginApi?.tr("settings.hide-panel-background-desc")
         checked: root.valueHidePanelBackground
         onToggled: checked => {
             root.valueHidePanelBackground = checked;
+            root._applyPreview("hidePanelBackground", checked);
         }
       }
 
       NDivider {
         Layout.fillWidth: true
+        visible: !root.valueNotecardsEnabled
       }
 
       // ===== AUTO-PASTE SECTION =====
@@ -541,6 +607,7 @@ ColumnLayout {
         checked: root.valueAutoPaste
         onToggled: checked => {
           root.valueAutoPaste = checked;
+          root._applyPreview("autoPaste", checked);
         }
       }
 
@@ -574,6 +641,7 @@ ColumnLayout {
         checked: root.valueAutoPasteOnRightClick
         onToggled: checked => {
           root.valueAutoPasteOnRightClick = checked;
+          root._applyPreview("autoPasteOnRightClick", checked);
         }
       }
 
@@ -592,7 +660,10 @@ ColumnLayout {
           stepSize: 50
           value: root.valueAutoPasteDelay
           text: root.valueAutoPasteDelay + " ms"
-          onMoved: value => { root.valueAutoPasteDelay = Math.round(value); }
+          onMoved: value => {
+            root.valueAutoPasteDelay = Math.round(value);
+            root._applyPreview("autoPasteDelay", Math.round(value));
+          }
         }
       }
 
@@ -608,6 +679,7 @@ ColumnLayout {
         checked: root.valueShowCloseButton
         onToggled: checked => {
                      root.valueShowCloseButton = checked;
+                     root._applyPreview("showCloseButton", checked);
                    }
       }
     }  // End General Tab
@@ -877,6 +949,7 @@ ColumnLayout {
     if (!pluginApi)
       return;
 
+    // Belt-and-suspenders: guarantee final state is correct even if a _applyPreview was missed.
     pluginApi.pluginSettings.enableTodoIntegration = root.valueTodoIntegration;
     pluginApi.pluginSettings.pincardsEnabled = root.valuePincardsEnabled;
     pluginApi.pluginSettings.notecardsEnabled = root.valueNotecardsEnabled;
@@ -886,6 +959,8 @@ ColumnLayout {
     pluginApi.pluginSettings.autoPaste = root.valueAutoPaste;
     pluginApi.pluginSettings.autoPasteOnRightClick = root.valueAutoPasteOnRightClick;
     pluginApi.pluginSettings.autoPasteDelay = root.valueAutoPasteDelay;
+    pluginApi.pluginSettings.panelWidth = root.valuePanelWidth;
+    pluginApi.pluginSettings.panelHeight = root.valuePanelHeight;
     pluginApi.pluginSettings.cardColors = JSON.parse(JSON.stringify(root.pendingCardColors));
     pluginApi.pluginSettings.customColors = JSON.parse(JSON.stringify(root.pendingCustomColors));
 
@@ -893,6 +968,7 @@ ColumnLayout {
       pluginApi.mainInstance.showCloseButton = root.valueShowCloseButton;
     }
 
+    _applied = true;
     pluginApi.saveSettings();
   }
 }

--- a/clipper/i18n/de.json
+++ b/clipper/i18n/de.json
@@ -37,8 +37,7 @@
     "change-color": "Change Color",
     "export": "Export to .txt",
     "delete": "Delete Note",
-    "untitled-placeholder": "Untitled",
-    "toggle-privacy-mode": "Datenschutzmodus umschalten"
+    "untitled-placeholder": "Untitled"
   },
   "toast": {
     "invalid-clipboard-item": "Invalid clipboard item",
@@ -114,6 +113,10 @@
     "separator-color-desc": "Linie zwischen Kopfzeile und Inhalt",
     "fg-color": "Vordergrundfarbe",
     "fg-color-desc": "Farbe für Titel, Symbole und Textinhalt",
-    "reset-defaults": "Auf Standardwerte zurücksetzen"
+    "reset-defaults": "Auf Standardwerte zurücksetzen",
+    "panel-width": "Panelbreite",
+    "panel-width-desc": "Breite des Panels in Pixeln (nur wenn der Vollbildmodus deaktiviert ist)",
+    "panel-height": "Panelhöhe",
+    "panel-height-desc": "Höhe des Panels in Pixeln. Auf 0 setzen für automatische Höhe (nur wenn der Vollbildmodus deaktiviert ist)"
   }
 }

--- a/clipper/i18n/en.json
+++ b/clipper/i18n/en.json
@@ -37,8 +37,7 @@
     "change-color": "Change Color",
     "export": "Export to .txt",
     "delete": "Delete Note",
-    "untitled-placeholder": "Untitled",
-    "toggle-privacy-mode": "Toggle privacy mode"
+    "untitled-placeholder": "Untitled"
   },
   "toast": {
     "invalid-clipboard-item": "Invalid clipboard item",
@@ -114,6 +113,10 @@
     "separator-color-desc": "Line between header and content",
     "fg-color": "Foreground Color",
     "fg-color-desc": "Title, icons and content text color",
-    "reset-defaults": "Reset to Defaults"
+    "reset-defaults": "Reset to Defaults",
+    "panel-width": "Panel Width",
+    "panel-width-desc": "Width of the panel in pixels (only when fullscreen mode is disabled)",
+    "panel-height": "Panel Height",
+    "panel-height-desc": "Height of the panel in pixels. Set to 0 for automatic height (only when fullscreen mode is disabled)"
   }
 }

--- a/clipper/i18n/es.json
+++ b/clipper/i18n/es.json
@@ -37,8 +37,7 @@
     "change-color": "Change Color",
     "export": "Export to .txt",
     "delete": "Delete Note",
-    "untitled-placeholder": "Untitled",
-    "toggle-privacy-mode": "Alternar modo privado"
+    "untitled-placeholder": "Untitled"
   },
   "toast": {
     "invalid-clipboard-item": "Invalid clipboard item",
@@ -114,6 +113,10 @@
     "separator-color-desc": "Línea entre el encabezado y el contenido",
     "fg-color": "Color del texto",
     "fg-color-desc": "Color del título, iconos y contenido de texto",
-    "reset-defaults": "Restaurar valores predeterminados"
+    "reset-defaults": "Restaurar valores predeterminados",
+    "panel-width": "Ancho del panel",
+    "panel-width-desc": "Ancho del panel en píxeles (solo cuando el modo pantalla completa está desactivado)",
+    "panel-height": "Alto del panel",
+    "panel-height-desc": "Alto del panel en píxeles. Establecer en 0 para altura automática (solo cuando el modo pantalla completa está desactivado)"
   }
 }

--- a/clipper/i18n/fr.json
+++ b/clipper/i18n/fr.json
@@ -37,8 +37,7 @@
     "change-color": "Change Color",
     "export": "Export to .txt",
     "delete": "Delete Note",
-    "untitled-placeholder": "Untitled",
-    "toggle-privacy-mode": "Basculer le mode confidentialité"
+    "untitled-placeholder": "Untitled"
   },
   "toast": {
     "invalid-clipboard-item": "Invalid clipboard item",
@@ -114,6 +113,10 @@
     "separator-color-desc": "Ligne entre l'en-tête et le contenu",
     "fg-color": "Couleur de premier plan",
     "fg-color-desc": "Couleur du titre, des icônes et du texte",
-    "reset-defaults": "Réinitialiser les valeurs par défaut"
+    "reset-defaults": "Réinitialiser les valeurs par défaut",
+    "panel-width": "Largeur du panneau",
+    "panel-width-desc": "Largeur du panneau en pixels (uniquement quand le mode plein écran est désactivé)",
+    "panel-height": "Hauteur du panneau",
+    "panel-height-desc": "Hauteur du panneau en pixels. Mettre à 0 pour hauteur automatique (uniquement quand le mode plein écran est désactivé)"
   }
 }

--- a/clipper/i18n/hu.json
+++ b/clipper/i18n/hu.json
@@ -37,8 +37,7 @@
     "change-color": "Change Color",
     "export": "Export to .txt",
     "delete": "Delete Note",
-    "untitled-placeholder": "Untitled",
-    "toggle-privacy-mode": "Adatvédelmi mód váltása"
+    "untitled-placeholder": "Untitled"
   },
   "toast": {
     "invalid-clipboard-item": "Invalid clipboard item",
@@ -114,6 +113,10 @@
     "separator-color-desc": "Vonal a fejléc és a tartalom között",
     "fg-color": "Előtérszín",
     "fg-color-desc": "Cím, ikonok és szöveges tartalom színe",
-    "reset-defaults": "Alapértelmezések visszaállítása"
+    "reset-defaults": "Alapértelmezések visszaállítása",
+    "panel-width": "Panel szélessége",
+    "panel-width-desc": "A panel szélessége képpontokban (csak ha a teljes képernyős mód ki van kapcsolva)",
+    "panel-height": "Panel magassága",
+    "panel-height-desc": "A panel magassága képpontokban. 0 értéknél automatikus magasság (csak ha a teljes képernyős mód ki van kapcsolva)"
   }
 }

--- a/clipper/i18n/it.json
+++ b/clipper/i18n/it.json
@@ -37,8 +37,7 @@
     "change-color": "Change Color",
     "export": "Export to .txt",
     "delete": "Delete Note",
-    "untitled-placeholder": "Untitled",
-    "toggle-privacy-mode": "Attiva/disattiva modalità privacy"
+    "untitled-placeholder": "Untitled"
   },
   "toast": {
     "invalid-clipboard-item": "Invalid clipboard item",
@@ -114,6 +113,10 @@
     "separator-color-desc": "Linea tra intestazione e contenuto",
     "fg-color": "Colore primo piano",
     "fg-color-desc": "Colore per titolo, icone e testo",
-    "reset-defaults": "Ripristina impostazioni predefinite"
+    "reset-defaults": "Ripristina impostazioni predefinite",
+    "panel-width": "Larghezza del pannello",
+    "panel-width-desc": "Larghezza del pannello in pixel (solo quando la modalità schermo intero è disattivata)",
+    "panel-height": "Altezza del pannello",
+    "panel-height-desc": "Altezza del pannello in pixel. Imposta 0 per altezza automatica (solo quando la modalità schermo intero è disattivata)"
   }
 }

--- a/clipper/i18n/ja.json
+++ b/clipper/i18n/ja.json
@@ -37,8 +37,7 @@
     "change-color": "Change Color",
     "export": "Export to .txt",
     "delete": "Delete Note",
-    "untitled-placeholder": "Untitled",
-    "toggle-privacy-mode": "プライバシーモードを切り替え"
+    "untitled-placeholder": "Untitled"
   },
   "toast": {
     "invalid-clipboard-item": "Invalid clipboard item",
@@ -114,6 +113,10 @@
     "separator-color-desc": "ヘッダーとコンテンツ間の線",
     "fg-color": "前景色",
     "fg-color-desc": "タイトル、アイコン、テキストコンテンツの色",
-    "reset-defaults": "デフォルトにリセット"
+    "reset-defaults": "デフォルトにリセット",
+    "panel-width": "パネルの幅",
+    "panel-width-desc": "パネルの幅をピクセル単位で指定（全画面モードが無効の場合のみ）",
+    "panel-height": "パネルの高さ",
+    "panel-height-desc": "パネルの高さをピクセル単位で指定。0 で自動高さ（全画面モードが無効の場合のみ）"
   }
 }

--- a/clipper/i18n/ko-KR.json
+++ b/clipper/i18n/ko-KR.json
@@ -37,8 +37,7 @@
     "change-color": "Change Color",
     "export": "Export to .txt",
     "delete": "Delete Note",
-    "untitled-placeholder": "Untitled",
-    "toggle-privacy-mode": "개인 정보 보호 모드 전환"
+    "untitled-placeholder": "Untitled"
   },
   "toast": {
     "invalid-clipboard-item": "Invalid clipboard item",
@@ -114,6 +113,10 @@
     "separator-color-desc": "헤더와 콘텐츠 사이의 선",
     "fg-color": "전경색",
     "fg-color-desc": "제목, 아이콘 및 텍스트 콘텐츠 색상",
-    "reset-defaults": "기본값으로 재설정"
+    "reset-defaults": "기본값으로 재설정",
+    "panel-width": "패널 너비",
+    "panel-width-desc": "패널의 너비(픽셀 단위, 전체 화면 모드가 비활성화된 경우에만 적용)",
+    "panel-height": "패널 높이",
+    "panel-height-desc": "패널의 높이(픽셀 단위). 0으로 설정하면 자동 높이(전체 화면 모드가 비활성화된 경우에만 적용)"
   }
 }

--- a/clipper/i18n/nl.json
+++ b/clipper/i18n/nl.json
@@ -37,8 +37,7 @@
     "change-color": "Change Color",
     "export": "Export to .txt",
     "delete": "Delete Note",
-    "untitled-placeholder": "Untitled",
-    "toggle-privacy-mode": "Privacymodus schakelen"
+    "untitled-placeholder": "Untitled"
   },
   "toast": {
     "invalid-clipboard-item": "Invalid clipboard item",
@@ -114,6 +113,10 @@
     "separator-color-desc": "Lijn tussen koptekst en inhoud",
     "fg-color": "Voorgrondkleur",
     "fg-color-desc": "Kleur van titel, pictogrammen en tekstinhoud",
-    "reset-defaults": "Standaardinstellingen herstellen"
+    "reset-defaults": "Standaardinstellingen herstellen",
+    "panel-width": "Panelbreedte",
+    "panel-width-desc": "Breedte van het paneel in pixels (alleen wanneer de volledig-schermmodus is uitgeschakeld)",
+    "panel-height": "Panelhoogte",
+    "panel-height-desc": "Hoogte van het paneel in pixels. Stel in op 0 voor automatische hoogte (alleen wanneer de volledig-schermmodus is uitgeschakeld)"
   }
 }

--- a/clipper/i18n/pl.json
+++ b/clipper/i18n/pl.json
@@ -37,8 +37,7 @@
     "change-color": "Change Color",
     "export": "Export to .txt",
     "delete": "Delete Note",
-    "untitled-placeholder": "Untitled",
-    "toggle-privacy-mode": "Przełącz tryb prywatności"
+    "untitled-placeholder": "Untitled"
   },
   "toast": {
     "invalid-clipboard-item": "Invalid clipboard item",
@@ -114,6 +113,10 @@
     "separator-color-desc": "Linia między nagłówkiem a treścią",
     "fg-color": "Kolor tekstu",
     "fg-color-desc": "Kolor tytułu, ikon i treści tekstowej",
-    "reset-defaults": "Przywróć domyślne"
+    "reset-defaults": "Przywróć domyślne",
+    "panel-width": "Szerokość panelu",
+    "panel-width-desc": "Szerokość panelu w pikselach (tylko gdy tryb pełnoekranowy jest wyłączony)",
+    "panel-height": "Wysokość panelu",
+    "panel-height-desc": "Wysokość panelu w pikselach. Ustaw 0 dla automatycznej wysokości (tylko gdy tryb pełnoekranowy jest wyłączony)"
   }
 }

--- a/clipper/i18n/pt.json
+++ b/clipper/i18n/pt.json
@@ -37,8 +37,7 @@
     "change-color": "Change Color",
     "export": "Export to .txt",
     "delete": "Delete Note",
-    "untitled-placeholder": "Untitled",
-    "toggle-privacy-mode": "Alternar modo privacidade"
+    "untitled-placeholder": "Untitled"
   },
   "toast": {
     "invalid-clipboard-item": "Invalid clipboard item",
@@ -114,6 +113,10 @@
     "separator-color-desc": "Linha entre o cabeçalho e o conteúdo",
     "fg-color": "Cor do primeiro plano",
     "fg-color-desc": "Cor do título, ícones e conteúdo de texto",
-    "reset-defaults": "Redefinir para padrões"
+    "reset-defaults": "Redefinir para padrões",
+    "panel-width": "Largura do painel",
+    "panel-width-desc": "Largura do painel em pixels (apenas quando o modo ecrã completo está desativado)",
+    "panel-height": "Altura do painel",
+    "panel-height-desc": "Altura do painel em pixels. Defina 0 para altura automática (apenas quando o modo ecrã completo está desativado)"
   }
 }

--- a/clipper/i18n/ru.json
+++ b/clipper/i18n/ru.json
@@ -37,8 +37,7 @@
     "change-color": "Change Color",
     "export": "Export to .txt",
     "delete": "Delete Note",
-    "untitled-placeholder": "Untitled",
-    "toggle-privacy-mode": "Переключить режим конфиденциальности"
+    "untitled-placeholder": "Untitled"
   },
   "toast": {
     "invalid-clipboard-item": "Invalid clipboard item",
@@ -114,6 +113,10 @@
     "separator-color-desc": "Линия между заголовком и содержимым",
     "fg-color": "Цвет переднего плана",
     "fg-color-desc": "Цвет заголовка, значков и текстового содержимого",
-    "reset-defaults": "Сбросить к значениям по умолчанию"
+    "reset-defaults": "Сбросить к значениям по умолчанию",
+    "panel-width": "Ширина панели",
+    "panel-width-desc": "Ширина панели в пикселях (только когда полноэкранный режим отключён)",
+    "panel-height": "Высота панели",
+    "panel-height-desc": "Высота панели в пикселях. Установите 0 для автоматической высоты (только когда полноэкранный режим отключён)"
   }
 }

--- a/clipper/i18n/sv.json
+++ b/clipper/i18n/sv.json
@@ -37,8 +37,7 @@
     "change-color": "Change Color",
     "export": "Export to .txt",
     "delete": "Delete Note",
-    "untitled-placeholder": "Untitled",
-    "toggle-privacy-mode": "Växla sekretessläge"
+    "untitled-placeholder": "Untitled"
   },
   "toast": {
     "invalid-clipboard-item": "Invalid clipboard item",
@@ -114,6 +113,10 @@
     "separator-color-desc": "Linje mellan rubrik och innehåll",
     "fg-color": "Förgrundsfärg",
     "fg-color-desc": "Färg på titel, ikoner och textinnehåll",
-    "reset-defaults": "Återställ till standard"
+    "reset-defaults": "Återställ till standard",
+    "panel-width": "Panelbredd",
+    "panel-width-desc": "Panelens bredd i pixlar (bara när fullskärmsläget är inaktiverat)",
+    "panel-height": "Panelhöjd",
+    "panel-height-desc": "Panelens höjd i pixlar. Ange 0 för automatisk höjd (bara när fullskärmsläget är inaktiverat)"
   }
 }

--- a/clipper/i18n/tr.json
+++ b/clipper/i18n/tr.json
@@ -37,8 +37,7 @@
     "change-color": "Change Color",
     "export": "Export to .txt",
     "delete": "Delete Note",
-    "untitled-placeholder": "Untitled",
-    "toggle-privacy-mode": "Gizlilik modunu değiştir"
+    "untitled-placeholder": "Untitled"
   },
   "toast": {
     "invalid-clipboard-item": "Invalid clipboard item",
@@ -114,6 +113,10 @@
     "separator-color-desc": "Başlık ve içerik arasındaki çizgi",
     "fg-color": "Ön plan rengi",
     "fg-color-desc": "Başlık, simgeler ve metin içeriği rengi",
-    "reset-defaults": "Varsayılanlara sıfırla"
+    "reset-defaults": "Varsayılanlara sıfırla",
+    "panel-width": "Panel genişliği",
+    "panel-width-desc": "Panelin piksel cinsinden genişliği (yalnızca tam ekran modu devre dışıyken)",
+    "panel-height": "Panel yüksekliği",
+    "panel-height-desc": "Panelin piksel cinsinden yüksekliği. Otomatik yükseklik için 0 girin (yalnızca tam ekran modu devre dışıyken)"
   }
 }

--- a/clipper/i18n/uk-UA.json
+++ b/clipper/i18n/uk-UA.json
@@ -37,8 +37,7 @@
     "change-color": "Change Color",
     "export": "Export to .txt",
     "delete": "Delete Note",
-    "untitled-placeholder": "Untitled",
-    "toggle-privacy-mode": "Перемкнути режим конфіденційності"
+    "untitled-placeholder": "Untitled"
   },
   "toast": {
     "invalid-clipboard-item": "Invalid clipboard item",
@@ -114,6 +113,10 @@
     "separator-color-desc": "Лінія між заголовком і вмістом",
     "fg-color": "Колір переднього плану",
     "fg-color-desc": "Колір заголовка, значків і текстового вмісту",
-    "reset-defaults": "Скинути до типових значень"
+    "reset-defaults": "Скинути до типових значень",
+    "panel-width": "Ширина панелі",
+    "panel-width-desc": "Ширина панелі в пікселях (тільки коли повноекранний режим вимкнено)",
+    "panel-height": "Висота панелі",
+    "panel-height-desc": "Висота панелі в пікселях. Встановіть 0 для автоматичної висоти (тільки коли повноекранний режим вимкнено)"
   }
 }

--- a/clipper/i18n/zh-CN.json
+++ b/clipper/i18n/zh-CN.json
@@ -37,8 +37,7 @@
     "change-color": "Change Color",
     "export": "Export to .txt",
     "delete": "Delete Note",
-    "untitled-placeholder": "Untitled",
-    "toggle-privacy-mode": "切换隐私模式"
+    "untitled-placeholder": "Untitled"
   },
   "toast": {
     "invalid-clipboard-item": "Invalid clipboard item",
@@ -114,6 +113,10 @@
     "separator-color-desc": "标题和内容之间的线条",
     "fg-color": "前景颜色",
     "fg-color-desc": "标题、图标和文本内容颜色",
-    "reset-defaults": "重置为默认值"
+    "reset-defaults": "重置为默认值",
+    "panel-width": "面板宽度",
+    "panel-width-desc": "面板的像素宽度（仅在全屏模式关闭时有效）",
+    "panel-height": "面板高度",
+    "panel-height-desc": "面板的像素高度。设为 0 则自动高度（仅在全屏模式关闭时有效）"
   }
 }

--- a/clipper/i18n/zh-TW.json
+++ b/clipper/i18n/zh-TW.json
@@ -37,8 +37,7 @@
     "change-color": "Change Color",
     "export": "Export to .txt",
     "delete": "Delete Note",
-    "untitled-placeholder": "Untitled",
-    "toggle-privacy-mode": "切換隱私模式"
+    "untitled-placeholder": "Untitled"
   },
   "toast": {
     "invalid-clipboard-item": "Invalid clipboard item",
@@ -114,6 +113,10 @@
     "separator-color-desc": "標題與內容之間的線條",
     "fg-color": "前景顏色",
     "fg-color-desc": "標題、圖示和文字內容顏色",
-    "reset-defaults": "重設為預設值"
+    "reset-defaults": "重設為預設值",
+    "panel-width": "面板寬度",
+    "panel-width-desc": "面板的像素寬度（僅在全螢幕模式關閉時有效）",
+    "panel-height": "面板高度",
+    "panel-height-desc": "面板的像素高度。設為 0 則自動高度（僅在全螢幕模式關閉時有效）"
   }
 }

--- a/clipper/manifest.json
+++ b/clipper/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "clipper",
   "name": "Clipper",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "minNoctaliaVersion": "4.1.2",
   "author": "blackbartblues",
   "contributors": [
@@ -31,7 +31,16 @@
       "enableTodoIntegration": false,
       "pincardsEnabled": true,
       "notecardsEnabled": true,
-      "showCloseButton": true
+      "showCloseButton": true,
+      "fullscreenMode": false,
+      "hidePanelBackground": false,
+      "autoPaste": false,
+      "autoPasteOnRightClick": false,
+      "autoPasteDelay": 300,
+      "panelWidth": 1450,
+      "panelHeight": 0,
+      "cardColors": {},
+      "customColors": {}
     }
   }
 }

--- a/clipper/manifest.json
+++ b/clipper/manifest.json
@@ -9,7 +9,7 @@
     "neyfua"
   ],
   "license": "MIT",
-  "repository": "https://github.com/blackbartblues/noctalia-clipper",
+  "repository": "https://github.com/noctalia-dev/noctalia-plugins",
   "description": "Advanced clipboard manager with history, search, keyboard navigation, ToDo integration, pinned items, notecards/sticky notes, and selection-to-notecard feature. Fully translated with comprehensive i18n support.",
   "tags": [
     "Utility",


### PR DESCRIPTION
## Summary
- Four user-facing fixes to Clipper's Settings + Panel, plus an i18n hygiene pass.
- New: configurable panel width/height via `NSpinBox` (hidden in fullscreen mode).
- New: Settings use a live-preview + revert-on-cancel pattern so users see the effect of panel-size changes immediately without persisting until Apply.

## Changes per task

### Task 1 — Auto-create notecards folder
- No code change required; `Main.qml:1237` already invokes `Quickshell.execDetached(["mkdir","-p", root.noteCardsDir])` during `onCompleted`.
- Adjacent fix: added seven missing keys to `manifest.json` → `metadata.defaultSettings` (`fullscreenMode`, `hidePanelBackground`, `autoPaste`, `autoPasteOnRightClick`, `autoPasteDelay`, `panelWidth`, `panelHeight`).

### Task 2 — Conditional "Hide Panel Background" toggle
- `Settings.qml`: added `visible: !root.valueNotecardsEnabled` to the toggle and its trailing `NDivider`. The option has no effect when NoteCards are on, so it is now hidden.

### Task 3 — Configurable panel width / height
- `Settings.qml`: two new `NSpinBox` controls for `panelWidth` (400–3840, step 50, default 1450) and `panelHeight` (0–2160, step 50, default 0 = auto). Both `visible: !root.valueFullscreenMode`.
- `Panel.qml:44–50`: reads `panelWidth`/`panelHeight` from settings, multiplied by `Style.uiScaleRatio`. A `panelHeight` of `0` yields `undefined` (SmartPanel auto-height).

### Task 4 — Live-preview + revert-on-cancel Settings pattern

**Deliberate deviation from AGENTS.md canonical edit-copy pattern.** Documented inline at the top of `Settings.qml`.

Mechanics:
1. `Component.onCompleted` snapshots `pluginApi.pluginSettings` via `JSON.parse(JSON.stringify(...))`.
2. `_applyPreview(key, value)` reassigns `pluginApi.pluginSettings = Object.assign({}, pluginApi.pluginSettings, patch)` on every edit — live binding updates in Panel/BarWidget without touching disk.
3. `saveSettings()` sets `_applied = true` and calls `pluginApi.saveSettings()` to persist, with a belt-and-suspenders rewrite of every field.
4. `Component.onDestruction` checks `!_applied` and restores the snapshot via `pluginApi.pluginSettings = Object.assign({}, _snapshot)`.

**Why this deviation:** Panel-size controls benefit enormously from immediate visual feedback. With classic edit-copy the user has to Save → reopen panel → see result → tweak → Save again. Live-preview collapses that loop. The revert-on-cancel contract keeps it safe: closing Settings without Apply restores the on-disk state exactly.

### i18n cleanup
- Removed every `|| "fallback"` suffix after `pluginApi?.tr()` across all QML (verified via grep: 0 matches remain).
- Added 4 new translation keys (`settings.panel-width`, `settings.panel-width-desc`, `settings.panel-height`, `settings.panel-height-desc`) to all 17 language files. Every locale file carries the same 113 keys.

## Testing
Manual smoke tests against `qs -c noctalia-shell`:
1. Notecards toggle hides/shows "Hide Panel Background" — OK
2. Fullscreen toggle hides/shows panel-size NSpinBoxes — OK
3. Panel-width change reflects in the opened panel without clicking Apply — OK
4. Closing Settings without Apply reverts on-disk settings — OK
5. Panel-height `0` yields SmartPanel auto-height — OK
6. Removing `notecards/` and restarting the shell re-creates the directory — OK
7. All 17 locales carry the new keys — verified by `jq` walk

## Version
- `manifest.json`: `2.3.1` → `2.4.0`
- `minNoctaliaVersion` unchanged at `4.1.2` (no newer Shell feature required)