### PR TITLE
(weather-indicator) fix: Capsule uses implicitWidth and implicitHeight

### DIFF
--- a/weather-indicator/BarWidget.qml
+++ b/weather-indicator/BarWidget.qml
@@ -28,7 +28,7 @@ Item {
 
   Rectangle {
     anchors.centerIn: parent
-    width: parent.width; height: parent.height
+    width: parent.implicitWidth; height: parent.implicitHeight
     color: mouseArea.containsMouse ? Color.mHover : Style.capsuleColor
     radius: Style.radiusL
     border { color: Style.capsuleBorderColor; width: Style.capsuleBorderWidth }

--- a/weather-indicator/manifest.json
+++ b/weather-indicator/manifest.json
@@ -1,15 +1,13 @@
 {
   "id": "weather-indicator",
   "name": "Weather Indicator",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "minNoctaliaVersion": "4.6.8",
   "author": "Sovereign",
   "license": "MIT",
   "repository": "https://github.com/noctalia-dev/noctalia-plugins",
   "description": "Shows the current weather condition and temperature.",
-  "tags": [
-    "Bar"
-  ],
+  "tags": ["Bar"],
   "entryPoints": {
     "barWidget": "BarWidget.qml",
     "panel": "Panel.qml",


### PR DESCRIPTION
the capsule rec is now using implicitWidth and implicitHeight from the parent. Fixes how plump it got after the refactor :)

BEFORE
<img width="114" height="217" alt="image" src="https://github.com/user-attachments/assets/21543af3-e579-41db-abb1-d09b08889869" />

NOW
<img width="104" height="210" alt="image" src="https://github.com/user-attachments/assets/333b5f57-3214-4c99-bf4e-7463cded8c2b" />
