### PR TITLE
fix(usb-drive-manager): use standard error hover colors for eject button

### DIFF
--- a/usb-drive-manager/DeviceCard.qml
+++ b/usb-drive-manager/DeviceCard.qml
@@ -223,8 +223,8 @@ Rectangle {
                 baseSize: Style.baseWidgetSize * 0.8
                 colorBg: Color.mSurfaceVariant
                 colorFg: Color.mOnSurfaceVariant
-                colorBgHover: Color.mErrorContainer
-                colorFgHover: Color.mOnErrorContainer
+                colorBgHover: Color.mError
+                colorFgHover: Color.mOnError
                 colorBorder: "transparent"
                 colorBorderHover: "transparent"
                 onClicked: root.ejectRequested(device.path, device.parentPath, root.displayLabel)

--- a/usb-drive-manager/manifest.json
+++ b/usb-drive-manager/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "usb-drive-manager",
   "name": "USB Drive Manager",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "minNoctaliaVersion": "3.6.0",
   "author": "hennifant",
   "license": "MIT",


### PR DESCRIPTION
Use standard error colors - `Color.mError` and `Color.mOnError` - for the "eject" button; instead of the "error container" ones. Initially I thought of using the standard "hover" colors, but this should give the "eject" button different color to the rest of them.
This should fix the "eject" button being black when hovering over it.

I'm not sure where the `mErrorContainer` and `mOnErrorContainer` should be from; noctalia-shell doesn't have them defined.