### PR TITLE
i18n(calibre-provider): update French translations

### DIFF
--- a/calibre-provider/i18n/fr.json
+++ b/calibre-provider/i18n/fr.json
@@ -1,0 +1,16 @@
+{
+    "settings": {
+        "launcher": {
+            "title": "Lanceur",
+            "description": "Le programme utilisé pour ouvrir les fichiers de livres"
+        },
+        "forcegrid": {
+            "label": "Forcer la vue en grille",
+            "description": "Toujours utiliser la vue en grille pour afficher les résultats. Si désactivé, utilise la configuration actuelle du lanceur"
+        },
+        "recentlyOpened": {
+            "label": "Nombre d'entrées récemment ouvertes",
+            "description": "Nombre d'entrées récemment ouvertes à mémoriser"
+        }
+    }
+}

--- a/calibre-provider/manifest.json
+++ b/calibre-provider/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "calibre-provider",
     "name": "Calibre Provider",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "description": "Search for books in your Calibre library",
     "tags": ["Launcher"],
     "minNoctaliaVersion": "4.6.1",


### PR DESCRIPTION
This pull request introduces French localization support for the Calibre Provider widget and updates the extension version. The most significant changes are the addition of a French translation file and a version bump in the manifest.

Localization:

* Added a new `fr.json` file with French translations for launcher program settings, grid view forcing, and recently opened entries count.

Version update:

* Bumped the extension version from 1.3.2 to 1.3.3 in manifest.json.