### PR TITLE
fix(clipper): replace deprecated Qt.btoa(string) with array-like overload (v2.4.1)

### DIFF
--- a/clipper/CHANGELOG.md
+++ b/clipper/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Clipper Plugin - Comprehensive Changelog
 
+## Version 2.4.1 (2026-04-21)
+
+### Fix Qt.btoa deprecation warnings
+
+- Replaced three deprecated `Qt.btoa(string)` calls in `Main.qml` (`savePinnedFile`, `exportNoteCard`, `saveNoteCard`) with a new `stringToBase64(str)` helper that encodes the string to UTF-8 bytes as a `Uint8Array` and passes it to the non-deprecated `Qt.btoa(array-like)` overload.
+- Simplified the matching `Qt.atob()` call: the array-like overload returns a `Uint8Array` directly, so the intermediate string + `charCodeAt` loop was removed.
+- Side benefit: `exportNoteCard()` now writes properly encoded UTF-8 `.txt` files — previously, notes containing non-ASCII characters (Polish, emoji, Cyrillic, etc.) were written with Latin-1 byte encoding.
+- No behavior change for existing `pinned.json` / `notecards/*.json` files: `JSON.stringify` already escapes non-ASCII to `\uNNNN`, so the base64 output is effectively identical for ASCII-safe JSON.
+
 ## Version 2.4.0 (2026-04-20)
 
 ### Live-Preview Settings, Panel Size Controls, i18n Cleanup

--- a/clipper/Main.qml
+++ b/clipper/Main.qml
@@ -350,6 +350,42 @@ Item {
               }
   }
 
+  // Helper: encode a UTF-8 string to base64 using the non-deprecated Qt.btoa(array-like) overload.
+  // Qt.btoa(string) is deprecated since Qt 6.8 and its output differs for non-ASCII characters
+  // (Latin-1 byte-per-char vs proper UTF-8). This helper encodes to UTF-8 bytes first.
+  function stringToBase64(str) {
+    var s = String(str);
+    var bytes = [];
+    for (var i = 0; i < s.length; i++) {
+      var code = s.charCodeAt(i);
+      if (code < 0x80) {
+        bytes.push(code);
+      } else if (code < 0x800) {
+        bytes.push(0xC0 | (code >> 6));
+        bytes.push(0x80 | (code & 0x3F));
+      } else if (code >= 0xD800 && code <= 0xDBFF && i + 1 < s.length) {
+        // UTF-16 surrogate pair → Unicode code point
+        var high = code;
+        var low = s.charCodeAt(i + 1);
+        if (low >= 0xDC00 && low <= 0xDFFF) {
+          var cp = 0x10000 + ((high - 0xD800) << 10) + (low - 0xDC00);
+          bytes.push(0xF0 | (cp >> 18));
+          bytes.push(0x80 | ((cp >> 12) & 0x3F));
+          bytes.push(0x80 | ((cp >> 6) & 0x3F));
+          bytes.push(0x80 | (cp & 0x3F));
+          i++;
+        } else {
+          bytes.push(0xEF, 0xBF, 0xBD); // U+FFFD replacement character for lone surrogate
+        }
+      } else {
+        bytes.push(0xE0 | (code >> 12));
+        bytes.push(0x80 | ((code >> 6) & 0x3F));
+        bytes.push(0x80 | (code & 0x3F));
+      }
+    }
+    return Qt.btoa(new Uint8Array(bytes));
+  }
+
   // Function to save pinned items to file
   function savePinnedFile() {
     const data = {
@@ -358,9 +394,9 @@ Item {
     const json = JSON.stringify(data, null, 2);
 
     // Use base64 encoding to safely pass JSON through shell
-    // Qt.btoa() produces valid base64 (A-Z, a-z, 0-9, +, /, =) - no shell metacharacters
+    // stringToBase64() produces valid base64 (A-Z, a-z, 0-9, +, /, =) - no shell metacharacters
     // File path is constant, not user-controlled
-    const base64 = Qt.btoa(json);
+    const base64 = stringToBase64(json);
     const filePath = Quickshell.env("HOME") + "/.config/noctalia/plugins/clipper/pinned.json";
 
     Quickshell.execDetached(["sh", "-c", `echo "${base64}" | base64 -d > "${filePath}"`]);
@@ -531,7 +567,7 @@ Item {
     const filePath = Quickshell.env("HOME") + "/Documents/" + fileName;
 
     // Use base64 encoding to safely pass content through shell
-    const base64 = Qt.btoa(note.content || "");
+    const base64 = stringToBase64(note.content || "");
     Quickshell.execDetached(["sh", "-c", `echo "${base64}" | base64 -d > "${filePath}"`]);
 
     // Store exported filename - append to list so all exports are tracked
@@ -575,7 +611,7 @@ Item {
     const json = JSON.stringify(note, null, 2);
 
     // Use base64 encoding to safely pass JSON through shell
-    const base64 = Qt.btoa(json);
+    const base64 = stringToBase64(json);
     Quickshell.execDetached(["sh", "-c", `echo "${base64}" | base64 -d > "${filePath}"`]);
   }
 
@@ -662,12 +698,9 @@ Item {
       const mimeType = matches[1];
       const base64Data = matches[2];
 
-      // Decode base64 to binary in JavaScript (no shell commands)
-      const binaryStr = Qt.atob(base64Data);
-      const bytes = new Uint8Array(binaryStr.length);
-      for (let i = 0; i < binaryStr.length; i++) {
-        bytes[i] = binaryStr.charCodeAt(i);
-      }
+      // Decode base64 to binary bytes (no shell commands).
+      // Qt.atob() with array-like overload returns a Uint8Array directly (non-deprecated form).
+      const bytes = new Uint8Array(Qt.atob(base64Data));
 
       // Copy binary data directly via Process stdin
       copyPinnedImageProc.running = true;

--- a/clipper/manifest.json
+++ b/clipper/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "clipper",
   "name": "Clipper",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "minNoctaliaVersion": "4.1.2",
   "author": "blackbartblues",
   "contributors": [


### PR DESCRIPTION
## Summary

Qt 6.8 deprecated the `Qt.btoa(string)` overload — it prints a runtime warning on every call and its output diverges from the Web API (Latin-1 bytes per char vs proper UTF-8). Clipper's `Main.qml` triggered three such warnings every time the panel loaded:

```
WARN: Qt.btoa(string): This method is deprecated. Its output differs from the common Web API. Use the overloads that take array-likes.
WARN: Qt.btoa(string): This method is deprecated. Its output differs from the common Web API. Use the overloads that take array-likes.
WARN: Qt.btoa(string): This method is deprecated. Its output differs from the common Web API. Use the overloads that take array-likes.
```

This PR switches every call site to the non-deprecated array-like overload.

## Changes

- Added a `stringToBase64(str)` helper in `Main.qml` that encodes a string to a UTF-8 `Uint8Array` and calls `Qt.btoa(arrayLike)`. Handles surrogate pairs (emoji, non-BMP) and lone surrogates (replaced with U+FFFD).
- Replaced three `Qt.btoa(string)` calls in `savePinnedFile()`, `exportNoteCard()`, `saveNoteCard()` with `stringToBase64()`.
- Simplified the paired `Qt.atob()` decode in the pinned-image copy path — the array-like overload returns a `Uint8Array` directly, so the old string + `charCodeAt` loop is gone.
- Bumped `manifest.json` version `2.4.0` → `2.4.1`.
- Added a 2.4.1 entry to `CHANGELOG.md`.

## Compatibility notes

- **pinned.json / notecards/*.json**: no practical change. `JSON.stringify` already escapes non-ASCII to `\uNNNN`, so the base64 output is identical for existing data on disk.
- **exportNoteCard() .txt output**: this is a *bug fix*. Previously, note content containing Polish/emoji/Cyrillic was written with Latin-1 byte encoding (one byte per JS code unit), producing malformed UTF-8 `.txt` files. The new code writes correct UTF-8.
- **Image decode path (`Qt.atob`)**: raw bytes, no text interpretation in either direction — purely a simplification.

## Test plan

- [x] Panel loads without the three `Qt.btoa` deprecation warnings in the log
- [x] Pin/unpin text and image items; verify `pinned.json` persists correctly
- [x] Create/edit/delete note cards; verify `notecards/*.json` persists
- [x] Export a note card to `.txt` — open the file and verify non-ASCII characters render correctly (previously broken)
- [x] Copy a pinned image back to the clipboard — verify the image pastes correctly in a consumer app