### PR TITLE
update README (OSK-Toggle): Document known issues and workaround

### DIFF
--- a/osk-toggle/README.md
+++ b/osk-toggle/README.md
@@ -57,6 +57,27 @@ The widget will **reflect these changes in real-time** without conflicts. Manual
 The plugin takes ownership of the wvkbd process: on load it kills any pre-existing instance and relaunches it with `--hidden`. Show/hide is then controlled by sending `SIGUSR1` / `SIGUSR2` directly to the owned process. When the plugin unloads, the process is stopped.
 
 
+## Known Issues
+
+### OSK closes when opening settings from the bar (touchscreen)
+
+When opening plugin settings from within the bar or shell interface on a touchscreen, the on-screen keyboard may close or stop receiving input. Opening settings through the general Noctalia settings panel works fine. This is a shell-level bug unrelated to this plugin.
+
+**Workaround** until a fix lands upstream: open the following file with a text editor (requires root):
+
+```
+/etc/xdg/quickshell/noctalia-shell/Modules/MainScreen/PopupMenuWindow.qml
+```
+
+Find line 39 and change `OnDemand` to `Exclusive`:
+
+```diff
+- WlrLayershell.keyboardFocus: hasDialog ? WlrKeyboardFocus.OnDemand : WlrKeyboardFocus.None
++ WlrLayershell.keyboardFocus: hasDialog ? WlrKeyboardFocus.Exclusive : WlrKeyboardFocus.None
+```
+
+Then restart the shell.
+
 ## License
 
 MIT — see [LICENSE](LICENSE).


### PR DESCRIPTION
Added known issues section in README with workaround for OSK closing when opening settings from the bar.