### PR TITLE
feat(translator): add configurable DeepLX-like backend

### DIFF
--- a/translator/LauncherProvider.qml
+++ b/translator/LauncherProvider.qml
@@ -137,12 +137,7 @@ Item {
     }
 
     function getErrorMessage(status, fallback) {
-        if (status === 401) return "Invalid API Key";
-        if (status === 403) return "Forbidden";
-        if (status === 404) return "API endpoint not found";
-        if (status === 429) return "Rate limited";
-        if (status >= 500) return "Upstream service error";
-        return fallback || (pluginApi?.tr("messages.connectionError") || "Connection error");
+        return fallback || pluginApi?.tr("messages.connectionError");
     }
 
     function translateText(text, targetLanguage, cacheKey) {
@@ -170,7 +165,7 @@ Item {
         } else if (backend === "deeplxLike") {
             translateDeepLXLike(text, targetLanguage, callback);
         } else {
-            callback(null, pluginApi?.tr("messages.error") || "Unknown backend");
+            callback(null, pluginApi?.tr("messages.error"));
         }
     }
 
@@ -236,6 +231,8 @@ Item {
                     } catch (e) { 
                         callback(null, pluginApi?.tr("messages.error") || "Translation error"); 
                         }
+                } else if (xhr.status === 403) {
+                    callback(null, pluginApi?.tr("messages.invalidApiKey") || "Invalid API Key");
                 } else {
                     callback(null, getErrorMessage(xhr.status));
                 }
@@ -249,7 +246,7 @@ Item {
         var apiKey = (pluginApi?.pluginSettings?.deeplxApiKey || "").trim();
 
         if (!url) {
-            callback(null, "Missing API URL");
+            callback(null, pluginApi?.tr("messages.missingApiUrl"));
             return;
         }
 
@@ -273,10 +270,10 @@ Item {
                         if (translatedText) {
                             callback(translatedText, null);
                         } else {
-                            callback(null, pluginApi?.tr("messages.error") || "Translation error");
+                            callback(null, pluginApi?.tr("messages.error"));
                         }
                     } catch (e) {
-                        callback(null, pluginApi?.tr("messages.error") || "Translation error");
+                        callback(null, pluginApi?.tr("messages.error"));
                     }
                 } else {
                     callback(null, getErrorMessage(xhr.status));

--- a/translator/LauncherProvider.qml
+++ b/translator/LauncherProvider.qml
@@ -74,7 +74,9 @@ Item {
             }];
         }
 
-        var cacheKey = targetLang + "|" + textToTranslate;
+        var backend = getBackend();
+        var deeplxApiUrl = (pluginApi?.pluginSettings?.deeplxApiUrl || "").trim();
+        var cacheKey = backend + "|" + deeplxApiUrl + "|" + targetLang + "|" + textToTranslate;
         var cached = translationCache[cacheKey];
         if (cached) {
             return [{
@@ -134,6 +136,15 @@ Item {
         return pluginApi?.pluginSettings?.backend || pluginApi?.manifest?.metadata?.defaultSettings?.backend || "google";
     }
 
+    function getErrorMessage(status, fallback) {
+        if (status === 401) return "Invalid API Key";
+        if (status === 403) return "Forbidden";
+        if (status === 404) return "API endpoint not found";
+        if (status === 429) return "Rate limited";
+        if (status >= 500) return "Upstream service error";
+        return fallback || (pluginApi?.tr("messages.connectionError") || "Connection error");
+    }
+
     function translateText(text, targetLanguage, cacheKey) {
         var backend = getBackend();
         
@@ -156,6 +167,8 @@ Item {
             translateGoogle(text, targetLanguage, callback);
         } else if (backend === "deepl") {
             translateDeepL(text, targetLanguage, callback);
+        } else if (backend === "deeplxLike") {
+            translateDeepLXLike(text, targetLanguage, callback);
         } else {
             callback(null, pluginApi?.tr("messages.error") || "Unknown backend");
         }
@@ -186,7 +199,7 @@ Item {
                         } 
                     } catch (e) { callback(null, pluginApi?.tr("messages.error") || "Translation error"); }
                 } else {
-                    callback(null, pluginApi?.tr("messages.connectionError") || "Connection error");
+                    callback(null, getErrorMessage(xhr.status));
                 }
             }
         };
@@ -223,13 +236,57 @@ Item {
                     } catch (e) { 
                         callback(null, pluginApi?.tr("messages.error") || "Translation error"); 
                         }
-                } else if (xhr.status === 403) {
-                     callback(null, pluginApi?.tr("messages.invalidApiKey") || "Invalid API Key");
                 } else {
-                    callback(null, pluginApi?.tr("messages.connectionError") || "Connection error");
+                    callback(null, getErrorMessage(xhr.status));
                 }
             }
         };
         xhr.send(postData);
+    }
+
+    function translateDeepLXLike(text, targetLanguage, callback) {
+        var url = (pluginApi?.pluginSettings?.deeplxApiUrl || "").trim();
+        var apiKey = (pluginApi?.pluginSettings?.deeplxApiKey || "").trim();
+
+        if (!url) {
+            callback(null, "Missing API URL");
+            return;
+        }
+
+        var xhr = new XMLHttpRequest();
+        xhr.open("POST", url);
+        xhr.setRequestHeader("Content-Type", "application/json");
+        if (apiKey) {
+            xhr.setRequestHeader("Authorization", "Bearer " + apiKey);
+        }
+
+        xhr.onreadystatechange = function() {
+            if (xhr.readyState === XMLHttpRequest.DONE) {
+                if (xhr.status === 200) {
+                    try {
+                        var response = JSON.parse(xhr.responseText);
+                        var translatedText =
+                            response?.data ||
+                            (response?.translations && response.translations[0] && response.translations[0].text) ||
+                            "";
+
+                        if (translatedText) {
+                            callback(translatedText, null);
+                        } else {
+                            callback(null, pluginApi?.tr("messages.error") || "Translation error");
+                        }
+                    } catch (e) {
+                        callback(null, pluginApi?.tr("messages.error") || "Translation error");
+                    }
+                } else {
+                    callback(null, getErrorMessage(xhr.status));
+                }
+            }
+        };
+
+        xhr.send(JSON.stringify({
+            text: text,
+            target_lang: targetLanguage.toUpperCase()
+        }));
     }
 }

--- a/translator/LauncherProvider.qml
+++ b/translator/LauncherProvider.qml
@@ -232,7 +232,7 @@ Item {
                         callback(null, pluginApi?.tr("messages.error") || "Translation error"); 
                         }
                 } else if (xhr.status === 403) {
-                    callback(null, pluginApi?.tr("messages.invalidApiKey") || "Invalid API Key");
+                    callback(null, pluginApi?.tr("messages.invalidApiKey"));
                 } else {
                     callback(null, getErrorMessage(xhr.status));
                 }

--- a/translator/README.md
+++ b/translator/README.md
@@ -81,9 +81,21 @@ You can use either the language code (e.g., `fr`, `ja`, `ru`) or the language na
 
 ## Configuration
 
-- **Translation Backend**: Choose the translation service to use (currently supports Google Translate and DeepL/DeepL Free)
+- **Translation Backend**: Choose the translation service to use (currently supports Google Translate, DeepL/DeepL Free, and DeepLX-like APIs)
 - **Realtime Translation**: Toggle between translating as you type or only upon pressing Enter (useful for saving API usage)
-- **API Key**: The API key required for premium backends like DeepL
+- **API Key**: The API key required for premium backends like DeepL, or an optional bearer token for DeepLX-like APIs
+- **API URL**: The endpoint URL for DeepLX-like APIs
+
+### DeepLX-like API Example
+
+Configure the backend as `DeepLX-like API` and set:
+
+- **API URL**: `http://127.0.0.1:1188/translate`
+- **API Key**: Leave empty, or provide a bearer token if your service requires one
+
+If your DeepLX instance uses a query token, include it directly in the URL, for example:
+
+- **API URL**: `http://127.0.0.1:1188/translate?token=YOUR_TOKEN`
 
 ## IPC Commands
 

--- a/translator/Settings.qml
+++ b/translator/Settings.qml
@@ -14,6 +14,8 @@ ColumnLayout {
         "google"
 
     property string editDeeplApiKey: pluginApi?.pluginSettings?.deeplApiKey || ""
+    property string editDeepLXApiUrl: pluginApi?.pluginSettings?.deeplxApiUrl || ""
+    property string editDeepLXApiKey: pluginApi?.pluginSettings?.deeplxApiKey || ""
     property bool editRealTime: pluginApi?.pluginSettings?.realTimeTranslation !== undefined ? pluginApi.pluginSettings.realTimeTranslation : true
     property bool editShowPreview: pluginApi?.pluginSettings?.showPreview !== undefined ? pluginApi.pluginSettings.showPreview : true
     spacing: Style.marginM
@@ -29,6 +31,10 @@ ColumnLayout {
             {
                 "key": "deepl",
                 "name": "DeepL"
+            },
+            {
+                "key": "deeplxLike",
+                "name": "DeepLX-like API"
             }
         ]
         currentKey: root.editBackend
@@ -43,6 +49,24 @@ ColumnLayout {
         text: root.editDeeplApiKey
         onTextChanged: root.editDeeplApiKey = text
         placeholderText: pluginApi?.tr("settings.apiKey-placeholder") || "Enter your API key here"
+    }
+
+    NTextInput {
+        visible: root.editBackend === "deeplxLike"
+        Layout.fillWidth: true
+        label: "API URL"
+        text: root.editDeepLXApiUrl
+        onTextChanged: root.editDeepLXApiUrl = text
+        placeholderText: "http://127.0.0.1:1188/translate"
+    }
+
+    NTextInput {
+        visible: root.editBackend === "deeplxLike"
+        Layout.fillWidth: true
+        label: pluginApi?.tr("settings.apiKey-label") || "API Key"
+        text: root.editDeepLXApiKey
+        onTextChanged: root.editDeepLXApiKey = text
+        placeholderText: "Optional"
     }
 
     NToggle {
@@ -66,6 +90,8 @@ ColumnLayout {
 
         pluginApi.pluginSettings.backend = root.editBackend;
         pluginApi.pluginSettings.deeplApiKey = root.editDeeplApiKey;
+        pluginApi.pluginSettings.deeplxApiUrl = root.editDeepLXApiUrl;
+        pluginApi.pluginSettings.deeplxApiKey = root.editDeepLXApiKey;
         pluginApi.pluginSettings.realTimeTranslation = root.editRealTime;
         pluginApi.pluginSettings.showPreview = root.editShowPreview;
         pluginApi.saveSettings();

--- a/translator/Settings.qml
+++ b/translator/Settings.qml
@@ -54,19 +54,19 @@ ColumnLayout {
     NTextInput {
         visible: root.editBackend === "deeplxLike"
         Layout.fillWidth: true
-        label: "API URL"
+        label: pluginApi?.tr("settings.apiUrl-label")
         text: root.editDeepLXApiUrl
         onTextChanged: root.editDeepLXApiUrl = text
-        placeholderText: "http://127.0.0.1:1188/translate"
+        placeholderText: pluginApi?.tr("settings.apiUrl-placeholder")
     }
 
     NTextInput {
         visible: root.editBackend === "deeplxLike"
         Layout.fillWidth: true
-        label: pluginApi?.tr("settings.apiKey-label") || "API Key"
+        label: pluginApi?.tr("settings.apiKey-label")
         text: root.editDeepLXApiKey
         onTextChanged: root.editDeepLXApiKey = text
-        placeholderText: "Optional"
+        placeholderText: pluginApi?.tr("settings.optional-placeholder")
     }
 
     NToggle {

--- a/translator/i18n/de.json
+++ b/translator/i18n/de.json
@@ -107,7 +107,8 @@
     "translation": "Übersetzung ({code})",
     "missingApiKey": "API-Schlüssel fehlt",
     "invalidApiKey": "Ungültiger API-Schlüssel",
-    "pressEnter": "Zum Übersetzen Enter drücken"
+    "pressEnter": "Zum Übersetzen Enter drücken",
+    "missingApiUrl": "API-URL fehlt"
   },
   "settings": {
     "backend-description": "Wählen Sie den zu verwendenden Übersetzungsdienst",
@@ -116,6 +117,9 @@
     "realTime-description": "Während der Eingabe übersetzen (kann zu einem erheblichen Token-Verbrauch führen)",
     "apiKey-placeholder": "Gib deinen API-Schlüssel hier ein",
     "apiKey-label": "API Schlüssel",
+    "apiUrl-label": "API-URL",
+    "apiUrl-placeholder": "http://127.0.0.1:1188/translate",
+    "optional-placeholder": "Optional",
     "showPreview-label": "Übersetzungsvorschau",
     "showPreview-description": "Das Übersetzungsergebnis im Vorschaufenster anzeigen"
   }

--- a/translator/i18n/en.json
+++ b/translator/i18n/en.json
@@ -107,7 +107,8 @@
     "translation": "Translation ({code})",
     "missingApiKey": "Missing API key",
     "invalidApiKey": "Invalid API key",
-    "pressEnter": "Press enter to translate"
+    "pressEnter": "Press enter to translate",
+    "missingApiUrl": "Missing API URL"
   },
   "settings": {
       "backend-description": "Choose the translation service to use",
@@ -116,6 +117,9 @@
       "realTime-description": "Translate as you type (May result in significant token consumption)",
       "apiKey-placeholder": "Enter your API key here",
       "apiKey-label": "API Key",
+      "apiUrl-label": "API URL",
+      "apiUrl-placeholder": "http://127.0.0.1:1188/translate",
+      "optional-placeholder": "Optional",
       "showPreview-label": "Translation Preview",
       "showPreview-description": "Show the translation result in the preview panel"
   }

--- a/translator/i18n/es.json
+++ b/translator/i18n/es.json
@@ -104,12 +104,17 @@
     "error": "Error de traducción",
     "targetLanguage": "Idioma objetivo: {code}",
     "translating": "Traduciendo...",
-    "translation": "Traducción ({code})"
+    "translation": "Traducción ({code})",
+    "missingApiUrl": "Falta la URL de la API"
   },
   "settings": {
     "backend": {
       "description": "Elija el servicio de traducción a utilizar",
       "label": "Servicio de traducción"
-    }
+    },
+    "apiUrl-label": "URL de la API",
+    "apiUrl-placeholder": "http://127.0.0.1:1188/translate",
+    "apiKey-label": "Clave API",
+    "optional-placeholder": "Opcional"
   }
 }

--- a/translator/i18n/fr.json
+++ b/translator/i18n/fr.json
@@ -107,7 +107,8 @@
     "translation": "Traduction ({code})",
     "missingApiKey": "Clé API manquante",
     "invalidApiKey": "Clé API invalide",
-    "pressEnter": "Appuyez sur Entrée pour traduire"
+    "pressEnter": "Appuyez sur Entrée pour traduire",
+    "missingApiUrl": "URL d'API manquante"
   },
   "settings": {
       "backend-description": "Choisissez le service de traduction à utiliser",
@@ -116,6 +117,9 @@
       "realTime-description": "Traduire au fur et à mesure que vous tapez (Peut entraîner une consommation importante de tokens)",
       "apiKey-placeholder": "Entrez votre clé API ici",
       "apiKey-label": "Clé API",
+      "apiUrl-label": "URL de l'API",
+      "apiUrl-placeholder": "http://127.0.0.1:1188/translate",
+      "optional-placeholder": "Optionnel",
       "showPreview-label": "Aperçu de la traduction",
       "showPreview-description": "Afficher le résultat de la traduction dans le panneau d'aperçu"
   }

--- a/translator/i18n/hu.json
+++ b/translator/i18n/hu.json
@@ -104,12 +104,17 @@
     "error": "Fordítási hiba",
     "targetLanguage": "Célnyelv: {code}",
     "translating": "Fordítás...",
-    "translation": "Fordítás ({code})"
+    "translation": "Fordítás ({code})",
+    "missingApiUrl": "Hiányzó API URL"
   },
   "settings": {
     "backend": {
       "description": "Válaszd ki a használni kívánt fordítószolgáltatást",
       "label": "Fordítóprogram háttérszolgáltatás"
-    }
+    },
+    "apiUrl-label": "API URL",
+    "apiUrl-placeholder": "http://127.0.0.1:1188/translate",
+    "apiKey-label": "API-kulcs",
+    "optional-placeholder": "Opcionális"
   }
 }

--- a/translator/i18n/it.json
+++ b/translator/i18n/it.json
@@ -104,12 +104,17 @@
     "error": "Errore di traduzione",
     "targetLanguage": "Lingua di destinazione: {code}",
     "translating": "Traduzione in corso...",
-    "translation": "Traduzione ({code})"
+    "translation": "Traduzione ({code})",
+    "missingApiUrl": "URL API mancante"
   },
   "settings": {
     "backend": {
       "description": "Scegli il servizio di traduzione da utilizzare",
       "label": "Servizio di traduzione"
-    }
+    },
+    "apiUrl-label": "URL API",
+    "apiUrl-placeholder": "http://127.0.0.1:1188/translate",
+    "apiKey-label": "Chiave API",
+    "optional-placeholder": "Facoltativo"
   }
 }

--- a/translator/i18n/ja.json
+++ b/translator/i18n/ja.json
@@ -104,12 +104,17 @@
     "error": "翻訳エラー",
     "targetLanguage": "対象言語: {code}",
     "translating": "翻訳中...",
-    "translation": "翻訳 ({code})"
+    "translation": "翻訳 ({code})",
+    "missingApiUrl": "API URL がありません"
   },
   "settings": {
     "backend": {
       "description": "使用する翻訳サービスを選択してください",
       "label": "翻訳バックエンド"
-    }
+    },
+    "apiUrl-label": "API URL",
+    "apiUrl-placeholder": "http://127.0.0.1:1188/translate",
+    "apiKey-label": "API キー",
+    "optional-placeholder": "任意"
   }
 }

--- a/translator/i18n/ku.json
+++ b/translator/i18n/ku.json
@@ -104,12 +104,17 @@
     "error": "Xeta wergerandinê",
     "targetLanguage": "Zimanê armanc: {code}",
     "translating": "Wergerandin...",
-    "translation": "Wergera ({code})"
+    "translation": "Wergera ({code})",
+    "missingApiUrl": "URL-a API tune ye"
   },
   "settings": {
     "backend": {
       "description": "Xizmeta wergerê ya ku tê bikar anîn hilbijêre",
       "label": "Paşmaya Wergerandinê"
-    }
+    },
+    "apiUrl-label": "URL-a API",
+    "apiUrl-placeholder": "http://127.0.0.1:1188/translate",
+    "apiKey-label": "Mifteya API",
+    "optional-placeholder": "Vebijarkî"
   }
 }

--- a/translator/i18n/nl.json
+++ b/translator/i18n/nl.json
@@ -104,12 +104,17 @@
     "error": "Vertalingsfout",
     "targetLanguage": "Doeltaal: {code}",
     "translating": "Vertalen...",
-    "translation": "Vertaling ({code})"
+    "translation": "Vertaling ({code})",
+    "missingApiUrl": "API-URL ontbreekt"
   },
   "settings": {
     "backend": {
       "description": "Kies de vertaaldienst die je wilt gebruiken",
       "label": "Vertaal-backend"
-    }
+    },
+    "apiUrl-label": "API-URL",
+    "apiUrl-placeholder": "http://127.0.0.1:1188/translate",
+    "apiKey-label": "API-sleutel",
+    "optional-placeholder": "Optioneel"
   }
 }

--- a/translator/i18n/pl.json
+++ b/translator/i18n/pl.json
@@ -104,12 +104,17 @@
     "error": "Błąd tłumaczenia",
     "targetLanguage": "Język docelowy: {code}",
     "translating": "Tłumaczenie...",
-    "translation": "Tłumaczenie ({code})"
+    "translation": "Tłumaczenie ({code})",
+    "missingApiUrl": "Brak adresu URL API"
   },
   "settings": {
     "backend": {
       "description": "Wybierz usługę tłumaczeniową, której chcesz użyć",
       "label": "Backend tłumaczeń"
-    }
+    },
+    "apiUrl-label": "Adres URL API",
+    "apiUrl-placeholder": "http://127.0.0.1:1188/translate",
+    "apiKey-label": "Klucz API",
+    "optional-placeholder": "Opcjonalne"
   }
 }

--- a/translator/i18n/pt.json
+++ b/translator/i18n/pt.json
@@ -104,12 +104,17 @@
     "error": "Erro de tradução",
     "targetLanguage": "Idioma de destino: {code}",
     "translating": "Traduzindo...",
-    "translation": "Tradução ({code})"
+    "translation": "Tradução ({code})",
+    "missingApiUrl": "URL da API ausente"
   },
   "settings": {
     "backend": {
       "description": "Escolha o serviço de tradução a usar",
       "label": "Serviço de tradução"
-    }
+    },
+    "apiUrl-label": "URL da API",
+    "apiUrl-placeholder": "http://127.0.0.1:1188/translate",
+    "apiKey-label": "Chave da API",
+    "optional-placeholder": "Opcional"
   }
 }

--- a/translator/i18n/ru.json
+++ b/translator/i18n/ru.json
@@ -104,12 +104,17 @@
     "error": "Ошибка перевода",
     "targetLanguage": "Целевой язык: {code}",
     "translating": "Перевод...",
-    "translation": "Перевод ({code})"
+    "translation": "Перевод ({code})",
+    "missingApiUrl": "Отсутствует URL API"
   },
   "settings": {
     "backend": {
       "description": "Выберите службу перевода для использования",
       "label": "Механизм перевода"
-    }
+    },
+    "apiUrl-label": "URL API",
+    "apiUrl-placeholder": "http://127.0.0.1:1188/translate",
+    "apiKey-label": "Ключ API",
+    "optional-placeholder": "Необязательно"
   }
 }

--- a/translator/i18n/tr.json
+++ b/translator/i18n/tr.json
@@ -104,12 +104,17 @@
     "error": "Çeviri hatası",
     "targetLanguage": "Hedef dil: {code}",
     "translating": "Çevriliyor...",
-    "translation": "Çeviri ({code})"
+    "translation": "Çeviri ({code})",
+    "missingApiUrl": "API URL eksik"
   },
   "settings": {
     "backend": {
       "description": "Kullanılacak çeviri hizmetini seçin",
       "label": "Çeviri Arka Ucu"
-    }
+    },
+    "apiUrl-label": "API URL",
+    "apiUrl-placeholder": "http://127.0.0.1:1188/translate",
+    "apiKey-label": "API Anahtarı",
+    "optional-placeholder": "İsteğe bağlı"
   }
 }

--- a/translator/i18n/uk-UA.json
+++ b/translator/i18n/uk-UA.json
@@ -104,12 +104,17 @@
     "error": "Помилка перекладу",
     "targetLanguage": "Цільова мова: {code}",
     "translating": "Переклад...",
-    "translation": "Переклад ({code})"
+    "translation": "Переклад ({code})",
+    "missingApiUrl": "Відсутній URL API"
   },
   "settings": {
     "backend": {
       "description": "Виберіть службу перекладу для використання",
       "label": "Серверна частина перекладу"
-    }
+    },
+    "apiUrl-label": "URL API",
+    "apiUrl-placeholder": "http://127.0.0.1:1188/translate",
+    "apiKey-label": "Ключ API",
+    "optional-placeholder": "Необов’язково"
   }
 }

--- a/translator/i18n/zh-CN.json
+++ b/translator/i18n/zh-CN.json
@@ -107,7 +107,8 @@
     "translation": "翻译 ({code})",
     "missingApiKey": "缺少 API 密钥",
     "invalidApiKey": "API 密钥无效",
-    "pressEnter": "按回车键翻译"
+    "pressEnter": "按回车键翻译",
+    "missingApiUrl": "缺少 API URL"
   },
   "settings": {
     "backend-label": "翻译后端",
@@ -116,6 +117,9 @@
     "realTime-description": "输入时即时翻译（可能导致大量 token 消耗）",
     "apiKey-label": "API 密钥",
     "apiKey-placeholder": "在此处输入您的 API 密钥",
+    "apiUrl-label": "API URL",
+    "apiUrl-placeholder": "http://127.0.0.1:1188/translate",
+    "optional-placeholder": "可选",
     "showPreview-label": "翻译预览",
     "showPreview-description": "在预览面板中显示翻译结果"
   }


### PR DESCRIPTION
  ## Summary

  This PR adds a minimal `DeepLX-like API` backend option to the Translator plugin.

  ## Changes

  - add a new `DeepLX-like API` backend in plugin settings
  - add configurable `API URL` and optional `API Key` fields
  - send custom backend translation requests as `POST` JSON
  - attach `Authorization: Bearer <token>` when an API key is provided
  - support parsing either `data` or `translations[0].text` from the response
  - include backend and API URL in the cache key to avoid stale cached results
  after switching backends
  - document DeepLX-like configuration in the plugin README

  ## Motivation

  The current Google backend relies on an unofficial endpoint and may fail due to
  rate limiting or anti-abuse checks.

  This change adds support for self-hosted DeepLX-like endpoints while keeping the
  implementation small and preserving the existing Google and DeepL backends.

  ## Notes

  - existing `google` and `deepl` backends are unchanged
  - for DeepLX instances using query-token auth, the token can be included directly
  in the configured API URL