### PR TITLE
fix(todo): unify details panel button styles

### DIFF
--- a/todo/Panel.qml
+++ b/todo/Panel.qml
@@ -1189,10 +1189,10 @@ Item {
               NButton {
                 text: detailDialog.todoDetails.length > 0 ? pluginApi?.tr("panel.todo_details.button_edit_details") : pluginApi?.tr("panel.todo_details.button_add_details")
                 icon: "pencil"
-                backgroundColor: Color.mSurfaceVariant
-                textColor: Color.mOnSurface
+                backgroundColor: Color.mPrimary
+                textColor: Color.mOnPrimary
                 fontSize: Style.fontSizeS
-                outlined: true
+                visible: !detailsEditMode
                 onClicked: {
                   detailsEditMode = true;
                   Qt.callLater(function () {
@@ -1240,6 +1240,7 @@ Item {
               NButton {
                 text: pluginApi?.tr("panel.todo_details.button_save")
                 backgroundColor: Color.mPrimary
+                textColor: Color.mOnPrimary
                 onClicked: {
                   updateTodo(detailDialog.todoId, {
                                details: detailsTextArea.text
@@ -1251,7 +1252,8 @@ Item {
 
               NButton {
                 text: pluginApi?.tr("panel.todo_details.button_cancel")
-                backgroundColor: Color.mSurfaceVariant
+                backgroundColor: Color.mPrimary
+                textColor: Color.mOnPrimary
                 onClicked: {
                   detailsEditMode = false;
                 }

--- a/todo/manifest.json
+++ b/todo/manifest.json
@@ -1,18 +1,13 @@
 {
   "id": "todo",
   "name": "Todo List",
-  "version": "1.9.10",
+  "version": "1.9.11",
   "minNoctaliaVersion": "3.7.1",
   "author": "lonerOrz <lonerOrz@qq.com>",
   "license": "MIT",
   "repository": "https://github.com/noctalia-dev/noctalia-plugins",
   "description": "A simple todo list manager plugin for Noctalia Shell.",
-  "tags": [
-    "Bar",
-    "Desktop",
-    "Panel",
-    "Productivity"
-  ],
+  "tags": ["Bar", "Desktop", "Panel", "Productivity"],
   "entryPoints": {
     "main": "Main.qml",
     "barWidget": "BarWidget.qml",


### PR DESCRIPTION
- Add/Edit, Save, and Cancel buttons now use consistent primary color
- Hide Add/Edit button when in details edit mode
- Fix text colors for proper visibility