### PR TITLE
i18n(wallcards): update French translations

### DIFF
--- a/wallcards/i18n/fr.json
+++ b/wallcards/i18n/fr.json
@@ -4,5 +4,19 @@
   },
   "widget": {
     "tooltip": "Ouvrir Wallcards"
+  },
+  "settings": {
+    "show_image_type": {
+      "label": "Afficher le type d'image",
+      "desc": "Afficher une icône indiquant le type de média sur les cartes."
+    },
+    "show_image_name": {
+      "label": "Afficher le nom de l'image",
+      "desc": "Afficher le nom du fichier sur la carte centrale."
+    },
+    "show_top_bar": {
+      "label": "Afficher la barre supérieure",
+      "desc": "Afficher la barre de navigation et de filtrage en haut."
+    }
   }
 }

--- a/wallcards/manifest.json
+++ b/wallcards/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "wallcards",
   "name": "Wallcards",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "minNoctaliaVersion": "4.7.0",
   "author": "tonigineer",
   "license": "MIT",


### PR DESCRIPTION
This pull request introduces French localization support for the Wallcards widget and updates the extension version. The most significant changes are the addition of a French translation file and a version bump in the manifest.

Localization:

* Added a new `fr.json` file with French translations for settings and widget tooltip.

Version update:

* Bumped the extension version from `0.0.4` to `0.0.5` in manifest.json.