### PR TITLE
feat(noctalia-calculator): copy result to clipboard from panel

### DIFF
--- a/noctalia-calculator/Main.qml
+++ b/noctalia-calculator/Main.qml
@@ -2,6 +2,7 @@ import QtQuick
 import Quickshell
 import Quickshell.Io
 import "AdvancedMath.js" as AdvancedMath
+import qs.Services.UI
 
 Item {
     id: root
@@ -28,6 +29,7 @@ Item {
     readonly property string displayText: errorState ? pluginApi?.tr("state.error") : currentInput
     readonly property string expressionText: expressionPreview()
     readonly property string badgeText: !showBarValue ? "" : compactDisplay(displayText, 9)
+    readonly property bool hasCopyableResult: !errorState && displayText !== "" && (justEvaluated || displayText !== "0" || tokens.length > 0)
 
     function _isOperator(token) {
         return token === "+" || token === "-" || token === "*" || token === "/";
@@ -363,6 +365,17 @@ Item {
 
         pressButton(action);
         return true;
+    }
+
+    function copyResult() {
+        if (!hasCopyableResult) return;
+        const value = displayText;
+        const escaped = value.replace(/'/g, "'\\''");
+        Quickshell.execDetached(["sh", "-c", "printf '%s' '" + escaped + "' | wl-copy"]);
+        const shown = value.length > 24 ? value.slice(0, 24) + "…" : value;
+        if (pluginApi) {
+            ToastService.showNotice(pluginApi.tr("toast.copied", { "value": shown }));
+        }
     }
 
     IpcHandler {

--- a/noctalia-calculator/Panel.qml
+++ b/noctalia-calculator/Panel.qml
@@ -221,7 +221,7 @@ FocusScope {
                                         hoverEnabled: true
                                         cursorShape: Qt.PointingHandCursor
                                         onClicked: mainInst?.copyResult()
-                                        onEntered: TooltipService.show(parent, pluginApi?.tr("panel.copy-result-tooltip") ?? "")
+                                        onEntered: TooltipService.show(parent, pluginApi?.tr("panel.copy-result-tooltip"))
                                         onExited: TooltipService.hide()
                                     }
                                 }

--- a/noctalia-calculator/Panel.qml
+++ b/noctalia-calculator/Panel.qml
@@ -2,6 +2,7 @@ import QtQuick
 import QtQuick.Layouts
 import qs.Commons
 import qs.Widgets
+import qs.Services.UI
 
 FocusScope {
     id: root
@@ -184,14 +185,46 @@ FocusScope {
                                 horizontalAlignment: Text.AlignRight
                             }
 
-                            NText {
+                            RowLayout {
                                 Layout.fillWidth: true
-                                text: mainInst?.displayText ?? "0"
-                                pointSize: Math.round(Style.fontSizeL * 1.85)
-                                font.bold: true
-                                color: (mainInst?.errorState ?? false) ? Color.mError : Color.mOnSurface
-                                elide: Text.ElideLeft
-                                horizontalAlignment: Text.AlignRight
+                                spacing: Style.marginS
+
+                                NText {
+                                    Layout.fillWidth: true
+                                    text: mainInst?.displayText ?? "0"
+                                    pointSize: Math.round(Style.fontSizeL * 1.85)
+                                    font.bold: true
+                                    color: (mainInst?.errorState ?? false) ? Color.mError : Color.mOnSurface
+                                    elide: Text.ElideLeft
+                                    horizontalAlignment: Text.AlignRight
+                                }
+
+                                Item {
+                                    Layout.preferredWidth: copyIcon.implicitWidth + Style.marginS
+                                    Layout.preferredHeight: copyIcon.implicitHeight
+                                    Layout.alignment: Qt.AlignVCenter
+                                    visible: mainInst?.hasCopyableResult ?? false
+
+                                    NIcon {
+                                        id: copyIcon
+                                        anchors.centerIn: parent
+                                        icon: "copy"
+                                        pointSize: Style.fontSizeM
+                                        color: copyMouse.containsMouse ? Color.mPrimary : Qt.alpha(Color.mOnSurface, 0.55)
+
+                                        Behavior on color { ColorAnimation { duration: Style.animationFast } }
+                                    }
+
+                                    MouseArea {
+                                        id: copyMouse
+                                        anchors.fill: parent
+                                        hoverEnabled: true
+                                        cursorShape: Qt.PointingHandCursor
+                                        onClicked: mainInst?.copyResult()
+                                        onEntered: TooltipService.show(parent, pluginApi?.tr("panel.copy-result-tooltip") ?? "")
+                                        onExited: TooltipService.hide()
+                                    }
+                                }
                             }
                         }
                     }

--- a/noctalia-calculator/README.md
+++ b/noctalia-calculator/README.md
@@ -39,6 +39,12 @@ A theme-aware calculator plugin for Noctalia on Niri, with a bar widget, floatin
 - `Settings.qml`: plugin settings UI
 - `i18n/`: translations (en, pt, es, fr, de, it, ru, zh, ja, ko)
 
+## Copying the result
+
+When the panel is open and a value is showing, a small copy icon appears to the right of the result. Click it to copy the value to the system clipboard. A toast confirms the copy.
+
+Requires `wl-copy` (from `wl-clipboard`) on `PATH`. The icon is hidden in the resting `0` state and while an error is displayed.
+
 ## Author
 
 Pir0c0pter0

--- a/noctalia-calculator/i18n/en.json
+++ b/noctalia-calculator/i18n/en.json
@@ -9,7 +9,11 @@
   },
   "panel": {
     "title": "Calculator",
-    "subtitle": "Quick math in the bar"
+    "subtitle": "Quick math in the bar",
+    "copy-result-tooltip": "Copy result"
+  },
+  "toast": {
+    "copied": "Copied: {value}"
   },
   "settings": {
     "about": "About",

--- a/noctalia-calculator/manifest.json
+++ b/noctalia-calculator/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "noctalia-calculator",
   "name": "Calculator",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "minNoctaliaVersion": "4.4.0",
   "author": "pir0c0pter0",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Adds a small copy icon next to the displayed result in the calculator panel; clicking copies the value via `wl-copy` and shows a toast.
- Adds two i18n keys (`panel.copy-result-tooltip`, `toast.copied`) — English only; other locales fall back to English.
- Bumps plugin version to 1.1.0.

## Why
The panel display is plain `Text`, so users cannot select or copy the result with the mouse. This adds the smallest possible discoverable affordance.

## Preview

![Calculator panel showing the new copy icon next to the result](https://github.com/kohanyirobert/noctalia-plugins/releases/download/pr-796-preview/calc-copy-icon-preview.png)

## Test plan
- [x] Resting `0` state: icon hidden.
- [x] After `1 + 2 =`: icon visible; click puts `3` in the clipboard (`wl-paste` confirms); toast reads `Copied: 3`.
- [x] Mid-expression (`1 + 2`, no `=`): click copies `2`.
- [x] Error state (`1 / 0 =`): icon hidden.
- [x] Long result (>24 chars): clipboard has full value; toast truncated with `…`.