### PR TITLE
feat(github-feed): add notification management features and bump the version

### DIFF
--- a/github-feed/Main.qml
+++ b/github-feed/Main.qml
@@ -856,6 +856,62 @@ Item {
         }
     }
 
+    function markAllNotificationsAsRead() {
+        if (!root.token || root.notificationsList.length === 0) return
+        var ids = root.notificationsList.map(function(n) { return n.id })
+        root.notificationsList = []
+        root.notificationCount = 0
+        for (var i = 0; i < ids.length; i++) {
+            root.markReadQueue.push(ids[i])
+        }
+        if (!root.isMarkingRead) processMarkReadQueue()
+    }
+
+    property var markReadQueue: []
+    property bool isMarkingRead: false
+
+    Process {
+        id: markReadProcess
+        stdout: StdioCollector {}
+        onExited: function(exitCode) {
+            if (exitCode !== 0) {
+                Logger.e("GitHubFeed", "Failed to mark notification as read, exit code: " + exitCode)
+            }
+            root.isMarkingRead = false
+            if (root.markReadQueue.length > 0) {
+                processMarkReadQueue()
+            } else {
+                fetchNotifications()
+            }
+        }
+    }
+
+    function markNotificationAsRead(threadId) {
+        var updated = []
+        for (var i = 0; i < root.notificationsList.length; i++) {
+            if (root.notificationsList[i].id !== threadId) updated.push(root.notificationsList[i])
+        }
+        root.notificationsList = updated
+        if (root.notificationCount > 0) root.notificationCount--
+
+        root.markReadQueue.push(threadId)
+        if (!root.isMarkingRead) processMarkReadQueue()
+    }
+
+    function processMarkReadQueue() {
+        if (root.markReadQueue.length === 0) return
+        var threadId = root.markReadQueue.shift()
+        root.isMarkingRead = true
+        markReadProcess.command = [
+            "curl", "-s", "--max-time", "10",
+            "-X", "PATCH",
+            "-H", "Authorization: Bearer " + root.token,
+            "-H", "Accept: application/vnd.github.v3+json",
+            root.githubRestApiUrl + "/notifications/threads/" + threadId
+        ]
+        markReadProcess.running = true
+    }
+
     function finalizeFetch() {
         root.collectedEvents.sort(function(a, b) {
             var dateA = new Date(a.created_at)

--- a/github-feed/Panel.qml
+++ b/github-feed/Panel.qml
@@ -154,6 +154,13 @@ Item {
                         }
                     }
                 }
+
+                NIconButton {
+                    icon: "checks"
+                    visible: root.currentTab === 1 && (root.mainInstance?.notificationCount || 0) > 0
+                    colorFg: Color.mOnSurfaceVariant
+                    onClicked: root.mainInstance?.markAllNotificationsAsRead()
+                }
             }
 
             RowLayout {
@@ -430,7 +437,7 @@ Item {
                                 id: notifCard
                                 Layout.fillWidth: true
                                 height: notifContent.implicitHeight + Style.marginM * 2
-                                color: notifMouse.containsMouse ? Qt.lighter(Color.mSurface, 1.05) : Color.mSurface
+                                color: cardHover.hovered ? Qt.lighter(Color.mSurface, 1.05) : Color.mSurface
                                 radius: Style.radiusM
 
                                 Behavior on color {
@@ -438,6 +445,8 @@ Item {
                                 }
 
                                 property var notification: modelData
+
+                                HoverHandler { id: cardHover }
 
                                 RowLayout {
                                     id: notifContent
@@ -479,6 +488,7 @@ Item {
                                             Item { Layout.fillWidth: true }
 
                                             NText {
+                                                visible: !cardHover.hovered
                                                 text: formatRelativeTime(notifCard.notification.updated_at)
                                                 pointSize: Style.fontSizeXS
                                                 color: Color.mOnSurfaceVariant
@@ -499,7 +509,6 @@ Item {
                                 MouseArea {
                                     id: notifMouse
                                     anchors.fill: parent
-                                    hoverEnabled: true
                                     cursorShape: Qt.PointingHandCursor
 
                                     onClicked: {
@@ -508,6 +517,19 @@ Item {
                                             Qt.openUrlExternally(url)
                                         }
                                     }
+                                }
+
+                                NIconButton {
+                                    z: 1
+                                    visible: cardHover.hovered
+                                    anchors {
+                                        right: parent.right
+                                        verticalCenter: parent.verticalCenter
+                                        rightMargin: Style.marginM
+                                    }
+                                    icon: "check"
+                                    colorFg: Color.mOnSurfaceVariant
+                                    onClicked: root.mainInstance?.markNotificationAsRead(notifCard.notification.id)
                                 }
                             }
                         }

--- a/github-feed/manifest.json
+++ b/github-feed/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "github-feed",
   "name": "GitHub Feed",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "minNoctaliaVersion": "3.6.0",
   "author": "linuxmobile",
   "license": "MIT",


### PR DESCRIPTION
## Changes

Add per-notification and bulk mark as read actions to the notifications tab.

- Hover a notification to reveal a check button that marks it as read and removes it from the list
- "Mark all as read" button in the panel header marks only the currently loaded notifications individually (avoids touching notifications outside the plugin's loaded set)
- Rapid clicks are serialized through a queue

## Motivation

The Notifications tab previously showed unread notifications with no way to act on them without leaving the panel. Users had to open the browser just to dismiss a notification, breaking the workflow.
