### PR TITLE
i18n(color-scheme-creator): update French translations

### DIFF
--- a/color-scheme-creator/i18n/fr.json
+++ b/color-scheme-creator/i18n/fr.json
@@ -1,0 +1,27 @@
+{
+  "menu": {
+    "settings": "Paramètres du widget"
+  },
+  "notifications": {
+    "save-error": "Échec de l'enregistrement du thème",
+    "saved": "Thème enregistré avec succès"
+  },
+  "panel": {
+    "dark": "Sombre",
+    "light": "Clair",
+    "preview": "Aperçu",
+    "reset": "Réinitialiser",
+    "save": "Enregistrer",
+    "scheme-name-placeholder": "Mon Thème",
+    "title": "Color Scheme Creator"
+  },
+  "settings": {
+    "iconColor": {
+      "desc": "Couleur de l'icône dans la barre.",
+      "label": "Couleur de l'icône"
+    }
+  }, 
+  "widget": {
+    "tooltip": "Color Scheme Creator"
+  }
+}

--- a/color-scheme-creator/manifest.json
+++ b/color-scheme-creator/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "color-scheme-creator",
   "name": "Color Scheme Creator",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "minNoctaliaVersion": "4.5.1",
   "author": "Noctalia Team",
   "official": true,


### PR DESCRIPTION
This pull request introduces French localization support for the Color Scheme Creator widget and updates the extension version. The most significant changes are the addition of a French translation file and a version bump in the manifest.

Localization:

* Added a new `fr.json` file with French translations for menu settings, save notifications, the visual editor panel (dark/light modes, preview, reset, save, placeholders), and widget settings.

Version update:

* Bumped the extension version from 1.0.4 to 1.0.5 in manifest.json.