### PR TITLE
i18n(asus-um5606-fan-state): update French translations

### DIFF
--- a/asus-um5606-fan-state/i18n/fr.json
+++ b/asus-um5606-fan-state/i18n/fr.json
@@ -1,0 +1,9 @@
+{
+  "tooltip": {
+    "standard": "Standard",
+    "quiet": "Silencieux",
+    "high": "Haute Performance",
+    "full": "Plein",
+    "unknown": "Inconnu"
+  }
+}

--- a/asus-um5606-fan-state/manifest.json
+++ b/asus-um5606-fan-state/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "asus-um5606-fan-state",
   "name": "ASUS UM5606 Fan State",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "minNoctaliaVersion": "3.6.0",
   "author": "ThatOneCalculator",
   "license": "MIT",


### PR DESCRIPTION
This pull request introduces French localization support for the ASUS UM5606 Fan State widget and updates the extension version. The most significant changes are the addition of a French translation file and a version bump in the manifest.

Localization:

* Added a new `fr.json` file with French translations for fan mode states (Standard, Silencieux, Haute Performance, Plein).

Version update:

* Bumped the extension version from `1.1.6` to `1.1.7` in manifest.json.