### PR TITLE
perf(monique): cache resolved binary path to reduce polling overhead

### DIFF
--- a/monique/BarWidget.qml
+++ b/monique/BarWidget.qml
@@ -85,7 +85,7 @@ Item {
 
   Process {
     id: openMoniqueProcess
-    command: ["monique"]
+    command: [mainInstance?.moniquePath ?? "monique"]
   }
 
   NPopupContextMenu {

--- a/monique/Main.qml
+++ b/monique/Main.qml
@@ -8,9 +8,10 @@ Item {
 
   property var pluginApi: null
 
-  readonly property int refreshInterval: pluginApi?.pluginSettings?.refreshInterval ?? 3000
+  readonly property int refreshInterval: pluginApi?.pluginSettings?.refreshInterval ?? 5000
 
   property bool moniqueInstalled: false
+  property string moniquePath: ""
   property string activeProfile: ""
   property var profiles: []
   property bool isRefreshing: false
@@ -43,7 +44,6 @@ Item {
     switchProcess.running = true
   }
 
-  // Verifica che monique sia installato
   Process {
     id: whichProcess
     command: ["which", "monique"]
@@ -51,22 +51,27 @@ Item {
     stderr: StdioCollector {}
 
     onExited: function(exitCode) {
-      root.moniqueInstalled = (exitCode === 0)
-      root.isRefreshing = false
-      if (root.moniqueInstalled) {
-        root.refresh()
-        listProfilesProcess.running = true
-        updateTimer.start()
-      } else {
-        Logger.w("Monique", "monique not found in PATH")
+      if (exitCode === 0) {
+        var resolved = String(whichProcess.stdout.text || "").trim()
+        if (resolved !== "") {
+          root.moniquePath = resolved
+          root.moniqueInstalled = true
+          root.isRefreshing = false
+          root.refresh()
+          listProfilesProcess.running = true
+          updateTimer.start()
+          return
+        }
       }
+      root.moniqueInstalled = false
+      root.isRefreshing = false
+      Logger.w("Monique", "monique not found in PATH")
     }
   }
 
-  // Carica la lista dei profili
   Process {
     id: listProfilesProcess
-    command: ["monique", "--list-profiles"]
+    command: [root.moniquePath, "--list-profiles"]
     stdout: StdioCollector {}
     stderr: StdioCollector {}
 
@@ -82,10 +87,9 @@ Item {
     }
   }
 
-  // Legge il profilo attivo
   Process {
     id: currentProfileProcess
-    command: ["monique", "--current-profile"]
+    command: [root.moniquePath, "--current-profile"]
     stdout: StdioCollector {}
     stderr: StdioCollector {}
 
@@ -99,13 +103,12 @@ Item {
     }
   }
 
-  // Esegue lo switch del profilo
   Process {
     id: switchProcess
 
     property string profileName: ""
 
-    command: ["monique", "--switch-profile", profileName]
+    command: [root.moniquePath, "--switch-profile", profileName]
     stdout: StdioCollector {}
     stderr: StdioCollector {}
 

--- a/monique/manifest.json
+++ b/monique/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "monique",
   "name": "Monique",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "minNoctaliaVersion": "4.0.0",
   "author": "ToRvaLDz",
   "license": "MIT",
@@ -23,7 +23,7 @@
   },
   "metadata": {
     "defaultSettings": {
-      "refreshInterval": 3000,
+      "refreshInterval": 5000,
       "activeColor": "primary",
       "showProfileLabel": false
     }


### PR DESCRIPTION
## Summary

- **Cache the resolved `monique` binary path at startup** — the `which` lookup runs once during `checkInstalled()`, and the resolved absolute path is reused for all subsequent polling calls (`--current-profile`, `--list-profiles`, `--switch-profile`).
- **Bump default refresh interval from 3s to 5s** — monitor profiles rarely change autonomously, 5s is still responsive enough for hotplug events.

## Problem

On systems using Python version managers like pyenv, the bare `monique` command resolves through a shell shim that spawns ~30 child processes on every invocation (pyenv-exec → pyenv-version-name → pyenv-version-file → pyenv-hooks → pyenv-latest → pyenv-versions → sort → grep → sed → awk → ...).

With the previous 3s polling interval, this resulted in **~600 unnecessary process spawns per minute** just to read a 4-character string (`"Full"`), causing measurable CPU overhead (~8% on the Quickshell process).

## Fix

The `whichProcess` already runs `which monique` at startup. This PR captures its stdout into a new `moniquePath` property and uses it as the command for all subsequent `Process` calls. The shim overhead happens exactly once instead of every 3-5 seconds.

`BarWidget.qml` also uses the cached path from `mainInstance.moniquePath` when opening monique from the context menu.

## Test plan

- [ ] Install monique via system package manager → plugin resolves and caches path correctly
- [ ] Install monique via pip/pipx (user-local) → plugin resolves `~/.local/bin/monique`
- [ ] Uninstall monique → plugin shows "not found" warning, no crashes
- [ ] Profile switching still works via panel
- [ ] Context menu "Open Monique" still launches the GUI
- [ ] Verify reduced CPU usage with `top` or `htop` on systems with pyenv