### PR TITLE
feat(usb-drive-manager): show usage bar before usage data is collected

### DIFF
--- a/usb-drive-manager/DeviceCard.qml
+++ b/usb-drive-manager/DeviceCard.qml
@@ -118,7 +118,7 @@ Rectangle {
 
         // ── Usage bar ────────────────────────────────────────────────────────
         ColumnLayout {
-            visible: (device?.isMounted ?? false) && (device?.usedPercent ?? 0) > 0
+            visible: device?.isMounted ?? false
             Layout.fillWidth: true
             spacing: Style.marginXS
 
@@ -148,7 +148,9 @@ Rectangle {
                 Layout.fillWidth: true
 
                 NText {
-                    text: pluginApi?.tr("device.used", { size: device?.usedSize ?? "" })
+                    text: device?.usedSize ?? ""
+                        ? pluginApi?.tr("device.used", { size: device?.usedSize ?? "" })
+                        : pluginApi?.tr("device.loading")
                     pointSize: Style.fontSizeXXS
                     color: Color.mOnSurfaceVariant
                 }
@@ -156,7 +158,9 @@ Rectangle {
                 Item { Layout.fillWidth: true }
 
                 NText {
-                    text: pluginApi?.tr("device.free", { size: device?.freeSize ?? "" })
+                    text: device?.freeSize ?? ""
+                        ? pluginApi?.tr("device.free", { size: device?.freeSize ?? "" })
+                        : ""
                     pointSize: Style.fontSizeXXS
                     color: Color.mOnSurfaceVariant
                 }

--- a/usb-drive-manager/i18n/de.json
+++ b/usb-drive-manager/i18n/de.json
@@ -14,6 +14,7 @@
   },
   "device": {
     "mounted": "Eingehängt",
+    "loading": "Laden...",
     "used": "{size} belegt",
     "free": "{size} frei",
     "action-open": "Öffnen",

--- a/usb-drive-manager/i18n/en.json
+++ b/usb-drive-manager/i18n/en.json
@@ -14,6 +14,7 @@
   },
   "device": {
     "mounted": "Mounted",
+    "loading": "Loading...",
     "used": "{size} used",
     "free": "{size} free",
     "action-open": "Open",

--- a/usb-drive-manager/i18n/fr.json
+++ b/usb-drive-manager/i18n/fr.json
@@ -14,6 +14,7 @@
   },
   "device": {
     "mounted": "Monté",
+    "loading": "Chargement...",
     "used": "{size} utilisé",
     "free": "{size} libre",
     "action-open": "Ouvrir",

--- a/usb-drive-manager/manifest.json
+++ b/usb-drive-manager/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "usb-drive-manager",
   "name": "USB Drive Manager",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "minNoctaliaVersion": "3.6.0",
   "author": "hennifant",
   "license": "MIT",


### PR DESCRIPTION
Show empty usage bar before usage statistics data is collected to prevent buttons below it "jumping down" once the data is updated.

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
  <td>

https://github.com/user-attachments/assets/c38a77c8-3358-4491-b14e-9ed77473b042

  </td>
  <td>

https://github.com/user-attachments/assets/ae413fda-4d75-4a42-85d3-7ed206945960

  </td>
  </tr>
</table>