### PR TITLE
fix(screen-toolkit): consistent styling for screen toolkit control center widget

### DIFF
--- a/hassio/manifest.json
+++ b/hassio/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "hassio",
   "name": "Home Assistant",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "minNoctaliaVersion": "3.6.0",
   "author": "Pozzoo",
   "license": "MIT",

--- a/hassio/manifest.json
+++ b/hassio/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "hassio",
   "name": "Home Assistant",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "minNoctaliaVersion": "3.6.0",
   "author": "Pozzoo",
   "license": "MIT",

--- a/screen-toolkit/ControlCenterWidget.qml
+++ b/screen-toolkit/ControlCenterWidget.qml
@@ -1,46 +1,25 @@
 import QtQuick
-import QtQuick.Layouts
 import Quickshell
 import qs.Commons
 import qs.Widgets
 import qs.Services.UI
-Item {
+
+NIconButtonHot {
     id: root
+
     property var pluginApi: null
     property ShellScreen screen
     property string widgetId: ""
     property string section: ""
+
     readonly property string screenName: screen?.name ?? ""
-    readonly property real capsuleHeight: Style.getCapsuleHeightForScreen(screenName)
-    readonly property real contentWidth: capsuleHeight
-    readonly property real contentHeight: capsuleHeight
-    implicitWidth: contentWidth
-    implicitHeight: contentHeight
-    Rectangle {
-        id: visualCapsule
-        x: Style.pixelAlignCenter(parent.width, width)
-        y: Style.pixelAlignCenter(parent.height, height)
-        width: root.contentWidth
-        height: root.contentHeight
-        color: mouseArea.containsMouse ? Color.mHover : Style.capsuleColor
-        radius: Style.radiusL
-        border.color: Style.capsuleBorderColor
-        border.width: Style.capsuleBorderWidth
-        NIcon {
-            anchors.centerIn: parent
-            icon: "crosshair"
-            color: Color.mPrimary
-        }
-    }
-    MouseArea {
-        id: mouseArea
-        anchors.fill: parent
-        hoverEnabled: true
-        cursorShape: Qt.PointingHandCursor
-        onEntered: TooltipService.show(root, "Screen Toolkit", BarService.getTooltipDirection())
-        onExited: TooltipService.hide()
-        onClicked: {
-            if (pluginApi) pluginApi.togglePanel(root.screen, root)
+
+    icon: "crosshair"
+    tooltipText: "Screen Toolkit"
+
+    onClicked: {
+        if (pluginApi) {
+            pluginApi.togglePanel(screen, root);
         }
     }
 }

--- a/screen-toolkit/manifest.json
+++ b/screen-toolkit/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "screen-toolkit",
   "name": "Screen Toolkit",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "minNoctaliaVersion": "4.5.0",
   "author": "ycf-anon",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Changes `ControlCenterWidget.qml` to use NIconButtonHot for consistent styling
- Fixes bad contrast between hover color and accent

## Testing

- [x] Plugin loads and runs with `qs -c noctalia-shell`
- [x] Works with both light and dark themes
- [x] Uses N* widgets, not raw Qt types