### PR TITLE
i18n(battery-threshold): update French translations

### DIFF
--- a/battery-threshold/Panel.qml
+++ b/battery-threshold/Panel.qml
@@ -51,7 +51,7 @@ Item {
                 spacing: 2
 
                 NText {
-                    text: "Battery Threshold"
+                    text: pluginApi?.tr("panel.title")
                     pointSize: Style.fontSizeL
                     font.weight: Font.DemiBold
                     color: Color.mOnSurface
@@ -59,7 +59,7 @@ Item {
 
                 NText {
                     visible: !service.isAvailable || root.batteryModelName !== ""
-                    text: !service.isAvailable ? "Not available on this system" : root.batteryModelName
+                    text: !service.isAvailable ? pluginApi?.tr("panel.not-available") : root.batteryModelName
                     pointSize: Style.fontSizeM
                     color: Color.mOnSurfaceVariant
                 }
@@ -82,7 +82,7 @@ Item {
                     Layout.fillWidth: true
 
                     NText {
-                        text: "Battery Threshold"
+                        text: pluginApi?.tr("panel.title")
                         pointSize: Style.fontSizeM
                         color: Color.mOnSurface
                         Layout.fillWidth: true
@@ -126,7 +126,7 @@ Item {
 
                 NText {
                     Layout.fillWidth: true
-                    text: service.isWritable ? "Drag slider to adjust limit" : "Read-only: Install udev rule for write access"
+                    text: service.isWritable ? pluginApi?.tr("panel.adjust-limit") : pluginApi?.tr("panel.read-only")
                     pointSize: Style.fontSizeXS
                     color: service.isWritable ? Color.mOnSurfaceVariant : Color.mTertiary
                     horizontalAlignment: Text.AlignHCenter

--- a/battery-threshold/Settings.qml
+++ b/battery-threshold/Settings.qml
@@ -16,7 +16,7 @@ ColumnLayout {
 
     NText {
         visible: !service.isAvailable
-        text: pluginApi?.tr("settings.no-battery-device") || "No configurable batteries are available on this system"
+        text: pluginApi?.tr("settings.no-battery-device")
         pointSize: Style.fontSizeM
         color: Color.mOnSurfaceVariant
     }
@@ -24,8 +24,8 @@ ColumnLayout {
     NComboBox {
         Layout.fillWidth: true
         visible: service.isAvailable
-        label: pluginApi?.tr("settings.battery-device") || "Battery Device"
-        description: pluginApi?.tr("settings.battery-device-desc") || "Battery to configure threshold for"
+        label: pluginApi?.tr("settings.battery-device")
+        description: pluginApi?.tr("settings.battery-device-desc")
 
         model: service.batteries.map(path => ({
                     key: path,

--- a/battery-threshold/i18n/en.json
+++ b/battery-threshold/i18n/en.json
@@ -6,5 +6,11 @@
   },
   "actions": {
     "widget-settings": "Widget Settings"
+  },
+  "panel": {
+    "title": "Battery Threshold",
+    "not-available": "Not available on this system",
+    "adjust-limit": "Drag slider to adjust limit",
+    "read-only": "Read-only: Install udev rule for write access"
   }
 }

--- a/battery-threshold/i18n/fr.json
+++ b/battery-threshold/i18n/fr.json
@@ -1,0 +1,16 @@
+{
+  "settings": {
+    "battery-device": "Appareil de batterie",
+    "battery-device-desc": "Batterie pour laquelle configurer le seuil",
+    "no-battery-device": "Aucune batterie configurable n'est disponible sur ce système"
+  },
+  "actions": {
+    "widget-settings": "Paramètres du widget"
+  },
+  "panel": {
+    "title": "Seuil de batterie",
+    "not-available": "Non disponible sur ce système",
+    "adjust-limit": "Faites glisser pour ajuster la limite",
+    "read-only": "Lecture seule : installez la règle udev pour l'accès en écriture"
+  }
+}

--- a/battery-threshold/manifest.json
+++ b/battery-threshold/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "battery-threshold",
   "name": "Battery Threshold Control",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "minNoctaliaVersion": "3.6.0",
   "author": "Wilfred Mallawa",
   "license": "MIT",


### PR DESCRIPTION
This pull request introduces French localization support for the Battery Threshold Control widget and updates the extension version. The most significant changes are the addition of a French translation file and a version bump in the manifest.

Localization:

* Added a new `fr.json` file with French translations for settings and panel strings.
* Updated `Panel.qml` to use translatable strings.
* Updated `en.json` with missing panel strings.

Version update:

* Bumped the extension version from 1.2.2 to 1.2.3 in manifest.json.