### PR TITLE
i18n(file-search): update French translations

### DIFF
--- a/file-search/i18n/fr.json
+++ b/file-search/i18n/fr.json
@@ -1,0 +1,55 @@
+{
+  "provider": {
+    "name": "Recherche de fichiers"
+  },
+  "launcher": {
+    "command": {
+      "description": "Rechercher des fichiers et des dossiers"
+    },
+    "errors": {
+      "fdNotFound": {
+        "title": "fd non trouvé",
+        "description": "Veuillez installer fd pour utiliser la recherche de fichiers"
+      }
+    },
+    "prompts": {
+      "emptyQuery": {
+        "title": "Tapez pour rechercher des fichiers et des dossiers",
+        "description": "Commencez à taper pour rechercher dans {{root}}"
+      },
+      "searching": {
+        "title": "Recherche en cours...",
+        "description": "Recherche de fichiers et dossiers correspondant à : {{query}}"
+      },
+      "noResults": {
+        "title": "Aucun résultat trouvé",
+        "description": "Aucun fichier ou dossier ne correspond à '{{query}}'"
+      }
+    }
+  },
+  "settings": {
+    "showHidden": {
+      "label": "Inclure les fichiers cachés"
+    },
+    "fileOpener": {
+      "label": "Commande d'ouverture de fichier",
+      "description": "Commande utilisée pour ouvrir les fichiers et dossiers",
+      "placeholder": "xdg-open"
+    },
+    "searchDirectory": {
+      "label": "Répertoire de recherche",
+      "description": "Répertoire où rechercher des fichiers et des dossiers",
+      "placeholder": "~"
+    },
+    "fdCommand": {
+      "label": "Chemin de la commande fd",
+      "description": "Nom de la commande ou chemin complet",
+      "placeholder": "fd"
+    },
+    "maxResults": {
+      "label": "Nombre maximal de résultats",
+      "unlimited": "Illimité",
+      "description": "Limiter le nombre de résultats de recherche affichés (définir à 0 pour illimité)"
+    }
+  }
+}

--- a/file-search/manifest.json
+++ b/file-search/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "file-search",
     "name": "File Search",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "minNoctaliaVersion": "4.1.2",
     "author": "ericbreh",
     "license": "MIT",


### PR DESCRIPTION
This pull request introduces French localization support for the file-search widget and updates the extension version. The most significant changes are the addition of a French translation file and a version bump in the manifest.

Localization:

* Added a new `fr.json` file with French translations for settings, launcher commands, and search prompts.

Version update:

* Bumped the extension version from `1.0.1` to `1.0.2` in manifest.json.