### PR TITLE
feat(file-search): add Chinese (zh-CN and zh-TW) translations

### DIFF
--- a/file-search/i18n/zh-CN.json
+++ b/file-search/i18n/zh-CN.json
@@ -1,0 +1,55 @@
+{
+  "provider": {
+    "name": "文件搜索"
+  },
+  "launcher": {
+    "command": {
+      "description": "搜索文件和文件夹"
+    },
+    "errors": {
+      "fdNotFound": {
+        "title": "未找到 fd",
+        "description": "请安装 fd 以使用文件搜索"
+      }
+    },
+    "prompts": {
+      "emptyQuery": {
+        "title": "输入以搜索文件和文件夹",
+        "description": "开始输入以在 {{root}} 中搜索"
+      },
+      "searching": {
+        "title": "正在搜索…",
+        "description": "正在查找匹配 {{query}} 的文件和文件夹"
+      },
+      "noResults": {
+        "title": "未找到结果",
+        "description": "没有匹配 '{{query}}' 的文件或文件夹"
+      }
+    }
+  },
+  "settings": {
+    "showHidden": {
+      "label": "包含隐藏文件"
+    },
+    "fileOpener": {
+      "label": "文件打开命令",
+      "description": "用于打开文件和文件夹的命令",
+      "placeholder": "xdg-open"
+    },
+    "searchDirectory": {
+      "label": "搜索目录",
+      "description": "用于搜索文件和文件夹的目录",
+      "placeholder": "~"
+    },
+    "fdCommand": {
+      "label": "fd 命令路径",
+      "description": "命令名称或完整路径",
+      "placeholder": "fd"
+    },
+    "maxResults": {
+      "label": "最大结果数",
+      "unlimited": "无限制",
+      "description": "限制显示的搜索结果数量（设为 0 表示无限制）"
+    }
+  }
+}

--- a/file-search/i18n/zh-TW.json
+++ b/file-search/i18n/zh-TW.json
@@ -1,0 +1,55 @@
+{
+  "provider": {
+    "name": "檔案搜尋"
+  },
+  "launcher": {
+    "command": {
+      "description": "搜尋檔案與資料夾"
+    },
+    "errors": {
+      "fdNotFound": {
+        "title": "找不到 fd",
+        "description": "請安裝 fd 以使用檔案搜尋"
+      }
+    },
+    "prompts": {
+      "emptyQuery": {
+        "title": "輸入以搜尋檔案與資料夾",
+        "description": "開始輸入以在 {{root}} 中搜尋"
+      },
+      "searching": {
+        "title": "正在搜尋…",
+        "description": "正在尋找符合 {{query}} 的檔案與資料夾"
+      },
+      "noResults": {
+        "title": "找不到結果",
+        "description": "沒有符合 '{{query}}' 的檔案或資料夾"
+      }
+    }
+  },
+  "settings": {
+    "showHidden": {
+      "label": "包含隱藏檔案"
+    },
+    "fileOpener": {
+      "label": "檔案開啟命令",
+      "description": "用於開啟檔案與資料夾的命令",
+      "placeholder": "xdg-open"
+    },
+    "searchDirectory": {
+      "label": "搜尋目錄",
+      "description": "用於搜尋檔案與資料夾的目錄",
+      "placeholder": "~"
+    },
+    "fdCommand": {
+      "label": "fd 命令路徑",
+      "description": "命令名稱或完整路徑",
+      "placeholder": "fd"
+    },
+    "maxResults": {
+      "label": "最大結果數",
+      "unlimited": "無限制",
+      "description": "限制顯示的搜尋結果數量（設為 0 表示無限制）"
+    }
+  }
+}

--- a/file-search/manifest.json
+++ b/file-search/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "file-search",
     "name": "File Search",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "minNoctaliaVersion": "4.1.2",
     "author": "ericbreh",
     "license": "MIT",


### PR DESCRIPTION
Add complete Chinese translations for the file-search plugin, covering both Simplified Chinese (zh-CN) and Traditional Chinese (zh-TW).

## Changes
- Add `i18n/zh-CN.json` — Simplified Chinese translation
- Add `i18n/zh-TW.json` — Traditional Chinese translation
