### PR TITLE
fix(usb-drive-manager): use standard hover colors for eject button

### DIFF
--- a/usb-drive-manager/DeviceCard.qml
+++ b/usb-drive-manager/DeviceCard.qml
@@ -223,8 +223,8 @@ Rectangle {
                 baseSize: Style.baseWidgetSize * 0.8
                 colorBg: Color.mSurfaceVariant
                 colorFg: Color.mOnSurfaceVariant
-                colorBgHover: Color.mErrorContainer
-                colorFgHover: Color.mOnErrorContainer
+                colorBgHover: Color.mHover
+                colorFgHover: Color.mOnHover
                 colorBorder: "transparent"
                 colorBorderHover: "transparent"
                 onClicked: root.ejectRequested(device.path, device.parentPath, root.displayLabel)


### PR DESCRIPTION
Use standard hover colors - `Color.mHover` and `Color.mOnHover` - for the "eject" button; instead of the "error" ones.
This should fix the "eject" button being black when hovering over it.