### PR TITLE
i18n(cookie-clock): update French translations

### DIFF
--- a/cookie-clock/i18n/fr.json
+++ b/cookie-clock/i18n/fr.json
@@ -1,0 +1,41 @@
+{
+  "desktopWidgetSettings": {
+    "dial-style-label": "Style des repères du cadran",
+    "dial-style-description": "Style des marqueurs d'heures et de minutes",
+    "style-dots": "Points",
+    "style-numbers": "Nombres",
+    "style-full": "Lignes complètes",
+    "style-none": "Aucun",
+    
+    "hour-hand-label": "Style de l'aiguille des heures",
+    "hour-hand-description": "Style visuel de l'aiguille des heures",
+    "style-fill": "Pleine",
+    "style-hollow": "Creuse",
+    "style-classic": "Classique",
+    "style-hide": "Masquer",
+
+    "minute-hand-label": "Style de l'aiguille des minutes",
+    "minute-hand-description": "Style visuel de l'aiguille des minutes",
+    "style-bold": "Grasse",
+    "style-medium": "Moyenne",
+    "style-thin": "Fine",
+
+    "second-hand-label": "Style de la trotteuse",
+    "second-hand-description": "Style visuel de la trotteuse",
+    "style-dot": "Point",
+    "style-line": "Ligne",
+
+    "date-style-label": "Style de la date",
+    "date-style-description": "Comment afficher la date actuelle",
+    "style-bubble": "Bulles",
+    "style-rect": "Rectangle",
+
+    "show-hour-marks-label": "Afficher les repères d'heures internes",
+    "show-hour-marks-description": "Afficher un ensemble interne de repères d'heures",
+
+    "cookie-shape-label": "Coins de la forme du biscuit",
+    "cookie-shape-description": "Nombre de bords en forme d'onde sinusoïdale",
+    "background-opacity-label": "Opacité de l'arrière-plan",
+    "background-opacity-description": "Ajuster la transparence de la forme du biscuit"
+  }
+}

--- a/cookie-clock/manifest.json
+++ b/cookie-clock/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "cookie-clock",
     "name": "Cookie Clock",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "minNoctaliaVersion": "3.6.0",
     "author": "elrondforwin",
     "license": "GPLv3",


### PR DESCRIPTION
This pull request introduces French localization support for the Cookie Clock widget and updates the extension version. The most significant changes are the addition of a French translation file and a version bump in the manifest.

Localization:

* Added a new `fr.json` file with French translations for cookie-clock widget settings.

Version update:

* Bumped the extension version from `1.0.0` to `1.0.1` in manifest.json.