### PR TITLE
feat(usb-drive-manager): Add "Eject All" to context menu, fix missing icons

### DIFF
--- a/usb-drive-manager/BarWidget.qml
+++ b/usb-drive-manager/BarWidget.qml
@@ -51,8 +51,8 @@ NIconButton {
     applyUiScale: false
     customRadius: Style.radiusL
 
-    colorBg: hasMountedDevices ? Color.mPrimaryContainer : Style.capsuleColor
-    colorFg: hasMountedDevices ? Color.mOnPrimaryContainer : root.iconColor !== "transparent" ? root.iconColor : Color.mOnSurface
+    colorBg: hasMountedDevices ? Color.mPrimary : Style.capsuleColor
+    colorFg: hasMountedDevices ? Color.mOnPrimary : root.iconColor !== "transparent" ? root.iconColor : Color.mOnSurface
     colorBgHover: Color.mHover
     colorFgHover: Color.mOnHover
     colorBorder: "transparent"
@@ -118,6 +118,11 @@ NIconButton {
                 "icon": "plug-connected-x"
             },
             {
+                "label": pluginApi?.tr("context.eject-all"),
+                "action": "eject-all",
+                "icon": "player-eject"
+            },
+            {
                 "label": pluginApi?.tr("context.settings"),
                 "action": "settings",
                 "icon": "settings"
@@ -135,6 +140,8 @@ NIconButton {
                 mainInstance?.refreshDevices()
             } else if (action === "unmount-all") {
                 mainInstance?.unmountAll()
+            } else if (action === "eject-all") {
+                mainInstance?.ejectAll()
             } else if (action === "settings") {
                 if (pluginApi?.manifest) {
                     BarService.openPluginSettings(screen, pluginApi.manifest)

--- a/usb-drive-manager/ControlCenterWidget.qml
+++ b/usb-drive-manager/ControlCenterWidget.qml
@@ -48,6 +48,11 @@ NIconButtonHot {
                 "icon": "plug-connected-x"
             },
             {
+                "label": pluginApi?.tr("context.eject-all"),
+                "action": "eject-all",
+                "icon": "player-eject"
+            },
+            {
                 "label": pluginApi?.tr("context.settings"),
                 "action": "settings",
                 "icon": "settings"
@@ -65,6 +70,8 @@ NIconButtonHot {
                 mainInstance?.refreshDevices()
             } else if (action === "unmount-all") {
                 mainInstance?.unmountAll()
+            } else if (action === "eject-all") {
+                mainInstance?.ejectAll()
             } else if (action === "settings") {
                 if (pluginApi?.manifest) {
                     BarService.openPluginSettings(screen, pluginApi.manifest)

--- a/usb-drive-manager/README.md
+++ b/usb-drive-manager/README.md
@@ -39,7 +39,7 @@ A Noctalia bar widget for managing USB drives and removable storage devices.
 ## Usage
 
 1. **Left-click** the bar icon to open the device panel
-2. **Right-click** for quick actions (Refresh, Unmount All, Settings)
+2. **Right-click** for quick actions (Refresh, Unmount All, Eject All, Settings)
 3. In the panel, each device card shows:
    - Device label, size, filesystem type
    - Mountpoint path (when mounted)

--- a/usb-drive-manager/i18n/de.json
+++ b/usb-drive-manager/i18n/de.json
@@ -26,6 +26,7 @@
     "open": "USB-Manager öffnen",
     "refresh": "Geräte aktualisieren",
     "unmount-all": "Alle aushängen",
+    "eject-all": "Alle auswerfen",
     "settings": "Einstellungen"
   },
   "notifications": {

--- a/usb-drive-manager/i18n/en.json
+++ b/usb-drive-manager/i18n/en.json
@@ -26,6 +26,7 @@
     "open": "Open USB Manager",
     "refresh": "Refresh Devices",
     "unmount-all": "Unmount All",
+    "eject-all": "Eject All",
     "settings": "Settings"
   },
   "notifications": {

--- a/usb-drive-manager/i18n/fr.json
+++ b/usb-drive-manager/i18n/fr.json
@@ -26,6 +26,7 @@
     "open": "Ouvrir le gestionnaire USB",
     "refresh": "Actualiser les périphériques",
     "unmount-all": "Tout démonter",
+    "eject-all": "Tout éjecter",
     "settings": "Paramètres"
   },
   "notifications": {

--- a/usb-drive-manager/manifest.json
+++ b/usb-drive-manager/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "usb-drive-manager",
   "name": "USB Drive Manager",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "minNoctaliaVersion": "3.6.0",
   "author": "hennifant",
   "license": "MIT",


### PR DESCRIPTION
## Add "Eject All" to context menu
Add "Eject All" to context menus, both to bar and control center widgets. Resolves #590
<img width="231" height="221" alt="eject" src="https://github.com/user-attachments/assets/3f3145b2-22f1-46f2-8419-ef7d9283bc04" />

## Fix icon colors when drives are mounted
Use `Color.mPrimary` and `Color.mOnPrimary` for bar widget colors when devices are mounted. Resolves #716

I'm not sure where did the previous `mPrimaryContainer` and `mOnPrimaryContainer` came from, I assume something got updated in noctalia, but not in this plugin. I think the "missing" colors caused the button to be rendered as black.

| Before | After |
|--------|--------|
| <img width="78" height="80" alt="before" src="https://github.com/user-attachments/assets/68caad6b-51a6-422a-8db2-338c0913064e" /> | <img width="80" height="80" alt="after" src="https://github.com/user-attachments/assets/035c2d4f-2d0d-4c2f-b122-9c3921327c36" /> |