### PR TITLE
i18n(custom-sticker): update French translations

### DIFF
--- a/custom-sticker/i18n/fr.json
+++ b/custom-sticker/i18n/fr.json
@@ -1,0 +1,17 @@
+{
+  "desktopWidgetSettings": {
+    "selection-title": "Sélectionner une image",
+    "selection-description": "Sélectionnez l'image à afficher.",
+    "selection-tooltip": "Sélectionnez l'image à afficher sur le sticker.",
+    "opacity-label": "Opacité",
+    "opacity-description": "Ajustez l'opacité de l'image.",
+    "mirror-label": "Miroir",
+    "mirror-description": "Miroir horizontal de l'image.",
+    "vertical-mirror-label": "Miroir vertical",
+    "vertical-mirror-description": "Miroir vertical de l'image.",
+    "show-background-label": "Afficher l'arrière-plan",
+    "show-background-description": "Afficher le conteneur d'arrière-plan pour le widget sticker personnalisé.",
+    "rounded-corners-label": "Coins arrondis",
+    "rounded-corners-description": "Utiliser des coins arrondis pour l'arrière-plan du widget."
+  }
+}

--- a/custom-sticker/manifest.json
+++ b/custom-sticker/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "custom-sticker",
   "name": "Custom Stickers",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "minNoctaliaVersion": "4.6.6",
   "author": "spiros132",
   "license": "MIT",


### PR DESCRIPTION
This pull request introduces French localization support for the Custom Stickers widget and updates the extension version. The most significant changes are the addition of a French translation file and a version bump in the manifest.

Localization:

* Added a new `fr.json` file with French translations for image selection, opacity, mirroring (horizontal/vertical), background visibility, and rounded corners settings.

Version update:

* Bumped the extension version from 1.0.1 to 1.0.2 in manifest.json.