### PR TITLE
fix(screen-shot-and-record): Remove the getaudiooutput

### DIFF
--- a/screen-shot-and-record/manifest.json
+++ b/screen-shot-and-record/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "screen-shot-and-record",
   "name": "ScreenShot & Record",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "minNoctaliaVersion": "3.6.0",
   "author": "Pulsar",
   "license": "GPL-3.0-or-later",

--- a/screen-shot-and-record/record.sh
+++ b/screen-shot-and-record/record.sh
@@ -20,9 +20,6 @@ RECORDING_DIR="$HOME/Videos"
 getdate() {
     date '+%Y-%m-%d_%H.%M.%S'
 }
-getaudiooutput() {
-    pactl list sources | grep 'Name' | grep 'monitor' | cut -d ' ' -f2
-}
 
 # parse --region <value> without modifying $@ so other flags like --fullscreen still work
 ARGS=("$@")
@@ -134,7 +131,7 @@ else
         fi
     fi
     if [[ $SOUND_FLAG -eq 1 ]]; then
-        wf-recorder --pixel-format yuv420p -f './recording_'"$(getdate)"'.mp4' -t --geometry "$MANUAL_REGION" "${FILTER_ARGS[@]}" --audio="$(getaudiooutput)"
+        wf-recorder --pixel-format yuv420p -f './recording_'"$(getdate)"'.mp4' -t --geometry "$MANUAL_REGION" "${FILTER_ARGS[@]}" --audio"
     else
         wf-recorder --pixel-format yuv420p -f './recording_'"$(getdate)"'.mp4' -t --geometry "$MANUAL_REGION" "${FILTER_ARGS[@]}"
     fi


### PR DESCRIPTION
remove var in argument --audio="$(getaudiooutput)" with --audio
remove the whole function getaudiooutput() since it is no longer needed, wf-recorder selects the default PipeWire source automatically 
As per https://github.com/noctalia-dev/noctalia-plugins/discussions/737
