### PR TITLE
fix(workspace-overview): scale workspace window with display scale

### DIFF
--- a/workspace-overview/Panel.qml
+++ b/workspace-overview/Panel.qml
@@ -191,12 +191,14 @@ Item {
                                         opacity: 0.8
                                     }
                                     
-                                    // Actual dimensions and positions come from the workspace monitor
+                                    // Actual dimensions and positions come from the workspace monitor.
+                                    // Use monitor scale to convert from physical to logical pixels.
                                     property var wsMonitor: modelData.monitor || null
                                     property real monitorX: wsMonitor ? wsMonitor.x : 0
                                     property real monitorY: wsMonitor ? wsMonitor.y : 0
-                                    property real monitorW: wsMonitor && wsMonitor.width > 0 ? wsMonitor.width : 1920
-                                    property real monitorH: wsMonitor && wsMonitor.height > 0 ? wsMonitor.height : 1080
+                                    property real monitorScale: wsMonitor && wsMonitor.scale > 0 ? wsMonitor.scale : 1.0
+                                    property real monitorW: (wsMonitor && wsMonitor.width > 0 ? wsMonitor.width : 1920) / monitorScale
+                                    property real monitorH: (wsMonitor && wsMonitor.height > 0 ? wsMonitor.height : 1080) / monitorScale
                                     property real scaleX: width / monitorW
                                     property real scaleY: height / monitorH
 

--- a/workspace-overview/manifest.json
+++ b/workspace-overview/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "workspace-overview",
   "name": "Workspace Overview for Hyprland",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "minNoctaliaVersion": "3.6.0",
   "author": "doughbran",
   "license": "MIT",


### PR DESCRIPTION
Use display scale to modify monitor dimensions for displayed workspace.
Otherwise the windows were rendered too small and towards the top-left of each workspace tile.