### PR TITLE
feat(usb-drive-manager): add a control center widget

### DIFF
--- a/usb-drive-manager/ControlCenterWidget.qml
+++ b/usb-drive-manager/ControlCenterWidget.qml
@@ -1,0 +1,75 @@
+import QtQuick
+import Quickshell
+import qs.Commons
+import qs.Widgets
+import qs.Services.UI
+
+NIconButtonHot {
+    id: root
+
+    property var pluginApi: null
+    property ShellScreen screen
+
+    readonly property var mainInstance: pluginApi?.mainInstance
+
+    icon: "usb"
+    tooltipText: mainInstance?.buildTooltip()
+
+    onClicked: {
+        if (mainInstance) {
+            mainInstance.refreshDevices()
+        }
+        if (pluginApi?.openPanel) {
+            pluginApi.openPanel(screen, root)
+        }
+    }
+
+    onRightClicked: {
+        PanelService.showContextMenu(contextMenu, root, screen)
+    }
+
+    NPopupContextMenu {
+        id: contextMenu
+
+        model: [
+            {
+                "label": pluginApi?.tr("context.open"),
+                "action": "open-panel",
+                "icon": "apps"
+            },
+            {
+                "label": pluginApi?.tr("context.refresh"),
+                "action": "refresh",
+                "icon": "refresh"
+            },
+            {
+                "label": pluginApi?.tr("context.unmount-all"),
+                "action": "unmount-all",
+                "icon": "plug-connected-x"
+            },
+            {
+                "label": pluginApi?.tr("context.settings"),
+                "action": "settings",
+                "icon": "settings"
+            }
+        ]
+
+        onTriggered: action => {
+            contextMenu.close()
+            PanelService.closeContextMenu(screen)
+
+            if (action === "open-panel") {
+                mainInstance?.refreshDevices()
+                if (pluginApi?.openPanel) pluginApi.openPanel(screen, root)
+            } else if (action === "refresh") {
+                mainInstance?.refreshDevices()
+            } else if (action === "unmount-all") {
+                mainInstance?.unmountAll()
+            } else if (action === "settings") {
+                if (pluginApi?.manifest) {
+                    BarService.openPluginSettings(screen, pluginApi.manifest)
+                }
+            }
+        }
+    }
+}

--- a/usb-drive-manager/manifest.json
+++ b/usb-drive-manager/manifest.json
@@ -15,6 +15,7 @@
   "entryPoints": {
     "main": "Main.qml",
     "barWidget": "BarWidget.qml",
+    "controlCenterWidget": "ControlCenterWidget.qml",
     "panel": "Panel.qml",
     "settings": "Settings.qml"
   },

--- a/usb-drive-manager/manifest.json
+++ b/usb-drive-manager/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "usb-drive-manager",
   "name": "USB Drive Manager",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "minNoctaliaVersion": "3.6.0",
   "author": "hennifant",
   "license": "MIT",


### PR DESCRIPTION
Add a control center widget to usb-drive-manager plugin, allowing accessing the plugin via a control center shortcut, in addition to regular bar button/widget.