### PR TITLE
feat(keybind-cheatsheet): add MangoWC support

### DIFF
--- a/keybind-cheatsheet/Main.qml
+++ b/keybind-cheatsheet/Main.qml
@@ -60,10 +60,6 @@ Item {
         short: pluginApi?.tr("error.labwc-not-supported"),
         detail: pluginApi?.tr("error.labwc-detail")
       },
-      "mango": {
-        short: pluginApi?.tr("error.mango-not-supported"),
-        detail: pluginApi?.tr("error.mango-detail")
-      },
       "unknown": {
         short: pluginApi?.tr("error.unknown-compositor"),
         detail: pluginApi?.tr("error.unknown-detail")
@@ -86,10 +82,13 @@ Item {
     if (niriReadProcess.running) niriReadProcess.running = false;
     if (hyprGlobProcess.running) hyprGlobProcess.running = false;
     if (hyprReadProcess.running) hyprReadProcess.running = false;
+    if (mangoGlobProcess.running) mangoGlobProcess.running = false;
+    if (mangoReadProcess.running) mangoReadProcess.running = false;
 
     // Clear process buffers
     niriGlobProcess.expandedFiles = [];
     hyprGlobProcess.expandedFiles = [];
+    mangoGlobProcess.expandedFiles = [];
     currentLines = [];
   }
 
@@ -139,7 +138,7 @@ Item {
 
     // Detect compositor using CompositorService
     var compositorName = getCurrentCompositor();
-    if (!CompositorService.isHyprland && !CompositorService.isNiri) {
+    if (!CompositorService.isHyprland && !CompositorService.isNiri && !CompositorService.isMango) {
       isCurrentlyParsing = false;
 
       var unsupportedMsg = getUnsupportedCompositorMessage(compositorName);
@@ -172,18 +171,21 @@ Item {
     var filePath;
     if (CompositorService.isHyprland) {
       filePath = pluginApi?.pluginSettings?.hyprlandConfigPath || (homeDir + "/.config/hypr/hyprland.conf");
-      filePath = filePath.replace(/^~/, homeDir);
     } else if (CompositorService.isNiri) {
       filePath = pluginApi?.pluginSettings?.niriConfigPath || (homeDir + "/.config/niri/config.kdl");
-      filePath = filePath.replace(/^~/, homeDir);
+    } else if (CompositorService.isMango) {
+      filePath = pluginApi?.pluginSettings?.mangoConfigPath || (homeDir + "/.config/mango/config.conf");
     }
+    filePath = filePath.replace(/^~/, homeDir);
 
     filesToParse = [filePath];
 
     if (CompositorService.isHyprland) {
       parseNextHyprlandFile();
-    } else {
+    } else if (CompositorService.isNiri) {
       parseNextNiriFile();
+    } else if (CompositorService.isMango) {
+      parseNextMangoFile();
     }
   }
 
@@ -655,6 +657,305 @@ Item {
     clearParsingData();
   }
 
+  // ========== MANGO RECURSIVE PARSING ==========
+  function parseNextMangoFile() {
+    if (parseDepthCounter >= maxParseDepth) {
+      isCurrentlyParsing = false;
+      clearParsingData();
+      return;
+    }
+    parseDepthCounter++;
+
+    if (filesToParse.length === 0) {
+      if (accumulatedLines.length > 0) {
+        parseMangoConfig(accumulatedLines.join("\n"));
+      } else {
+        isCurrentlyParsing = false;
+      }
+      return;
+    }
+
+    var nextFile = filesToParse.shift();
+
+    if (isGlobPattern(nextFile)) {
+      mangoGlobProcess.expandedFiles = [];
+      mangoGlobProcess.command = ["sh", "-c", 'for f in $1; do [ -f "$f" ] && echo "$f"; done', "sh", nextFile];
+      mangoGlobProcess.running = true;
+      return;
+    }
+
+    if (parsedFiles[nextFile]) {
+      parseNextMangoFile();
+      return;
+    }
+
+    parsedFiles[nextFile] = true;
+    currentLines = [];
+    mangoReadProcess.currentFilePath = nextFile;
+    mangoReadProcess.command = ["cat", nextFile];
+    mangoReadProcess.running = true;
+  }
+
+  Process {
+    id: mangoGlobProcess
+    property var expandedFiles: []
+    running: false
+
+    stdout: SplitParser {
+      onRead: data => {
+        var trimmed = data.trim();
+        if (trimmed.length > 0 && mangoGlobProcess.expandedFiles.length < 100) {
+          mangoGlobProcess.expandedFiles.push(trimmed);
+        }
+      }
+    }
+
+    onExited: {
+      for (var i = 0; i < expandedFiles.length; i++) {
+        var path = expandedFiles[i];
+        if (!root.parsedFiles[path] && root.filesToParse.indexOf(path) === -1) {
+          root.filesToParse.push(path);
+        }
+      }
+      expandedFiles = [];
+      root.parseNextMangoFile();
+    }
+  }
+
+  Process {
+    id: mangoReadProcess
+    property string currentFilePath: ""
+    running: false
+
+    stdout: SplitParser {
+      onRead: data => {
+        if (root.currentLines.length < 10000) {
+          root.currentLines.push(data);
+        }
+      }
+    }
+
+    onExited: (exitCode, exitStatus) => {
+      if (exitCode === 0 && root.currentLines.length > 0) {
+        for (var i = 0; i < root.currentLines.length; i++) {
+          var line = root.currentLines[i];
+          root.accumulatedLines.push(line);
+
+          // source=path (optionally source-optional=path)
+          var sourceMatch = line.trim().match(/^source(?:-optional)?\s*=\s*(.+)$/);
+          if (sourceMatch) {
+            var sourcePath = sourceMatch[1].trim();
+            var commentIdx = sourcePath.indexOf('#');
+            if (commentIdx > 0) sourcePath = sourcePath.substring(0, commentIdx).trim();
+            var resolvedPath = root.resolveRelativePath(currentFilePath, sourcePath);
+            if (!root.parsedFiles[resolvedPath] && root.filesToParse.indexOf(resolvedPath) === -1) {
+              root.filesToParse.push(resolvedPath);
+            }
+          }
+        }
+      }
+      root.currentLines = [];
+      root.parseNextMangoFile();
+    }
+  }
+
+  // ========== MANGO PARSER ==========
+  //
+  // Format: bind=MODS,KEY,ACTION[,ARGS...]          (and axisbind= for scroll binds)
+  // Modifiers: SUPER, SHIFT, CTRL, ALT, NONE; combined with +  e.g. SUPER+SHIFT
+  // Categories: # Title  or  # N. Title  (horizontal-rule dashes stripped)
+  // Optional per-bind description: trailing  #"description"
+  function parseMangoConfig(text) {
+    var lines = text.split('\n');
+    var categories = [];
+    var currentCategory = null;
+    var defaultCategoryName = pluginApi?.tr("default-category") || "Keybinds";
+
+    for (var i = 0; i < lines.length; i++) {
+      var line = lines[i].trim();
+      if (line.length === 0) continue;
+
+      if (line.charAt(0) === "#") {
+        var catName = extractMangoCategory(line);
+        if (catName) {
+          if (currentCategory && currentCategory.binds.length > 0) {
+            categories.push(currentCategory);
+          }
+          currentCategory = { "title": catName, "binds": [] };
+        }
+        continue;
+      }
+
+      var bindMatch = line.match(/^(bind|axisbind|mousebind)\s*=\s*(.+)$/);
+      if (!bindMatch) continue;
+
+      var directiveKind = bindMatch[1]; // "bind" | "axisbind" | "mousebind"
+      var rest = bindMatch[2];
+
+      var explicitDesc = null;
+      var descMatch = rest.match(/#"([^"]*)"\s*$/);
+      if (descMatch) {
+        explicitDesc = descMatch[1];
+        rest = rest.substring(0, descMatch.index).trim();
+      }
+
+      var commentIdx = findMangoUnquotedComment(rest);
+      if (commentIdx >= 0) {
+        rest = rest.substring(0, commentIdx).trim();
+      }
+      rest = rest.replace(/,\s*$/, "");
+
+      var fields = rest.split(',');
+      for (var f = 0; f < fields.length; f++) fields[f] = fields[f].trim();
+      if (fields.length < 3) continue;
+
+      var modPart = fields[0];
+      var rawKey = fields[1];
+      var action = fields[2];
+      var args = fields.slice(3);
+
+      if (!currentCategory) {
+        currentCategory = { "title": defaultCategoryName, "binds": [] };
+      }
+
+      var formattedKeys = formatMangoKeyCombo(modPart, rawKey, directiveKind);
+      var description = explicitDesc || formatMangoAction(action, args);
+
+      currentCategory.binds.push({
+        "keys": formattedKeys,
+        "desc": description
+      });
+    }
+
+    if (currentCategory && currentCategory.binds.length > 0) {
+      categories.push(currentCategory);
+    }
+
+    saveToDb(categories);
+    isCurrentlyParsing = false;
+    clearParsingData();
+  }
+
+  function extractMangoCategory(line) {
+    var stripped = line.replace(/^#+\s*/, "").trim();
+    stripped = stripped.replace(/^[─—━–\-=_]+\s*/, "").replace(/\s*[─—━–\-=_]+$/, "").trim();
+    var numbered = stripped.match(/^\d+\.\s*(.+)$/);
+    if (numbered) stripped = numbered[1].trim();
+    if (stripped.length === 0 || stripped.length > 100) return null;
+    // Skip parenthetical continuations and lines with flow arrows
+    if (stripped.charAt(0) === "(") return null;
+    if (stripped.indexOf("→") !== -1 || stripped.indexOf("←") !== -1) return null;
+    return stripped;
+  }
+
+  function findMangoUnquotedComment(str) {
+    var inQuotes = false;
+    for (var i = 0; i < str.length; i++) {
+      var c = str.charAt(i);
+      if (c === '"') { inQuotes = !inQuotes; continue; }
+      if (c === '#' && !inQuotes) {
+        if (str.charAt(i + 1) !== '"') return i;
+      }
+    }
+    return -1;
+  }
+
+  // kind: "bind" | "axisbind" | "mousebind"
+  function formatMangoKeyCombo(modStr, key, kind) {
+    var mods = [];
+    var modUpper = (modStr || "").toUpperCase();
+    if (modUpper.indexOf("SUPER") !== -1 || modUpper.indexOf("LOGO") !== -1) mods.push("Super");
+    if (modUpper.indexOf("SHIFT") !== -1) mods.push("Shift");
+    if (modUpper.indexOf("CTRL") !== -1 || modUpper.indexOf("CONTROL") !== -1) mods.push("Ctrl");
+    if (modUpper.indexOf("ALT") !== -1 || modUpper.indexOf("MOD1") !== -1) mods.push("Alt");
+
+    var k = key || "";
+    var kUp = k.toUpperCase();
+
+    if (kind === "axisbind" && mangoAxisMap[kUp]) {
+      k = mangoAxisMap[kUp];
+    } else if (kind === "mousebind" && mangoButtonMap[kUp]) {
+      k = mangoButtonMap[kUp];
+    } else if (!/^code:/i.test(k)) {
+      // code:NN keycodes kept verbatim so users see the raw keycode.
+      k = formatSpecialKey(k);
+      if (mangoKeyNameMap[k]) k = mangoKeyNameMap[k];
+    }
+
+    if (mods.length === 0) return k;
+    return mods.join(" + ") + " + " + k;
+  }
+
+  // Mango action -> human-readable description
+  function formatMangoAction(action, args) {
+    // spawn / spawn_shell: Noctalia IPC or generic command
+    if (action === "spawn" || action === "spawn_shell" || action === "spawn-sh") {
+      var cmd = args.join(",").trim();
+      if (cmd.indexOf("noctalia-shell") !== -1 && cmd.indexOf("ipc") !== -1) {
+        var ipcMatch = cmd.match(/ipc\s+call\s+([\w:.\-]+)\s+(\w+)/);
+        if (ipcMatch) {
+          var target = ipcMatch[1];
+          var fn = ipcMatch[2];
+          var ipcKey = target + " " + fn;
+          if (noctaliaIpcLabels[ipcKey]) return noctaliaIpcLabels[ipcKey];
+          // plugin:<name> targets: format as "Plugin Name: Function"
+          var pluginMatch = target.match(/^plugin:(.+)$/);
+          if (pluginMatch) {
+            var pname = pluginMatch[1].replace(/[_\-]/g, ' ').replace(/\b\w/g, function(l) { return l.toUpperCase(); });
+            var fLabel = fn.replace(/([A-Z])/g, ' $1').replace(/^./, function(l) { return l.toUpperCase(); }).trim();
+            return pname + ": " + fLabel;
+          }
+          return target.replace(/([A-Z])/g, ' $1').trim() + ": " +
+                 fn.replace(/([A-Z])/g, ' $1').trim();
+        }
+      }
+      var first = cmd.split(/\s+/)[0] || cmd;
+      var basename = first.split('/').pop();
+      // Strip nix store hash prefix: abc123xyz-pkgname -> pkgname
+      var stripHash = basename.match(/^[a-z0-9]{32,}-(.+)$/);
+      if (stripHash) basename = stripHash[1];
+      return "Run: " + (basename || cmd);
+    }
+
+    if (mangoNoArgActions[action]) return mangoNoArgActions[action];
+
+    if (mangoDirActions[action] && args.length > 0) {
+      var dir = args[0];
+      return mangoDirActions[action] + " " + dir.charAt(0).toUpperCase() + dir.slice(1);
+    }
+
+    if (action === "focusstack" && args.length > 0) {
+      if (args[0] === "next") return "Focus Next Window";
+      if (args[0] === "prev") return "Focus Previous Window";
+    }
+
+    if (action === "view" && args.length > 0) return "Workspace " + args[0];
+    if (action === "tag" && args.length > 0) return "Send to Workspace " + args[0];
+    if (action === "toggletag" && args.length > 0) return "Toggle Workspace " + args[0];
+    if (action === "toggleview" && args.length > 0) return "Toggle View Workspace " + args[0];
+
+    if (action === "set_proportion" && args.length > 0) {
+      var v = parseFloat(args[0]);
+      if (!isNaN(v)) return "Column width " + Math.round(v * 100) + "%";
+    }
+
+    if (action === "toggle_named_scratchpad" && args.length > 0) {
+      return "Scratchpad: " + args[0];
+    }
+
+    // moveresize etc. for mousebind
+    if (action === "moveresize" && args.length > 0) {
+      var mr = args[0];
+      if (mr === "curmove") return "Move window";
+      if (mr === "curresize") return "Resize window";
+      return "Move/Resize: " + mr;
+    }
+
+    var formatted = action.replace(/[_\-]/g, ' ').replace(/\b\w/g, function(l) { return l.toUpperCase(); });
+    if (args.length > 0) formatted += " " + args.join(", ");
+    return formatted;
+  }
+
   function formatSpecialKey(key) {
     var keyMap = {
       // Audio keys (uppercase for Hyprland)
@@ -739,6 +1040,47 @@ Item {
 
     return formattedParts.join(" + ");
   }
+
+  // Mango lookup tables, hoisted to module level to avoid per-bind allocation.
+  readonly property var mangoKeyNameMap: ({
+    "Return": "Enter", "return": "Enter",
+    "equal": "=", "minus": "-", "plus": "+",
+    "space": "Space", "comma": ",", "period": ".",
+    "semicolon": ";", "apostrophe": "'", "grave": "`",
+    "slash": "/", "backslash": "\\",
+    "bracketleft": "[", "bracketright": "]",
+    "Escape": "Esc", "escape": "Esc"
+  })
+  readonly property var mangoAxisMap: ({
+    "UP": "Scroll Up", "DOWN": "Scroll Down",
+    "LEFT": "Scroll Left", "RIGHT": "Scroll Right"
+  })
+  readonly property var mangoButtonMap: ({
+    "BTN_LEFT": "Left Click", "BTN_RIGHT": "Right Click",
+    "BTN_MIDDLE": "Middle Click", "BTN_SIDE": "Mouse Side",
+    "BTN_EXTRA": "Mouse Extra"
+  })
+  readonly property var mangoNoArgActions: ({
+    "killclient": "Close window",
+    "togglefullscreen": "Toggle fullscreen",
+    "togglemaximizescreen": "Maximize",
+    "togglefloating": "Toggle floating",
+    "reload_config": "Reload config",
+    "toggleoverview": "Toggle overview",
+    "quit": "Quit compositor",
+    "switch_proportion_preset": "Cycle column width",
+    "switch_keyboard_layout": "Switch keyboard layout",
+    "zoom": "Zoom",
+    "restart": "Restart",
+    "incnmaster": "Increase masters",
+    "switch_layout": "Switch layout"
+  })
+  readonly property var mangoDirActions: ({
+    "focusdir": "Focus",
+    "exchange_client": "Swap",
+    "focusmon": "Focus Monitor",
+    "tagmon": "Send to Monitor"
+  })
 
   // Map Noctalia IPC target+function to human-readable descriptions
   property var noctaliaIpcLabels: ({

--- a/keybind-cheatsheet/Main.qml
+++ b/keybind-cheatsheet/Main.qml
@@ -769,7 +769,7 @@ Item {
     var lines = text.split('\n');
     var categories = [];
     var currentCategory = null;
-    var defaultCategoryName = pluginApi?.tr("default-category") || "Keybinds";
+    var defaultCategoryName = pluginApi?.tr("default-category");
 
     for (var i = 0; i < lines.length; i++) {
       var line = lines[i].trim();

--- a/keybind-cheatsheet/Panel.qml
+++ b/keybind-cheatsheet/Panel.qml
@@ -187,6 +187,7 @@ Item {
         NText {
           text: CompositorService.isHyprland ? pluginApi?.tr("panel.title-hyprland") :
                 CompositorService.isNiri     ? pluginApi?.tr("panel.title-niri") :
+                CompositorService.isMango    ? pluginApi?.tr("panel.title-mango") :
                                                pluginApi?.tr("panel.title")
           font.pointSize: Style.fontSizeM
           font.weight: Font.Bold

--- a/keybind-cheatsheet/README.md
+++ b/keybind-cheatsheet/README.md
@@ -1,13 +1,13 @@
 # Keybind Cheatsheet for Noctalia
 
-Universal keyboard shortcuts cheatsheet plugin for Noctalia that **automatically detects** your compositor (Hyprland or Niri) and displays your keybindings with **recursive config parsing**.
+Universal keyboard shortcuts cheatsheet plugin for Noctalia that **automatically detects** your compositor (Hyprland, Niri, or MangoWC) and displays your keybindings with **recursive config parsing**.
 
 ![Preview](preview.png)
 
 ## Features
 
-- **Automatic compositor detection** (Hyprland or Niri)
-- **Recursive config parsing** - follows all `source` (Hyprland) and `include` (Niri) directives
+- **Automatic compositor detection** (Hyprland, Niri, or MangoWC)
+- **Recursive config parsing** - follows all `source` (Hyprland/MangoWC) and `include` (Niri) directives
 - **Glob pattern support** - parses `~/.config/hypr/*.conf` style includes
 - **Configurable paths** - set custom config file locations in settings
 - **Smart key formatting** - XF86 keys display as readable names (Vol Up, Bright Down, etc.)
@@ -22,6 +22,7 @@ Universal keyboard shortcuts cheatsheet plugin for Noctalia that **automatically
 |------------|----------------|--------|
 | **Hyprland** | `~/.config/hypr/hyprland.conf` | Hyprland config format |
 | **Niri** | `~/.config/niri/config.kdl` | KDL format |
+| **MangoWC** | `~/.config/mango/config.conf` | `bind=MODS,KEY,ACTION,ARGS` |
 
 ## Installation
 
@@ -49,6 +50,12 @@ Add to your config:
 binds {
     Mod+F1 { spawn-sh "qs -c noctalia-shell ipc call plugin:keybind-cheatsheet toggle"; }
 }
+```
+
+#### MangoWC
+Add to your config:
+```
+bind=SUPER,F1,spawn_shell,noctalia-shell ipc call plugin:keybind-cheatsheet toggle
 ```
 
 ## Config Format
@@ -114,6 +121,52 @@ binds {
 include "~/.config/niri/binds.kdl"
 ```
 
+### MangoWC
+
+The plugin parses `~/.config/mango/config.conf` and follows every `source=` include.
+
+**Keybind format:**
+```
+# Applications
+bind=SUPER,Return,spawn,ghostty
+bind=SUPER,b,spawn,firefox
+bind=SUPER,d,spawn_shell,noctalia-shell ipc call launcher toggle
+
+# Window management
+bind=SUPER,q,killclient,
+bind=SUPER,f,togglemaximizescreen,
+bind=SUPER+SHIFT,f,togglefullscreen,
+
+# Workspaces
+bind=SUPER,1,view,1,0
+bind=SUPER+CTRL,1,tag,1,0
+
+# Scroll binds (mouse wheel)
+axisbind=SUPER,UP,focusdir,left
+axisbind=SUPER,DOWN,focusdir,right
+```
+
+**Requirements:**
+- Categories are drawn from `#` comment lines. The parser accepts a comment as a category heading when **all** of these hold:
+  - After stripping any leading or trailing horizontal rule characters (box drawing `U+2500`, heavy `U+2501`, light quadruple `U+2505`, em dash `U+2014`, en dash `U+2013`, ASCII `-`, `=`, `_`), the text is 1 to 100 characters long.
+  - It does not start with `(` (filters parenthetical continuations such as `# (replaces the old behaviour)`).
+  - It does not contain a Unicode flow arrow (`U+2192` or `U+2190`), which filters description lines.
+  - `# N. Name` is also accepted (Hyprland style).
+- A heading only materialises as a section in the cheatsheet when at least one `bind`/`axisbind`/`mousebind` follows it; headings with no binds are discarded silently.
+- Modifiers: `SUPER`, `SHIFT`, `CTRL`, `ALT`, `NONE` (and aliases `LOGO`, `CONTROL`, `MOD1`), combined with `+` (e.g. `SUPER+SHIFT`).
+- Directives supported: `bind=`, `axisbind=` (mouse wheel), `mousebind=` (mouse buttons).
+- Optional per-bind description: trailing `#"description"` overrides the auto-generated text.
+- Actions without explicit descriptions are auto-formatted (`killclient` → "Close window", `view,1,0` → "Workspace 1", `focusdir,left` → "Focus Left", `set_proportion,0.5` → "Column width 50%", `moveresize,curmove` → "Move window", etc.).
+- Mouse button names translate (`btn_left` → "Left Click", `btn_side` → "Mouse Side").
+- `code:NN` keycodes are kept verbatim so you can still recognise the raw evdev code.
+- Noctalia IPC calls via `spawn_shell,noctalia-shell ipc call ...` map to friendly labels, including `plugin:<name>` targets.
+
+**Source directives (automatically followed):**
+```
+source=~/.config/mango/bind.conf
+source-optional=~/.config/mango/host.conf
+```
+
 ## Auto-Categorization (Niri)
 
 When no category comment is provided, keybindings are grouped by action:
@@ -154,7 +207,7 @@ Access settings via the gear icon in the panel header:
 - **Window width** - 400-3000px
 - **Height** - Auto or manual (300-2000px)
 - **Columns** - 1-4 columns
-- **Config paths** - Custom paths for Hyprland/Niri configs
+- **Config paths** - Custom paths for Hyprland, Niri, and MangoWC configs
 - **Refresh** - Force reload keybindings
 
 ## Troubleshooting
@@ -171,14 +224,16 @@ Access settings via the gear icon in the panel header:
 
 **Niri:** Use `// #"Category Name"` format for custom categories.
 
+**MangoWC:** `# Heading` comments become categories as described in [Config Format → MangoWC](#mangowc). Comments that start with `(`, contain `→`/`←`, or exceed 100 characters are skipped. A heading only renders when at least one bind follows it, so explanatory comments above config blocks do not leak into the cheatsheet.
+
 ### Keybinds from included files not showing
 
-The plugin follows `source` (Hyprland) and `include` (Niri) directives automatically. Check logs to see which files are being parsed.
+The plugin follows `source` (Hyprland/MangoWC) and `include` (Niri) directives automatically. Check logs to see which files are being parsed.
 
 ## Requirements
 
 - Noctalia Shell 4.1.0+
-- Hyprland or Niri compositor
+- Hyprland, Niri, or MangoWC compositor
 
 ## License
 

--- a/keybind-cheatsheet/Settings.qml
+++ b/keybind-cheatsheet/Settings.qml
@@ -70,6 +70,7 @@ Item {
   property string editModKeyVariable: cfg.modKeyVariable || defaults.modKeyVariable || "$mod"
   property string editHyprlandConfigPath: cfg.hyprlandConfigPath || defaults.hyprlandConfigPath || "~/.config/hypr/hyprland.conf"
   property string editNiriConfigPath: cfg.niriConfigPath || defaults.niriConfigPath || "~/.config/niri/config.kdl"
+  property string editMangoConfigPath: cfg.mangoConfigPath || defaults.mangoConfigPath || "~/.config/mango/config.conf"
 
   // Header
   NText {
@@ -409,6 +410,52 @@ Item {
           wrapMode: Text.WordWrap
         }
       }
+
+      Rectangle {
+        Layout.preferredHeight: 1
+        color: Color.mOutline
+        opacity: 0.3
+      }
+
+      // Mango path
+      ColumnLayout {
+        spacing: Style.marginXS
+
+        RowLayout {
+          spacing: Style.marginS
+          NIcon {
+            icon: "terminal"
+            pointSize: Style.fontSizeM
+            color: Color.mTertiary
+          }
+          NText {
+            text: rootItem.pluginApi?.tr("settings.mango-path")
+            color: Color.mOnSurface
+            pointSize: Style.fontSizeM
+            font.weight: Style.fontWeightBold
+          }
+        }
+
+        NTextInput {
+          id: mangoPathInput
+          Layout.fillWidth: true
+          Layout.preferredHeight: Style.baseWidgetSize
+          text: root.editMangoConfigPath
+          placeholderText: "~/.config/mango/config.conf"
+
+          onTextChanged: {
+            if (text.length > 0) root.editMangoConfigPath = text;
+          }
+        }
+
+        NText {
+          Layout.fillWidth: true
+          text: rootItem.pluginApi?.tr("settings.mango-format-hint")
+          color: Color.mOnSurfaceVariant
+          pointSize: Style.fontSizeXS
+          wrapMode: Text.WordWrap
+        }
+      }
     }
   }
 
@@ -457,12 +504,14 @@ Item {
             root.editModKeyVariable = defaults.modKeyVariable || "$mod";
             root.editHyprlandConfigPath = defaults.hyprlandConfigPath || "~/.config/hypr/hyprland.conf";
             root.editNiriConfigPath = defaults.niriConfigPath || "~/.config/niri/config.kdl";
+            root.editMangoConfigPath = defaults.mangoConfigPath || "~/.config/mango/config.conf";
 
             widthInput.text = root.editWindowWidth.toString();
             heightInput.text = "850";
             modVarInput.text = root.editModKeyVariable;
             hyprlandPathInput.text = root.editHyprlandConfigPath;
             niriPathInput.text = root.editNiriConfigPath;
+            mangoPathInput.text = root.editMangoConfigPath;
 
             if (rootItem.pluginApi && rootItem.pluginApi.pluginSettings) {
               rootItem.pluginApi.pluginSettings.cheatsheetData = [];
@@ -539,6 +588,14 @@ Item {
         pointSize: Style.fontSizeXS
         wrapMode: Text.WordWrap
       }
+
+      NText {
+        Layout.fillWidth: true
+        text: rootItem.pluginApi?.tr("settings.keybind-example-mango")
+        color: Color.mOnSurfaceVariant
+        pointSize: Style.fontSizeXS
+        wrapMode: Text.WordWrap
+      }
     }
   }
 
@@ -559,6 +616,7 @@ Item {
     pluginApi.pluginSettings.modKeyVariable = root.editModKeyVariable;
     pluginApi.pluginSettings.hyprlandConfigPath = root.editHyprlandConfigPath;
     pluginApi.pluginSettings.niriConfigPath = root.editNiriConfigPath;
+    pluginApi.pluginSettings.mangoConfigPath = root.editMangoConfigPath;
     pluginApi.saveSettings();
     ToastService.showNotice(
       pluginApi?.tr("settings.saved")

--- a/keybind-cheatsheet/i18n/de.json
+++ b/keybind-cheatsheet/i18n/de.json
@@ -19,7 +19,8 @@
     "workspace-switching": "ARBEITSBEREICHE - WECHSELN",
     "workspace-moving": "ARBEITSBEREICHE - VERSCHIEBEN",
     "workspace-mouse": "ARBEITSBEREICHE - MAUS",
-    "search-placeholder": "Tastenbelegung suchen..."
+    "search-placeholder": "Tastenbelegung suchen...",
+    "title-mango": "MangoWC Keymap"
   },
   "settings": {
     "title": "Tastenkürzel-Ubersicht Einstellungen",
@@ -51,7 +52,10 @@
     "width-range": "px (400-3000)",
     "height-range": "px (300-2000)",
     "hyprland-path": "Hyprland Pfad",
-    "niri-path": "Niri Pfad"
+    "niri-path": "Niri Pfad",
+    "mango-path": "Mango Path",
+    "mango-format-hint": "Expected format: bind=MODS,KEY,ACTION,ARGS\nCategories: # Category Name (horizontal rules stripped)\nOptional per-bind description: trailing #\"description\"",
+    "keybind-example-mango": "Mango example: bind=SUPER,F1,spawn_shell,noctalia-shell ipc call plugin:keybind-cheatsheet toggle"
   },
   "barwidget": {
     "tooltip": "Tastenkürzel-Spickzettel",

--- a/keybind-cheatsheet/i18n/en.json
+++ b/keybind-cheatsheet/i18n/en.json
@@ -19,7 +19,8 @@
     "workspace-switching": "WORKSPACES - SWITCHING",
     "workspace-moving": "WORKSPACES - MOVING",
     "workspace-mouse": "WORKSPACES - MOUSE",
-    "search-placeholder": "Search keybinds..."
+    "search-placeholder": "Search keybinds...",
+    "title-mango": "MangoWC Keymap"
   },
   "settings": {
     "title": "Keybind Cheatsheet Settings",
@@ -51,7 +52,10 @@
     "width-range": "px (400-3000)",
     "height-range": "px (300-2000)",
     "hyprland-path": "Hyprland Path",
-    "niri-path": "Niri Path"
+    "niri-path": "Niri Path",
+    "mango-path": "Mango Path",
+    "mango-format-hint": "Expected format: bind=MODS,KEY,ACTION,ARGS\nCategories: # Category Name (horizontal rules stripped)\nOptional per-bind description: trailing #\"description\"",
+    "keybind-example-mango": "Mango example: bind=SUPER,F1,spawn_shell,noctalia-shell ipc call plugin:keybind-cheatsheet toggle"
   },
   "barwidget": {
     "tooltip": "Keybind Cheatsheet",

--- a/keybind-cheatsheet/i18n/es.json
+++ b/keybind-cheatsheet/i18n/es.json
@@ -19,7 +19,8 @@
     "workspace-switching": "ESPACIOS DE TRABAJO - CAMBIAR",
     "workspace-moving": "ESPACIOS DE TRABAJO - MOVER",
     "workspace-mouse": "ESPACIOS DE TRABAJO - RATÓN",
-    "search-placeholder": "Buscar atajos..."
+    "search-placeholder": "Buscar atajos...",
+    "title-mango": "MangoWC Keymap"
   },
   "settings": {
     "title": "Configuracion de Atajos de Teclado",
@@ -51,7 +52,10 @@
     "width-range": "px (400-3000)",
     "height-range": "px (300-2000)",
     "hyprland-path": "Ruta Hyprland",
-    "niri-path": "Ruta Niri"
+    "niri-path": "Ruta Niri",
+    "mango-path": "Mango Path",
+    "mango-format-hint": "Expected format: bind=MODS,KEY,ACTION,ARGS\nCategories: # Category Name (horizontal rules stripped)\nOptional per-bind description: trailing #\"description\"",
+    "keybind-example-mango": "Mango example: bind=SUPER,F1,spawn_shell,noctalia-shell ipc call plugin:keybind-cheatsheet toggle"
   },
   "barwidget": {
     "tooltip": "Hoja de trucos de atajos",

--- a/keybind-cheatsheet/i18n/fr.json
+++ b/keybind-cheatsheet/i18n/fr.json
@@ -19,7 +19,8 @@
     "workspace-switching": "ESPACES DE TRAVAIL - BASCULER",
     "workspace-moving": "ESPACES DE TRAVAIL - DÉPLACER",
     "workspace-mouse": "ESPACES DE TRAVAIL - SOURIS",
-    "search-placeholder": "Rechercher des raccourcis..."
+    "search-placeholder": "Rechercher des raccourcis...",
+    "title-mango": "MangoWC Keymap"
   },
   "settings": {
     "title": "Parametres des Raccourcis Clavier",
@@ -51,7 +52,10 @@
     "width-range": "px (400-3000)",
     "height-range": "px (300-2000)",
     "hyprland-path": "Chemin Hyprland",
-    "niri-path": "Chemin Niri"
+    "niri-path": "Chemin Niri",
+    "mango-path": "Mango Path",
+    "mango-format-hint": "Expected format: bind=MODS,KEY,ACTION,ARGS\nCategories: # Category Name (horizontal rules stripped)\nOptional per-bind description: trailing #\"description\"",
+    "keybind-example-mango": "Mango example: bind=SUPER,F1,spawn_shell,noctalia-shell ipc call plugin:keybind-cheatsheet toggle"
   },
   "barwidget": {
     "tooltip": "Aide-mémoire des raccourcis",

--- a/keybind-cheatsheet/i18n/hn.json
+++ b/keybind-cheatsheet/i18n/hn.json
@@ -19,7 +19,8 @@
     "workspace-switching": "कार्यक्षेत्र - स्विच करना",
     "workspace-moving": "कार्यक्षेत्र - स्थानांतरण",
     "workspace-mouse": "कार्यक्षेत्र - माउस",
-    "search-placeholder": "कीबाइंड खोजें..."
+    "search-placeholder": "कीबाइंड खोजें...",
+    "title-mango": "MangoWC Keymap"
   },
   "settings": {
     "title": "कीबाइंड चीटशीट सेटिंग्स",
@@ -51,7 +52,10 @@
     "width-range": "px (400-3000)",
     "height-range": "px (300-2000)",
     "hyprland-path": "Hyprland पथ",
-    "niri-path": "Niri पथ"
+    "niri-path": "Niri पथ",
+    "mango-path": "Mango Path",
+    "mango-format-hint": "Expected format: bind=MODS,KEY,ACTION,ARGS\nCategories: # Category Name (horizontal rules stripped)\nOptional per-bind description: trailing #\"description\"",
+    "keybind-example-mango": "Mango example: bind=SUPER,F1,spawn_shell,noctalia-shell ipc call plugin:keybind-cheatsheet toggle"
   },
   "barwidget": {
     "tooltip": "कीबाइंड चीटशीट",

--- a/keybind-cheatsheet/i18n/hu.json
+++ b/keybind-cheatsheet/i18n/hu.json
@@ -19,7 +19,8 @@
     "workspace-switching": "MUNKATERÜLETEK - VÁLTÁS",
     "workspace-moving": "MUNKATERÜLETEK - ÁTHELYEZÉS",
     "workspace-mouse": "MUNKATERÜLETEK - EGÉR",
-    "search-placeholder": "Billentyűparancsok keresése..."
+    "search-placeholder": "Billentyűparancsok keresése...",
+    "title-mango": "MangoWC Keymap"
   },
   "settings": {
     "title": "Billentyuparancsok Beallitasai",
@@ -51,7 +52,10 @@
     "width-range": "px (400-3000)",
     "height-range": "px (300-2000)",
     "hyprland-path": "Hyprland útvonal",
-    "niri-path": "Niri útvonal"
+    "niri-path": "Niri útvonal",
+    "mango-path": "Mango Path",
+    "mango-format-hint": "Expected format: bind=MODS,KEY,ACTION,ARGS\nCategories: # Category Name (horizontal rules stripped)\nOptional per-bind description: trailing #\"description\"",
+    "keybind-example-mango": "Mango example: bind=SUPER,F1,spawn_shell,noctalia-shell ipc call plugin:keybind-cheatsheet toggle"
   },
   "barwidget": {
     "tooltip": "Billentyűparancs súgó",

--- a/keybind-cheatsheet/i18n/it.json
+++ b/keybind-cheatsheet/i18n/it.json
@@ -19,7 +19,8 @@
     "workspace-switching": "SPAZI DI LAVORO - CAMBIO",
     "workspace-moving": "SPAZI DI LAVORO - SPOSTAMENTO",
     "workspace-mouse": "SPAZI DI LAVORO - MOUSE",
-    "search-placeholder": "Cerca scorciatoie..."
+    "search-placeholder": "Cerca scorciatoie...",
+    "title-mango": "MangoWC Keymap"
   },
   "settings": {
     "title": "Impostazioni Scorciatoie da Tastiera",
@@ -51,7 +52,10 @@
     "width-range": "px (400-3000)",
     "height-range": "px (300-2000)",
     "hyprland-path": "Percorso Hyprland",
-    "niri-path": "Percorso Niri"
+    "niri-path": "Percorso Niri",
+    "mango-path": "Mango Path",
+    "mango-format-hint": "Expected format: bind=MODS,KEY,ACTION,ARGS\nCategories: # Category Name (horizontal rules stripped)\nOptional per-bind description: trailing #\"description\"",
+    "keybind-example-mango": "Mango example: bind=SUPER,F1,spawn_shell,noctalia-shell ipc call plugin:keybind-cheatsheet toggle"
   },
   "barwidget": {
     "tooltip": "Scheda scorciatoie",

--- a/keybind-cheatsheet/i18n/ja.json
+++ b/keybind-cheatsheet/i18n/ja.json
@@ -19,7 +19,8 @@
     "workspace-switching": "ワークスペース - 切り替え",
     "workspace-moving": "ワークスペース - 移動",
     "workspace-mouse": "ワークスペース - マウス",
-    "search-placeholder": "キーバインドを検索..."
+    "search-placeholder": "キーバインドを検索...",
+    "title-mango": "MangoWC Keymap"
   },
   "settings": {
     "title": "キーバインド一覧の設定",
@@ -51,7 +52,10 @@
     "width-range": "px (400-3000)",
     "height-range": "px (300-2000)",
     "hyprland-path": "Hyprland パス",
-    "niri-path": "Niri パス"
+    "niri-path": "Niri パス",
+    "mango-path": "Mango Path",
+    "mango-format-hint": "Expected format: bind=MODS,KEY,ACTION,ARGS\nCategories: # Category Name (horizontal rules stripped)\nOptional per-bind description: trailing #\"description\"",
+    "keybind-example-mango": "Mango example: bind=SUPER,F1,spawn_shell,noctalia-shell ipc call plugin:keybind-cheatsheet toggle"
   },
   "barwidget": {
     "tooltip": "キーバインドチートシート",

--- a/keybind-cheatsheet/i18n/ko-KR.json
+++ b/keybind-cheatsheet/i18n/ko-KR.json
@@ -19,7 +19,8 @@
     "workspace-switching": "작업공간 - 전환",
     "workspace-moving": "작업공간 - 이동",
     "workspace-mouse": "작업공간 - 마우스",
-    "search-placeholder": "단축키 검색..."
+    "search-placeholder": "단축키 검색...",
+    "title-mango": "MangoWC Keymap"
   },
   "settings": {
     "title": "키바인드 치트시트 설정",
@@ -51,7 +52,10 @@
     "width-range": "px (400-3000)",
     "height-range": "px (300-2000)",
     "hyprland-path": "Hyprland 경로",
-    "niri-path": "Niri 경로"
+    "niri-path": "Niri 경로",
+    "mango-path": "Mango Path",
+    "mango-format-hint": "Expected format: bind=MODS,KEY,ACTION,ARGS\nCategories: # Category Name (horizontal rules stripped)\nOptional per-bind description: trailing #\"description\"",
+    "keybind-example-mango": "Mango example: bind=SUPER,F1,spawn_shell,noctalia-shell ipc call plugin:keybind-cheatsheet toggle"
   },
   "barwidget": {
     "tooltip": "키바인드 치트시트",

--- a/keybind-cheatsheet/i18n/ku.json
+++ b/keybind-cheatsheet/i18n/ku.json
@@ -19,7 +19,8 @@
     "workspace-switching": "QADÊN XEBATÊ - GUHEZTIN",
     "workspace-moving": "QADÊN XEBATÊ - VEGUHESTIN",
     "workspace-mouse": "QADÊN XEBATÊ - MIŞK",
-    "search-placeholder": "Bişkokan lêbigere..."
+    "search-placeholder": "Bişkokan lêbigere...",
+    "title-mango": "MangoWC Keymap"
   },
   "settings": {
     "title": "Mîhengên Kurterêyên Klavyeyê",
@@ -51,7 +52,10 @@
     "width-range": "px (400-3000)",
     "height-range": "px (300-2000)",
     "hyprland-path": "Rêça Hyprland",
-    "niri-path": "Rêça Niri"
+    "niri-path": "Rêça Niri",
+    "mango-path": "Mango Path",
+    "mango-format-hint": "Expected format: bind=MODS,KEY,ACTION,ARGS\nCategories: # Category Name (horizontal rules stripped)\nOptional per-bind description: trailing #\"description\"",
+    "keybind-example-mango": "Mango example: bind=SUPER,F1,spawn_shell,noctalia-shell ipc call plugin:keybind-cheatsheet toggle"
   },
   "barwidget": {
     "tooltip": "Çavkaniya Kurterêyan",

--- a/keybind-cheatsheet/i18n/nl.json
+++ b/keybind-cheatsheet/i18n/nl.json
@@ -19,7 +19,8 @@
     "workspace-switching": "WERKRUIMTEN - WISSELEN",
     "workspace-moving": "WERKRUIMTEN - VERPLAATSEN",
     "workspace-mouse": "WERKRUIMTEN - MUIS",
-    "search-placeholder": "Sneltoetsen zoeken..."
+    "search-placeholder": "Sneltoetsen zoeken...",
+    "title-mango": "MangoWC Keymap"
   },
   "settings": {
     "title": "Sneltoetsen Overzicht Instellingen",
@@ -51,7 +52,10 @@
     "width-range": "px (400-3000)",
     "height-range": "px (300-2000)",
     "hyprland-path": "Hyprland pad",
-    "niri-path": "Niri pad"
+    "niri-path": "Niri pad",
+    "mango-path": "Mango Path",
+    "mango-format-hint": "Expected format: bind=MODS,KEY,ACTION,ARGS\nCategories: # Category Name (horizontal rules stripped)\nOptional per-bind description: trailing #\"description\"",
+    "keybind-example-mango": "Mango example: bind=SUPER,F1,spawn_shell,noctalia-shell ipc call plugin:keybind-cheatsheet toggle"
   },
   "barwidget": {
     "tooltip": "Sneltoetsen Spiekbriefje",

--- a/keybind-cheatsheet/i18n/nn-NO.json
+++ b/keybind-cheatsheet/i18n/nn-NO.json
@@ -19,7 +19,8 @@
     "workspace-switching": "ARBEIDSOMRÅDE - BYTTE",
     "workspace-moving": "ARBEIDSOMRÅDE - FLYTTE",
     "workspace-mouse": "ARBEIDSOMRÅDE - MUS",
-    "search-placeholder": "Søk etter snarveiar..."
+    "search-placeholder": "Søk etter snarveiar...",
+    "title-mango": "MangoWC Keymap"
   },
   "settings": {
     "title": "Tastesnarveg-jukselapp Innstillingar",
@@ -51,7 +52,10 @@
     "width-range": "px (400-3000)",
     "height-range": "px (300-2000)",
     "hyprland-path": "Hyprland-sti",
-    "niri-path": "Niri-sti"
+    "niri-path": "Niri-sti",
+    "mango-path": "Mango Path",
+    "mango-format-hint": "Expected format: bind=MODS,KEY,ACTION,ARGS\nCategories: # Category Name (horizontal rules stripped)\nOptional per-bind description: trailing #\"description\"",
+    "keybind-example-mango": "Mango example: bind=SUPER,F1,spawn_shell,noctalia-shell ipc call plugin:keybind-cheatsheet toggle"
   },
   "barwidget": {
     "tooltip": "Tastesnarveg-jukselapp",

--- a/keybind-cheatsheet/i18n/pl.json
+++ b/keybind-cheatsheet/i18n/pl.json
@@ -19,7 +19,8 @@
     "workspace-switching": "OBSZARY ROBOCZE - PRZEŁĄCZANIE",
     "workspace-moving": "OBSZARY ROBOCZE - PRZENOSZENIE",
     "workspace-mouse": "OBSZARY ROBOCZE - MYSZ",
-    "search-placeholder": "Szukaj skrótów..."
+    "search-placeholder": "Szukaj skrótów...",
+    "title-mango": "MangoWC Keymap"
   },
   "settings": {
     "title": "Ustawienia Skrotow Klawiszowych",
@@ -51,7 +52,10 @@
     "width-range": "px (400-3000)",
     "height-range": "px (300-2000)",
     "hyprland-path": "Ścieżka Hyprland",
-    "niri-path": "Ścieżka Niri"
+    "niri-path": "Ścieżka Niri",
+    "mango-path": "Mango Path",
+    "mango-format-hint": "Expected format: bind=MODS,KEY,ACTION,ARGS\nCategories: # Category Name (horizontal rules stripped)\nOptional per-bind description: trailing #\"description\"",
+    "keybind-example-mango": "Mango example: bind=SUPER,F1,spawn_shell,noctalia-shell ipc call plugin:keybind-cheatsheet toggle"
   },
   "barwidget": {
     "tooltip": "Ściągawka skrótów klawiszowych",

--- a/keybind-cheatsheet/i18n/pt.json
+++ b/keybind-cheatsheet/i18n/pt.json
@@ -19,7 +19,8 @@
     "workspace-switching": "ESPAÇOS DE TRABALHO - ALTERNAR",
     "workspace-moving": "ESPAÇOS DE TRABALHO - MOVER",
     "workspace-mouse": "ESPAÇOS DE TRABALHO - MOUSE",
-    "search-placeholder": "Pesquisar atalhos..."
+    "search-placeholder": "Pesquisar atalhos...",
+    "title-mango": "MangoWC Keymap"
   },
   "settings": {
     "title": "Configuracoes de Atalhos de Teclado",
@@ -51,7 +52,10 @@
     "width-range": "px (400-3000)",
     "height-range": "px (300-2000)",
     "hyprland-path": "Caminho Hyprland",
-    "niri-path": "Caminho Niri"
+    "niri-path": "Caminho Niri",
+    "mango-path": "Mango Path",
+    "mango-format-hint": "Expected format: bind=MODS,KEY,ACTION,ARGS\nCategories: # Category Name (horizontal rules stripped)\nOptional per-bind description: trailing #\"description\"",
+    "keybind-example-mango": "Mango example: bind=SUPER,F1,spawn_shell,noctalia-shell ipc call plugin:keybind-cheatsheet toggle"
   },
   "barwidget": {
     "tooltip": "Folha de dicas de atalhos",

--- a/keybind-cheatsheet/i18n/ru.json
+++ b/keybind-cheatsheet/i18n/ru.json
@@ -19,7 +19,8 @@
     "workspace-switching": "РАБОЧИЕ ОБЛАСТИ - ПЕРЕКЛЮЧЕНИЕ",
     "workspace-moving": "РАБОЧИЕ ОБЛАСТИ - ПЕРЕМЕЩЕНИЕ",
     "workspace-mouse": "РАБОЧИЕ ОБЛАСТИ - МЫШЬ",
-    "search-placeholder": "Поиск сочетаний клавиш..."
+    "search-placeholder": "Поиск сочетаний клавиш...",
+    "title-mango": "MangoWC Keymap"
   },
   "settings": {
     "title": "Настройки горячих клавиш",
@@ -51,7 +52,10 @@
     "width-range": "px (400-3000)",
     "height-range": "px (300-2000)",
     "hyprland-path": "Путь Hyprland",
-    "niri-path": "Путь Niri"
+    "niri-path": "Путь Niri",
+    "mango-path": "Mango Path",
+    "mango-format-hint": "Expected format: bind=MODS,KEY,ACTION,ARGS\nCategories: # Category Name (horizontal rules stripped)\nOptional per-bind description: trailing #\"description\"",
+    "keybind-example-mango": "Mango example: bind=SUPER,F1,spawn_shell,noctalia-shell ipc call plugin:keybind-cheatsheet toggle"
   },
   "barwidget": {
     "tooltip": "Шпаргалка горячих клавиш",

--- a/keybind-cheatsheet/i18n/sv.json
+++ b/keybind-cheatsheet/i18n/sv.json
@@ -19,7 +19,8 @@
     "workspace-switching": "ARBETSYTOR - BYTA",
     "workspace-moving": "ARBETSYTOR - FLYTTA",
     "workspace-mouse": "ARBETSYTOR - MUS",
-    "search-placeholder": "Sök tangentbindningar..."
+    "search-placeholder": "Sök tangentbindningar...",
+    "title-mango": "MangoWC Keymap"
   },
   "settings": {
     "title": "Tangentbordsgenvägar Inställningar",
@@ -51,7 +52,10 @@
     "width-range": "px (400-3000)",
     "height-range": "px (300-2000)",
     "hyprland-path": "Hyprland-sökväg",
-    "niri-path": "Niri-sökväg"
+    "niri-path": "Niri-sökväg",
+    "mango-path": "Mango Path",
+    "mango-format-hint": "Expected format: bind=MODS,KEY,ACTION,ARGS\nCategories: # Category Name (horizontal rules stripped)\nOptional per-bind description: trailing #\"description\"",
+    "keybind-example-mango": "Mango example: bind=SUPER,F1,spawn_shell,noctalia-shell ipc call plugin:keybind-cheatsheet toggle"
   },
   "barwidget": {
     "tooltip": "Tangentbordsgenvägar",

--- a/keybind-cheatsheet/i18n/tr.json
+++ b/keybind-cheatsheet/i18n/tr.json
@@ -19,7 +19,8 @@
     "workspace-switching": "ÇALIŞMA ALANLARI - GEÇİŞ",
     "workspace-moving": "ÇALIŞMA ALANLARI - TAŞIMA",
     "workspace-mouse": "ÇALIŞMA ALANLARI - FARE",
-    "search-placeholder": "Kısayol ara..."
+    "search-placeholder": "Kısayol ara...",
+    "title-mango": "MangoWC Keymap"
   },
   "settings": {
     "title": "Klavye Kisayollari Ayarlari",
@@ -51,7 +52,10 @@
     "width-range": "px (400-3000)",
     "height-range": "px (300-2000)",
     "hyprland-path": "Hyprland yolu",
-    "niri-path": "Niri yolu"
+    "niri-path": "Niri yolu",
+    "mango-path": "Mango Path",
+    "mango-format-hint": "Expected format: bind=MODS,KEY,ACTION,ARGS\nCategories: # Category Name (horizontal rules stripped)\nOptional per-bind description: trailing #\"description\"",
+    "keybind-example-mango": "Mango example: bind=SUPER,F1,spawn_shell,noctalia-shell ipc call plugin:keybind-cheatsheet toggle"
   },
   "barwidget": {
     "tooltip": "Kısayol Kopya Kağıdı",

--- a/keybind-cheatsheet/i18n/uk-UA.json
+++ b/keybind-cheatsheet/i18n/uk-UA.json
@@ -19,7 +19,8 @@
     "workspace-switching": "РОБОЧІ ОБЛАСТІ - ПЕРЕМИКАННЯ",
     "workspace-moving": "РОБОЧІ ОБЛАСТІ - ПЕРЕМІЩЕННЯ",
     "workspace-mouse": "РОБОЧІ ОБЛАСТІ - МИША",
-    "search-placeholder": "Пошук сполучень клавіш..."
+    "search-placeholder": "Пошук сполучень клавіш...",
+    "title-mango": "MangoWC Keymap"
   },
   "settings": {
     "title": "Налаштування гарячих клавіш",
@@ -51,7 +52,10 @@
     "width-range": "px (400-3000)",
     "height-range": "px (300-2000)",
     "hyprland-path": "Шлях Hyprland",
-    "niri-path": "Шлях Niri"
+    "niri-path": "Шлях Niri",
+    "mango-path": "Mango Path",
+    "mango-format-hint": "Expected format: bind=MODS,KEY,ACTION,ARGS\nCategories: # Category Name (horizontal rules stripped)\nOptional per-bind description: trailing #\"description\"",
+    "keybind-example-mango": "Mango example: bind=SUPER,F1,spawn_shell,noctalia-shell ipc call plugin:keybind-cheatsheet toggle"
   },
   "barwidget": {
     "tooltip": "Шпаргалка гарячих клавіш",

--- a/keybind-cheatsheet/i18n/zh-CN.json
+++ b/keybind-cheatsheet/i18n/zh-CN.json
@@ -19,7 +19,8 @@
     "workspace-switching": "工作区 - 切换",
     "workspace-moving": "工作区 - 移动",
     "workspace-mouse": "工作区 - 鼠标",
-    "search-placeholder": "搜索按键绑定..."
+    "search-placeholder": "搜索按键绑定...",
+    "title-mango": "MangoWC Keymap"
   },
   "settings": {
     "title": "快捷键速查表设置",
@@ -51,7 +52,10 @@
     "width-range": "px (400-3000)",
     "height-range": "px (300-2000)",
     "hyprland-path": "Hyprland 路径",
-    "niri-path": "Niri 路径"
+    "niri-path": "Niri 路径",
+    "mango-path": "Mango Path",
+    "mango-format-hint": "Expected format: bind=MODS,KEY,ACTION,ARGS\nCategories: # Category Name (horizontal rules stripped)\nOptional per-bind description: trailing #\"description\"",
+    "keybind-example-mango": "Mango example: bind=SUPER,F1,spawn_shell,noctalia-shell ipc call plugin:keybind-cheatsheet toggle"
   },
   "barwidget": {
     "tooltip": "快捷键速查表",

--- a/keybind-cheatsheet/i18n/zh-TW.json
+++ b/keybind-cheatsheet/i18n/zh-TW.json
@@ -19,7 +19,8 @@
     "workspace-switching": "工作區 - 切換",
     "workspace-moving": "工作區 - 移動",
     "workspace-mouse": "工作區 - 滑鼠",
-    "search-placeholder": "搜尋按鍵綁定..."
+    "search-placeholder": "搜尋按鍵綁定...",
+    "title-mango": "MangoWC Keymap"
   },
   "settings": {
     "title": "快捷鍵速查表設定",
@@ -51,7 +52,10 @@
     "width-range": "px (400-3000)",
     "height-range": "px (300-2000)",
     "hyprland-path": "Hyprland 路徑",
-    "niri-path": "Niri 路徑"
+    "niri-path": "Niri 路徑",
+    "mango-path": "Mango Path",
+    "mango-format-hint": "Expected format: bind=MODS,KEY,ACTION,ARGS\nCategories: # Category Name (horizontal rules stripped)\nOptional per-bind description: trailing #\"description\"",
+    "keybind-example-mango": "Mango example: bind=SUPER,F1,spawn_shell,noctalia-shell ipc call plugin:keybind-cheatsheet toggle"
   },
   "barwidget": {
     "tooltip": "快捷鍵速查表",

--- a/keybind-cheatsheet/manifest.json
+++ b/keybind-cheatsheet/manifest.json
@@ -6,7 +6,7 @@
   "author": "blacku",
   "license": "MIT",
   "repository": "https://github.com/noctalia-dev/noctalia-plugins",
-  "description": "Universal keyboard shortcuts keymap that automatically detects and displays keybindings for Hyprland or Niri compositors.",
+  "description": "Universal keyboard shortcuts keymap that automatically detects and displays keybindings for Hyprland, Niri, or MangoWC compositors.",
   "tags": ["Bar", "Panel", "System", "Indicator"],
   "entryPoints": {
     "main": "Main.qml",
@@ -27,7 +27,8 @@
       "columnCount": 3,
       "modKeyVariable": "$mod",
       "hyprlandConfigPath": "~/.config/hypr/hyprland.conf",
-      "niriConfigPath": "~/.config/niri/config.kdl"
+      "niriConfigPath": "~/.config/niri/config.kdl",
+      "mangoConfigPath": "~/.config/mango/config.conf"
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds a MangoWC parser to the keybind-cheatsheet plugin alongside the existing Hyprland and Niri parsers.

- Parses `~/.config/mango/config.conf`, follows `source=` and `source-optional=` includes recursively (glob patterns supported).
- Handles `bind=`, `axisbind=`, and `mousebind=` directives.
- Auto-formats common actions (`killclient`, `focusdir`, `view`, `tag`, `exchange_client`, `focusmon`, `tagmon`, `set_proportion`, `moveresize`, `toggleoverview`, `quit`, `switch_proportion_preset`).
- Translates mouse button names (`btn_left`, `btn_side`, ...) and axis directions (`UP`/`DOWN`/`LEFT`/`RIGHT` under `axisbind=`).
- `code:NN` keycodes are kept verbatim.
- Maps Noctalia IPC calls via `spawn_shell` to friendly labels, including `plugin:<name>` targets.
- New `mangoConfigPath` setting with a Mango Path field in the Settings UI.
- Panel title picks up `MangoWC Keymap` when `CompositorService.isMango`. The shell already sets that when `XDG_CURRENT_DESKTOP=mango`.
- `title-mango`, `mango-path`, `mango-format-hint`, `keybind-example-mango` keys added to all 20 locale files. English is used as the value for non-English locales as a placeholder; native-speaker follow-up translations welcome.
- Mango formatters read lookup tables from module-level `readonly property var` constants to avoid per-bind allocation.
- Category detection rules documented in the README (length cap, paren/arrow filters, orphan-heading discard).

The Hyprland and Niri parsers are not modified. No regressions expected for existing users.

Version bump, CHANGELOG entry, and related i18n-string cleanups (for example the obsolete `error.mango-not-supported` keys) are left to the maintainer to handle at merge time.

## Test plan

- [x] Plugin loads under MangoWC, `CompositorService.isMango` fires, parser populates `pluginSettings.cheatsheetData`.
- [x] Panel opens and renders categories under `MangoWC Keymap`.
- [x] Category / bind breakdown matches the source `config.conf`.
- [x] `mousebind=` entries show their mouse-button label; `axisbind=` entries show their scroll direction.
- [x] A `Super+F1` bind to `spawn_shell,noctalia-shell ipc call plugin:keybind-cheatsheet toggle` renders as `Keybind Cheatsheet: Toggle`.
- [x] Hyprland and Niri configs parse unchanged.
