### PR TITLE
fix(clipper): replace silently-broken atomic write with stdin Process (v2.4.4)

### DIFF
--- a/clipper/CHANGELOG.md
+++ b/clipper/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Clipper Plugin - Comprehensive Changelog
 
+## Version 2.4.4 (2026-04-26)
+
+### Critical data-loss fix: notecards never reached disk
+
+If you lost a notecard between v2.4.3 and v2.4.4 — I'm sorry. This was my fault. The "atomic write" hotfix shipped in v2.4.3 turned out to be **silently broken** on noctalia-qs and similar Quickshell builds: `Quickshell.execDetached(["sh", "-c", script, ...])` with the multi-arg shell pipeline never actually executed the script. Every `saveNoteCard()` call returned successfully, the note appeared in the panel UI, and a "Note created" toast was shown — but the file never landed in `~/.config/noctalia/plugins/clipper/notecards/`. On the next panel open, `loadNoteCards` saw nothing and the note was gone.
+
+The same path was used for `pinned.json` and notecard `.txt` exports, so those could vanish too under the same conditions.
+
+#### Root cause
+
+- `Quickshell.execDetached` with `["sh", "-c", script, "$0", "$1", "$2", "$3"]` (where `$3` was a long base64 string) silently no-ops in noctalia-qs 0.0.x. The simpler 2–3 argv calls (`mkdir -p`, `find ... -delete`) work; the long-argv save path does not. There is no error, no log, no partial file — the script never starts.
+- `loadNoteCards` used `jq -s '.' *.json 2>/dev/null || echo '[]'`, which is **all-or-nothing**: a single 0-byte or malformed file in the directory made jq exit non-zero, the fallback returned an empty array, and the in-memory `noteCards` was wiped — making every other note invisible in the UI even though it was intact on disk.
+
+#### Fix
+
+- **New atomic-write engine.** Replaced `Quickshell.execDetached` + base64 with a queued `Process` that pipes the raw payload to `sh -c 'cat > "$1.tmp" && [ -s "$1.tmp" ] && mv -f "$1.tmp" "$1" && { [ -z "$2" ] || [ "$2" = "$1" ] || rm -f "$2"; } || { rm -f "$1.tmp"; exit 1; }'` via stdin. Process gives us a real exit code and stderr, so genuine failures are now logged via `Logger.w` instead of vanishing. The queue serializes saves because Process is single-instance.
+- **Resilient loader.** `loadNoteCards` now validates each `*.json` file individually with `jq -e .` and concatenates only the valid ones into the slurp. A single corrupt or 0-byte file no longer wipes the rest. The `onExited` handler also stops blanking `noteCards` on shell errors or empty results — when the disk read gives nothing useful, in-memory state is preserved instead of cleared.
+- **No more base64.** Payload travels through stdin, so Polish / Cyrillic / emoji titles and content survive verbatim without escaping concerns. The `stringToBase64` helper and the `atomicWriteBase64` shim are gone.
+
+Applied to `savePinnedFile`, `saveNoteCard`, `updateNoteCard`, and `exportNoteCard`. Tested by reproducing the disappearing-notecard case (rename + reopen panel) on noctalia-qs 0.0.12 — pre-fix: file vanished; post-fix: file persists across restarts.
+
+If you can still reproduce a disappearance, please open an issue with `grep Clipper /run/user/$(id -u)/quickshell/by-id/*/log.log | tail -40`. The `atomicWrite FAIL` lines now carry exit code and stderr.
+
 ## Version 2.4.3 (2026-04-22)
 
 ### Data-loss hotfix: atomic writes for pinned items and notecards

--- a/clipper/Main.qml
+++ b/clipper/Main.qml
@@ -82,38 +82,55 @@ Item {
     stderr: StdioCollector {}
 
     onExited: exitCode => {
+                // Never wipe in-memory notes on shell-level error — the files
+                // are still on disk and would silently disappear from the UI.
                 if (exitCode !== 0) {
-                  root.noteCards = [];
+                  Logger.w("Clipper", "loadNoteCards: shell exit=" + exitCode + ", keeping in-memory notes");
                   return;
                 }
 
                 try {
                   const output = String(stdout.text).trim();
                   if (!output || output === "[]") {
-                    root.noteCards = [];
-                    root.noteCardsRevision++;
-
-                    // Save to file
+                    // Empty load result. Only clear in-memory state when it
+                    // was already empty; otherwise preserve it. This avoids
+                    // wiping freshly-created (still-being-saved) notes if the
+                    // disk listing raced ahead of the atomic-write rename.
+                    if (root.noteCards.length === 0) {
+                      root.noteCardsRevision++;
+                    }
                     return;
                   }
 
                   const loadedNotes = JSON.parse(output);
-                  root.noteCards = Array.isArray(loadedNotes) ? loadedNotes : [];
-                  root.noteCardsRevision++;
-
-                  // Save to file
-
+                  if (Array.isArray(loadedNotes)) {
+                    root.noteCards = loadedNotes;
+                    root.noteCardsRevision++;
+                  }
                 } catch (e) {
-                  root.noteCards = [];
+                  Logger.w("Clipper", "loadNoteCards: parse error, keeping in-memory notes: " + e);
                 }
               }
   }
 
-  // Function to load all notecards
+  // Function to load all notecards.
+  // IMPORTANT: per-file validation — a single malformed or 0-byte .json
+  // file must NOT wipe all notes. The previous `jq -s '.' *.json` approach
+  // was all-or-nothing: any bad file made jq exit non-zero, the
+  // `|| echo '[]'` fallback returned an empty array, and onExited cleared
+  // root.noteCards even though every other note was intact on disk.
   function loadNoteCards() {
-    // Use jq to create a proper JSON array from all .json files
-    const script = "cd '" + root.noteCardsDir + "' || { echo '[]'; exit 0; }; " + "jq -s '.' *.json 2>/dev/null || echo '[]'";
-    loadNoteCardsProc.command = ["bash", "-c", script];
+    // Capture concatenated valid files into a single var, then decide.
+    // jq -s reads a stream of JSON values with no required separator, so
+    // concatenating is enough — we never feed it empty or malformed input.
+    const script = 'cd "$1" 2>/dev/null || { echo "[]"; exit 0; }; ' +
+                   'shopt -s nullglob; ' +
+                   'out=$(for f in *.json; do ' +
+                   '  jq -e . "$f" >/dev/null 2>&1 && cat "$f"; ' +
+                   'done); ' +
+                   'if [ -z "$out" ]; then echo "[]"; ' +
+                   'else printf "%s" "$out" | jq -s "."; fi';
+    loadNoteCardsProc.command = ["bash", "-c", script, "loadNoteCards", root.noteCardsDir];
     loadNoteCardsProc.running = true;
   }
 
@@ -350,69 +367,79 @@ Item {
               }
   }
 
-  // Helper: encode a UTF-8 string to base64 using the non-deprecated Qt.btoa(array-like) overload.
-  // Qt.btoa(string) is deprecated since Qt 6.8 and its output differs for non-ASCII characters
-  // (Latin-1 byte-per-char vs proper UTF-8). This helper encodes to UTF-8 bytes first.
-  function stringToBase64(str) {
-    var s = String(str);
-    var bytes = [];
-    for (var i = 0; i < s.length; i++) {
-      var code = s.charCodeAt(i);
-      if (code < 0x80) {
-        bytes.push(code);
-      } else if (code < 0x800) {
-        bytes.push(0xC0 | (code >> 6));
-        bytes.push(0x80 | (code & 0x3F));
-      } else if (code >= 0xD800 && code <= 0xDBFF && i + 1 < s.length) {
-        // UTF-16 surrogate pair → Unicode code point
-        var high = code;
-        var low = s.charCodeAt(i + 1);
-        if (low >= 0xDC00 && low <= 0xDFFF) {
-          var cp = 0x10000 + ((high - 0xD800) << 10) + (low - 0xDC00);
-          bytes.push(0xF0 | (cp >> 18));
-          bytes.push(0x80 | ((cp >> 12) & 0x3F));
-          bytes.push(0x80 | ((cp >> 6) & 0x3F));
-          bytes.push(0x80 | (cp & 0x3F));
-          i++;
-        } else {
-          bytes.push(0xEF, 0xBF, 0xBD); // U+FFFD replacement character for lone surrogate
-        }
-      } else {
-        bytes.push(0xE0 | (code >> 12));
-        bytes.push(0x80 | ((code >> 6) & 0x3F));
-        bytes.push(0x80 | (code & 0x3F));
-      }
-    }
-    return Qt.btoa(new Uint8Array(bytes));
+  // Atomic write: payload arrives via stdin, lands in <path>.tmp, then is
+  // renamed onto the target. Optional `oldPath` is removed only after the
+  // new file is verified non-empty and renamed, so a failed save never wipes
+  // existing data. Replaces the previous Quickshell.execDetached + base64
+  // pipeline, which silently failed in noctalia-qs 0.0.x (no file ever
+  // appeared on disk despite saveNoteCard firing). Process gives us exit
+  // codes and stderr; the queue serializes saves because Process is
+  // single-instance. Each queue entry: { content, path, oldPath, id }.
+  property var _atomicWriteQueue: []
+  property var _atomicWriteCurrent: null
+  property bool _atomicWriteBusy: false
+
+  Process {
+    id: atomicWriteProc
+    running: false
+    stdinEnabled: true
+    stderr: StdioCollector {}
+
+    onExited: (exitCode, exitStatus) => {
+                const job = root._atomicWriteCurrent;
+                root._atomicWriteCurrent = null;
+                root._atomicWriteBusy = false;
+                stdinEnabled = true;
+                if (exitCode !== 0) {
+                  Logger.w("Clipper", "atomicWrite FAIL exit=" + exitCode +
+                                      " id=" + (job ? job.id : "?") +
+                                      " path=" + (job ? job.path : "?") +
+                                      " stderr=" + String(stderr.text).trim());
+                }
+                root._drainAtomicWriteQueue();
+              }
   }
 
-  // Atomic write: decode base64 to a temp file, verify non-empty, then rename
-  // onto the target. Optionally rm a stale filename (from a rename) only after
-  // the new file is verified on disk. All paths are passed through argv — not
-  // interpolated into the shell string — so filenames with spaces or shell
-  // metacharacters cannot break the command. Replaces the prior
-  // `echo | base64 -d > file` pattern which truncated the target before any
-  // data flowed and left 0-byte files whenever the shell was killed between
-  // the open-for-truncate syscall and the write (shutdown, panel teardown,
-  // interrupted process, empty base64, etc.). On any failure, the original
-  // file is preserved untouched.
-  function atomicWriteBase64(filePath, base64, oldFilePath) {
-    if (!filePath || typeof filePath !== "string") {
-      Logger.w("Clipper", "atomicWriteBase64: missing filePath");
+  function _drainAtomicWriteQueue() {
+    if (_atomicWriteBusy || _atomicWriteQueue.length === 0)
       return;
-    }
-    if (!base64 || base64.length === 0) {
-      Logger.w("Clipper", "atomicWriteBase64: refusing empty write to " + filePath);
-      return;
-    }
-    const script = 'p="$1"; t="${1}.tmp"; o="$2"; ' +
-                   'echo "$3" | base64 -d > "$t" && ' +
+
+    const job = _atomicWriteQueue.shift();
+    _atomicWriteCurrent = job;
+    _atomicWriteBusy = true;
+
+    const script = 'p="$1"; t="${p}.tmp"; o="$2"; ' +
+                   'cat > "$t" && ' +
                    '[ -s "$t" ] && ' +
                    'mv -f "$t" "$p" && ' +
                    '{ [ -z "$o" ] || [ "$o" = "$p" ] || rm -f "$o"; } ' +
                    '|| { rm -f "$t"; exit 1; }';
-    Quickshell.execDetached(["sh", "-c", script, "atomicWrite",
-                             filePath, oldFilePath || "", base64]);
+    atomicWriteProc.command = ["sh", "-c", script, "atomicWrite",
+                               job.path, job.oldPath || ""];
+    atomicWriteProc.stdinEnabled = true;
+    atomicWriteProc.running = true;
+    atomicWriteProc.write(job.content);
+    atomicWriteProc.stdinEnabled = false;
+  }
+
+  // Public entry point. `oldPath` may be empty; if non-empty and different
+  // from `path`, it is removed only after the new file is safely on disk.
+  function atomicWrite(filePath, content, oldFilePath, id) {
+    if (!filePath || typeof filePath !== "string") {
+      Logger.w("Clipper", "atomicWrite: missing filePath");
+      return;
+    }
+    if (!content || content.length === 0) {
+      Logger.w("Clipper", "atomicWrite: refusing empty write to " + filePath);
+      return;
+    }
+    _atomicWriteQueue.push({
+                             content: content,
+                             path: filePath,
+                             oldPath: oldFilePath || "",
+                             id: id || ""
+                           });
+    _drainAtomicWriteQueue();
   }
 
   // Function to save pinned items to file
@@ -421,10 +448,8 @@ Item {
       items: root.pinnedItems
     };
     const json = JSON.stringify(data, null, 2);
-    const base64 = stringToBase64(json);
     const filePath = Quickshell.env("HOME") + "/.config/noctalia/plugins/clipper/pinned.json";
-
-    atomicWriteBase64(filePath, base64);
+    atomicWrite(filePath, json, "", "pinned");
   }
 
   // Function to unpin item
@@ -506,11 +531,10 @@ Item {
 
     const newFilename = getNoteFilename(updatedNote);
 
-    // Track the stale filename so saveNoteCard / atomicWriteBase64 can delete
-    // it atomically only AFTER the new file is successfully on disk. The
-    // previous code fired rm and save in parallel via execDetached, which
-    // could reorder so that rm landed after a failed save — wiping both
-    // files at once. Never again.
+    // Track the stale filename so saveNoteCard / atomicWrite can delete it
+    // only AFTER the new file is successfully on disk. The pre-2.4.3 code
+    // fired rm and save in parallel via execDetached, which could reorder
+    // so that rm landed after a failed save — wiping both files at once.
     let oldFilePathToReplace = "";
     if (oldFilename !== newFilename && updates.title !== undefined) {
       oldFilePathToReplace = root.noteCardsDir + "/" + oldFilename;
@@ -595,9 +619,10 @@ Item {
     const fileName = "notecard_" + timestamp + ".txt";
     const filePath = Quickshell.env("HOME") + "/Documents/" + fileName;
 
-    // Atomic write so a partial/killed export cannot leave a 0-byte .txt
-    const base64 = stringToBase64(note.content || "");
-    atomicWriteBase64(filePath, base64);
+    // Force a non-empty payload so the atomicWrite guard never trips for
+    // blank notes — a single space exports cleanly as a 1-byte file.
+    const exportContent = (note.content && note.content.length > 0) ? note.content : " ";
+    atomicWrite(filePath, exportContent, "", "export-" + noteId);
 
     // Store exported filename - append to list so all exports are tracked
     const existingExports = note.exportedFiles || [];
@@ -635,7 +660,7 @@ Item {
 
   // Function to save individual notecard to file.
   // oldFilePath (optional) is the previous on-disk filename when the note
-  // has been renamed — atomicWriteBase64 removes it only after the new file
+  // has been renamed — atomicWrite removes it only after the new file
   // is verified non-empty, so a failed save never wipes the old data.
   function saveNoteCard(note, oldFilePath) {
     if (!note || !note.id) {
@@ -649,13 +674,11 @@ Item {
       Logger.w("Clipper", "saveNoteCard: refusing suspiciously small JSON for note " + note.id);
       return;
     }
-    const base64 = stringToBase64(json);
-    atomicWriteBase64(filePath, base64, oldFilePath);
+    atomicWrite(filePath, json, oldFilePath, note.id);
   }
 
   // Function to save all note cards (saves each to individual file)
   function saveNoteCards() {
-    // Save each notecard individually
     for (let i = 0; i < root.noteCards.length; i++) {
       saveNoteCard(root.noteCards[i]);
     }
@@ -1349,6 +1372,9 @@ Item {
       wipeProc.terminate();
     if (loadNoteCardsProc.running)
       loadNoteCardsProc.terminate();
+    if (atomicWriteProc.running)
+      atomicWriteProc.terminate();
+    _atomicWriteQueue = [];
 
     autoPasteTimer.stop();
     if (autoPasteProc.running) autoPasteProc.terminate();

--- a/clipper/manifest.json
+++ b/clipper/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "clipper",
   "name": "Clipper",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "minNoctaliaVersion": "4.1.2",
   "author": "blackbartblues",
   "contributors": [


### PR DESCRIPTION
## Summary

This is a critical follow-up to PR #728 (v2.4.3). **My v2.4.3 atomic-write hotfix was silently broken on noctalia-qs and similar Quickshell builds — saves never reached disk, and notecards were lost between panel reopens.** Sorry to anyone who lost a note. This PR actually fixes it.

## What was broken in v2.4.3

`Quickshell.execDetached(["sh", "-c", script, ...])` with the multi-arg shell pipeline **silently no-ops** in noctalia-qs 0.0.x. The shell never starts, no error is raised, no log is emitted. `saveNoteCard()` returned successfully, the panel UI added the note, the \"Note created\" toast appeared — but the file never landed in `~/.config/noctalia/plugins/clipper/notecards/`. On the next panel open, `loadNoteCards` saw nothing and the note was gone.

Same path was used for `pinned.json` and notecard `.txt` exports, so those could vanish under the same conditions.

Reproducing on noctalia-qs 0.0.12 was straightforward: create a note via panel or IPC (\`qs ipc call plugin:clipper addNoteCard \"X\"\`), close panel, reopen panel → note gone, folder empty.

## Root cause (two bugs, compounding)

1. **Silent execDetached failure.** `Quickshell.execDetached(["sh", "-c", script, "$0", "$1", "$2", "$3"])` where `$3` was a long base64 string never executes the script. Shorter calls (\`mkdir -p\`, \`find ... -delete\`) work; the long-argv save path doesn't. No exit code surface, no stderr, nothing.
2. **Fragile loader.** `loadNoteCards` used `jq -s '.' *.json 2>/dev/null || echo '[]'`, which is **all-or-nothing**: a single 0-byte or malformed file in the directory made jq exit non-zero, the fallback returned an empty array, and the in-memory \`noteCards\` was wiped — making every other note invisible in the UI even though it was intact on disk.

## Fix

- **New atomic-write engine.** Replaced `Quickshell.execDetached` + base64 with a queued `Process` that pipes the raw payload to \`sh -c 'cat > \"\$1.tmp\" && [ -s \"\$1.tmp\" ] && mv -f \"\$1.tmp\" \"\$1\" && { [ -z \"\$2\" ] || [ \"\$2\" = \"\$1\" ] || rm -f \"\$2\"; } || { rm -f \"\$1.tmp\"; exit 1; }'\` via stdin. Process gives a real exit code and stderr, so genuine failures are logged via \`Logger.w\` instead of vanishing. The queue serializes saves because Process is single-instance.
- **Resilient loader.** \`loadNoteCards\` now validates each \`*.json\` file individually with \`jq -e .\` and concatenates only the valid ones into the slurp. A single corrupt or 0-byte file no longer wipes the rest. \`onExited\` also stops blanking \`noteCards\` on shell errors or empty results — when the disk read gives nothing useful, in-memory state is preserved.
- **No more base64.** Payload travels through stdin, so Polish / Cyrillic / emoji titles and content survive verbatim without escape concerns. The \`stringToBase64\` helper and the \`atomicWriteBase64\` shim are gone.

Applied to \`savePinnedFile\`, \`saveNoteCard\`, \`updateNoteCard\`, and \`exportNoteCard\`.

## Apology

If you upgraded to v2.4.3 and lost a notecard between then and now — I'm sorry. The hotfix that was meant to *prevent* data loss instead silently broke every save in the affected Quickshell builds. The earlier PR description claimed the fix had been verified; in reality I tested the shell script in isolation.

## Changes

- \`clipper/Main.qml\`: new \`atomicWrite\` (queued Process + stdin), drop \`stringToBase64\` and \`atomicWriteBase64\`, update savePinnedFile / saveNoteCard / updateNoteCard / exportNoteCard, harden loadNoteCards loader and onExited handler
- \`clipper/manifest.json\`: bump version 2.4.3 → 2.4.4
- \`clipper/CHANGELOG.md\`: v2.4.4 entry with apology and root-cause writeup

## Test plan

- [x] On noctalia-qs 0.0.12: create notecard via panel UI → file appears in \`notecards/\` immediately
- [x] Edit title (rename) → old file removed, new file present, content intact across panel close/reopen
- [x] Create via IPC: \`qs -p ... ipc call plugin:clipper addNoteCard \"foo\"\` → file persists
- [x] Drop a 0-byte \`.json\` file into \`notecards/\` → other notes still load and display correctly (regression check on the load-side bug)
- [x] Pin a clipboard item → \`pinned.json\` updates correctly
- [x] Export a notecard → \`.txt\` file appears in \`~/Documents/\` even for blank notes
- [x] Panel close + reopen with multiple notes → all persist; \`Logger.w atomicWrite FAIL\` lines absent

If you can still reproduce a disappearance, please open an issue with \`grep Clipper /run/user/\$(id -u)/quickshell/by-id/*/log.log | tail -40\` — \`atomicWrite FAIL\` lines now carry exit code and stderr, so the next bug will be diagnosable in seconds instead of hours.