### PR TITLE
wallcards - fix showing orphaned cards

### DIFF
--- a/wallcards/Settings.qml
+++ b/wallcards/Settings.qml
@@ -25,7 +25,6 @@ ColumnLayout {
   property string editSelectedFilter: pluginApi?.pluginSettings?.selected_filter || pluginApi?.manifest?.metadata?.defaultSettings?.selected_filter
   property real editShearFactor: pluginApi?.pluginSettings?.shear_factor ?? pluginApi?.manifest?.metadata?.defaultSettings?.shear_factor
   property int editTopBarHeight: pluginApi?.pluginSettings?.top_bar_height ?? pluginApi?.manifest?.metadata?.defaultSettings?.top_bar_height
-  property string editWallpaperDir: pluginApi?.pluginSettings?.wallpaper_directory || root.pluginApi?.Settings.data.wallpaper.directory
   property var pluginApi: null
 
   function saveSettings() {
@@ -55,7 +54,6 @@ ColumnLayout {
     pluginApi.pluginSettings.hide_help = root.editHideHelp;
     pluginApi.pluginSettings.hide_top_bar = root.editHideTopBar;
     pluginApi.pluginSettings.animate_window = root.editAnimateWindow;
-    pluginApi.pluginSettings.directory = root.editWallpaperDir;
 
     pluginApi.saveSettings();
     Logger.i("Wallcards", "Settings saved");
@@ -73,22 +71,6 @@ ColumnLayout {
     model: Color.colorKeyModel
 
     onSelected: key => root.editIconColor = key
-  }
-  NDivider {
-    Layout.fillWidth: true
-  }
-
-  // ── Wallpaper Directory ──
-  NTextInputButton {
-    buttonIcon: "folder-open"
-    buttonTooltip: root.pluginApi?.tr("settings.wallpaper-directory.tooltip")
-    description: root.pluginApi?.tr("settings.wallpaper-directory.description")
-    label: root.pluginApi?.tr("settings.wallpaper-directory.label")
-    placeholderText: Quickshell.env("HOME") + "/Pictures/Wallpapers"
-    text: root.editWallpaperDir
-
-    onButtonClicked: folderPicker.openFilePicker()
-    onInputEditingFinished: root.editWallpaperDir = text
   }
   NDivider {
     Layout.fillWidth: true
@@ -374,20 +356,5 @@ ColumnLayout {
   ColumnLayout {
     Layout.fillWidth: true
     spacing: Style.marginXXS
-  }
-
-  // ── Utils ──
-  NFilePicker {
-    id: folderPicker
-
-    initialPath: root.editWallpaperDir || Quickshell.env("HOME") + "/Pictures/Wallpapers"
-    selectionMode: "folders"
-    title: root.pluginApi?.tr("settings.folder-picker-title")
-
-    onAccepted: paths => {
-      if (paths.length > 0) {
-        root.editWallpaperDir = paths[0];
-      }
-    }
   }
 }

--- a/wallcards/i18n/de.json
+++ b/wallcards/i18n/de.json
@@ -16,12 +16,6 @@
       "label": "Symbolfarbe",
       "description": "Farbe des Leistensymbols"
     },
-    "wallpaper-directory": {
-      "label": "Hintergrundbilder-Ordner",
-      "description": "Ordner mit deinen Hintergrundbildern",
-      "tooltip": "Hintergrundbilder-Ordner auswählen",
-      "placeholder": "~/Bilder/Hintergrundbilder"
-    },
     "live-preview": {
       "label": "Live-Vorschau",
       "description": "Hintergrundbild beim Durchblättern anwenden"
@@ -85,8 +79,7 @@
     "top-bar-height": {
       "label": "Kopfleistenhöhe",
       "description": "Höhe der Werkzeugleiste"
-    },
-    "folder-picker-title": "Hintergrundbilder-Ordner auswählen"
+    }
   },
   "shortcuts": {
     "key-separator": "/",

--- a/wallcards/i18n/en.json
+++ b/wallcards/i18n/en.json
@@ -16,12 +16,6 @@
       "label": "Icon Color",
       "description": "Color of the bar widget icon"
     },
-    "wallpaper-directory": {
-      "label": "Wallpaper Directory",
-      "description": "Folder containing your wallpapers",
-      "tooltip": "Select wallpaper folder",
-      "placeholder": "~/Pictures/Wallpapers"
-    },
     "live-preview": {
       "label": "Live Preview",
       "description": "Apply wallpaper while browsing cards"
@@ -85,8 +79,7 @@
     "top-bar-height": {
       "label": "Top Bar Height",
       "description": "Height of the toolbar"
-    },
-    "folder-picker-title": "Select wallpaper folder"
+    }
   },
   "shortcuts": {
     "key-separator": "/",

--- a/wallcards/i18n/es.json
+++ b/wallcards/i18n/es.json
@@ -16,12 +16,6 @@
       "label": "Color del icono",
       "description": "Color del icono del widget de barra"
     },
-    "wallpaper-directory": {
-      "label": "Directorio de fondos",
-      "description": "Carpeta que contiene tus fondos de pantalla",
-      "tooltip": "Seleccionar carpeta de fondos",
-      "placeholder": "~/Imágenes/Fondos"
-    },
     "live-preview": {
       "label": "Vista previa en vivo",
       "description": "Aplicar fondo mientras navegas por las tarjetas"
@@ -85,8 +79,7 @@
     "top-bar-height": {
       "label": "Altura de barra superior",
       "description": "Altura de la barra de herramientas"
-    },
-    "folder-picker-title": "Seleccionar carpeta de fondos"
+    }
   },
   "shortcuts": {
     "key-separator": "/",

--- a/wallcards/i18n/fr.json
+++ b/wallcards/i18n/fr.json
@@ -16,12 +16,6 @@
       "label": "Couleur de l'icône",
       "description": "Couleur de l'icône du widget de barre"
     },
-    "wallpaper-directory": {
-      "label": "Dossier de fonds d'écran",
-      "description": "Dossier contenant vos fonds d'écran",
-      "tooltip": "Sélectionner le dossier de fonds d'écran",
-      "placeholder": "~/Images/Fonds"
-    },
     "live-preview": {
       "label": "Aperçu en direct",
       "description": "Appliquer le fond d'écran en parcourant les cartes"
@@ -85,8 +79,7 @@
     "top-bar-height": {
       "label": "Hauteur de la barre supérieure",
       "description": "Hauteur de la barre d'outils"
-    },
-    "folder-picker-title": "Sélectionner le dossier de fonds d'écran"
+    }
   },
   "shortcuts": {
     "key-separator": "/",

--- a/wallcards/i18n/hu.json
+++ b/wallcards/i18n/hu.json
@@ -16,12 +16,6 @@
       "label": "Ikon színe",
       "description": "A sáv widget ikonjának színe"
     },
-    "wallpaper-directory": {
-      "label": "Háttérképek mappa",
-      "description": "A háttérképeket tartalmazó mappa",
-      "tooltip": "Háttérképek mappa kiválasztása",
-      "placeholder": "~/Képek/Háttérképek"
-    },
     "live-preview": {
       "label": "Élő előnézet",
       "description": "Háttérkép alkalmazása böngészés közben"
@@ -85,8 +79,7 @@
     "top-bar-height": {
       "label": "Felső sáv magassága",
       "description": "Az eszköztár magassága"
-    },
-    "folder-picker-title": "Háttérképek mappa kiválasztása"
+    }
   },
   "shortcuts": {
     "key-separator": "/",

--- a/wallcards/i18n/it.json
+++ b/wallcards/i18n/it.json
@@ -16,12 +16,6 @@
       "label": "Colore icona",
       "description": "Colore dell'icona del widget della barra"
     },
-    "wallpaper-directory": {
-      "label": "Cartella sfondi",
-      "description": "Cartella contenente i tuoi sfondi",
-      "tooltip": "Seleziona cartella sfondi",
-      "placeholder": "~/Immagini/Sfondi"
-    },
     "live-preview": {
       "label": "Anteprima dal vivo",
       "description": "Applica lo sfondo durante la navigazione delle schede"
@@ -85,8 +79,7 @@
     "top-bar-height": {
       "label": "Altezza barra superiore",
       "description": "Altezza della barra degli strumenti"
-    },
-    "folder-picker-title": "Seleziona cartella sfondi"
+    }
   },
   "shortcuts": {
     "key-separator": "/",

--- a/wallcards/i18n/ja.json
+++ b/wallcards/i18n/ja.json
@@ -16,12 +16,6 @@
       "label": "アイコンの色",
       "description": "バーウィジェットのアイコンの色"
     },
-    "wallpaper-directory": {
-      "label": "壁紙フォルダ",
-      "description": "壁紙が含まれるフォルダ",
-      "tooltip": "壁紙フォルダを選択",
-      "placeholder": "~/画像/壁紙"
-    },
     "live-preview": {
       "label": "ライブプレビュー",
       "description": "カードを閲覧しながら壁紙を適用"
@@ -85,8 +79,7 @@
     "top-bar-height": {
       "label": "トップバーの高さ",
       "description": "ツールバーの高さ"
-    },
-    "folder-picker-title": "壁紙フォルダを選択"
+    }
   },
   "shortcuts": {
     "key-separator": "/",

--- a/wallcards/i18n/ku.json
+++ b/wallcards/i18n/ku.json
@@ -16,12 +16,6 @@
       "label": "Rengê îkonê",
       "description": "Rengê îkona wîceta barê"
     },
-    "wallpaper-directory": {
-      "label": "Peldanka dîwarê",
-      "description": "Peldanka ku dîwarên te tê de hene",
-      "tooltip": "Peldanka dîwarê hilbijêre",
-      "placeholder": "~/Wêne/Dîwar"
-    },
     "live-preview": {
       "label": "Pêşdîtina zindî",
       "description": "Dîwarê bi kar bîne dema ku kartên digerin"
@@ -85,8 +79,7 @@
     "top-bar-height": {
       "label": "Bilindahiya barê jorîn",
       "description": "Bilindahiya amûrbarê"
-    },
-    "folder-picker-title": "Peldanka dîwarê hilbijêre"
+    }
   },
   "shortcuts": {
     "key-separator": "/",

--- a/wallcards/i18n/nl.json
+++ b/wallcards/i18n/nl.json
@@ -16,12 +16,6 @@
       "label": "Pictogramkleur",
       "description": "Kleur van het balkwidget-pictogram"
     },
-    "wallpaper-directory": {
-      "label": "Achtergrondmap",
-      "description": "Map met je achtergronden",
-      "tooltip": "Achtergrondmap selecteren",
-      "placeholder": "~/Afbeeldingen/Achtergronden"
-    },
     "live-preview": {
       "label": "Live voorbeeld",
       "description": "Achtergrond toepassen tijdens het bladeren"
@@ -85,8 +79,7 @@
     "top-bar-height": {
       "label": "Hoogte bovenste balk",
       "description": "Hoogte van de werkbalk"
-    },
-    "folder-picker-title": "Achtergrondmap selecteren"
+    }
   },
   "shortcuts": {
     "key-separator": "/",

--- a/wallcards/i18n/pl.json
+++ b/wallcards/i18n/pl.json
@@ -16,12 +16,6 @@
       "label": "Kolor ikony",
       "description": "Kolor ikony widżetu paska"
     },
-    "wallpaper-directory": {
-      "label": "Folder tapet",
-      "description": "Folder zawierający twoje tapety",
-      "tooltip": "Wybierz folder tapet",
-      "placeholder": "~/Obrazy/Tapety"
-    },
     "live-preview": {
       "label": "Podgląd na żywo",
       "description": "Zastosuj tapetę podczas przeglądania kart"
@@ -85,8 +79,7 @@
     "top-bar-height": {
       "label": "Wysokość górnego paska",
       "description": "Wysokość paska narzędzi"
-    },
-    "folder-picker-title": "Wybierz folder tapet"
+    }
   },
   "shortcuts": {
     "key-separator": "/",

--- a/wallcards/i18n/pt.json
+++ b/wallcards/i18n/pt.json
@@ -16,12 +16,6 @@
       "label": "Cor do ícone",
       "description": "Cor do ícone do widget da barra"
     },
-    "wallpaper-directory": {
-      "label": "Pasta de papéis de parede",
-      "description": "Pasta que contém seus papéis de parede",
-      "tooltip": "Selecionar pasta de papéis de parede",
-      "placeholder": "~/Imagens/PapeisDeParede"
-    },
     "live-preview": {
       "label": "Pré-visualização ao vivo",
       "description": "Aplicar papel de parede enquanto navega pelos cartões"
@@ -85,8 +79,7 @@
     "top-bar-height": {
       "label": "Altura da barra superior",
       "description": "Altura da barra de ferramentas"
-    },
-    "folder-picker-title": "Selecionar pasta de papéis de parede"
+    }
   },
   "shortcuts": {
     "key-separator": "/",

--- a/wallcards/i18n/ru.json
+++ b/wallcards/i18n/ru.json
@@ -16,12 +16,6 @@
       "label": "Цвет значка",
       "description": "Цвет значка виджета панели"
     },
-    "wallpaper-directory": {
-      "label": "Папка обоев",
-      "description": "Папка с вашими обоями",
-      "tooltip": "Выбрать папку обоев",
-      "placeholder": "~/Изображения/Обои"
-    },
     "live-preview": {
       "label": "Предпросмотр",
       "description": "Применять обои при просмотре карточек"
@@ -85,8 +79,7 @@
     "top-bar-height": {
       "label": "Высота верхней панели",
       "description": "Высота панели инструментов"
-    },
-    "folder-picker-title": "Выбрать папку обоев"
+    }
   },
   "shortcuts": {
     "key-separator": "/",

--- a/wallcards/i18n/tr.json
+++ b/wallcards/i18n/tr.json
@@ -16,12 +16,6 @@
       "label": "Simge rengi",
       "description": "Çubuk widget simgesinin rengi"
     },
-    "wallpaper-directory": {
-      "label": "Duvar kağıdı klasörü",
-      "description": "Duvar kağıtlarınızı içeren klasör",
-      "tooltip": "Duvar kağıdı klasörü seç",
-      "placeholder": "~/Resimler/DuvarKagitlari"
-    },
     "live-preview": {
       "label": "Canlı önizleme",
       "description": "Kartlara göz atarken duvar kağıdını uygula"
@@ -85,8 +79,7 @@
     "top-bar-height": {
       "label": "Üst çubuk yüksekliği",
       "description": "Araç çubuğunun yüksekliği"
-    },
-    "folder-picker-title": "Duvar kağıdı klasörü seç"
+    }
   },
   "shortcuts": {
     "key-separator": "/",

--- a/wallcards/i18n/uk-UA.json
+++ b/wallcards/i18n/uk-UA.json
@@ -16,12 +16,6 @@
       "label": "Колір значка",
       "description": "Колір значка віджета панелі"
     },
-    "wallpaper-directory": {
-      "label": "Тека шпалер",
-      "description": "Тека з вашими шпалерами",
-      "tooltip": "Обрати теку шпалер",
-      "placeholder": "~/Зображення/Шпалери"
-    },
     "live-preview": {
       "label": "Попередній перегляд",
       "description": "Застосовувати шпалери під час перегляду карток"
@@ -85,8 +79,7 @@
     "top-bar-height": {
       "label": "Висота верхньої панелі",
       "description": "Висота панелі інструментів"
-    },
-    "folder-picker-title": "Обрати теку шпалер"
+    }
   },
   "shortcuts": {
     "key-separator": "/",

--- a/wallcards/i18n/vi.json
+++ b/wallcards/i18n/vi.json
@@ -16,12 +16,6 @@
       "label": "Màu biểu tượng",
       "description": "Màu của biểu tượng widget thanh"
     },
-    "wallpaper-directory": {
-      "label": "Thư mục hình nền",
-      "description": "Thư mục chứa hình nền của bạn",
-      "tooltip": "Chọn thư mục hình nền",
-      "placeholder": "~/Ảnh/HìnhNền"
-    },
     "live-preview": {
       "label": "Xem trước trực tiếp",
       "description": "Áp dụng hình nền khi duyệt thẻ"
@@ -85,8 +79,7 @@
     "top-bar-height": {
       "label": "Chiều cao thanh trên",
       "description": "Chiều cao của thanh công cụ"
-    },
-    "folder-picker-title": "Chọn thư mục hình nền"
+    }
   },
   "shortcuts": {
     "key-separator": "/",

--- a/wallcards/i18n/zh-CN.json
+++ b/wallcards/i18n/zh-CN.json
@@ -16,12 +16,6 @@
       "label": "图标颜色",
       "description": "栏小部件图标的颜色"
     },
-    "wallpaper-directory": {
-      "label": "壁纸目录",
-      "description": "包含壁纸的文件夹",
-      "tooltip": "选择壁纸文件夹",
-      "placeholder": "~/图片/壁纸"
-    },
     "live-preview": {
       "label": "实时预览",
       "description": "浏览卡片时应用壁纸"
@@ -85,8 +79,7 @@
     "top-bar-height": {
       "label": "顶栏高度",
       "description": "工具栏的高度"
-    },
-    "folder-picker-title": "选择壁纸文件夹"
+    }
   },
   "shortcuts": {
     "key-separator": "/",

--- a/wallcards/manifest.json
+++ b/wallcards/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "wallcards",
   "name": "Wallcards",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "minNoctaliaVersion": "4.7.0",
   "author": "tonigineer",
   "license": "MIT",

--- a/wallcards/src/ThumbnailService.qml
+++ b/wallcards/src/ThumbnailService.qml
@@ -142,6 +142,13 @@ Item {
   }
 
   function buildFileList() {
+    // Ground truth needed to avoid showing thumbnails for files
+    // that are no longer in the wallpaper directory.
+    var existingFiles = new Set();
+    for (let j = 0; j < thumbnailModel.count; j++) {
+      existingFiles.add(thumbnailModel.get(j, "fileName"));
+    }
+
     var items = [];
 
     for (let i = 0; i < filesModel.count; i++) {
@@ -159,6 +166,10 @@ Item {
       // Strip trailing .jpg to recover the original video filename.
       var isVid = thumbBase.toLowerCase().endsWith(".jpg") && Utils.isVideo(thumbBase.substring(0, thumbBase.lastIndexOf(".")), service.videoFilter);
       var wallpaperName = isVid ? thumbBase.substring(0, thumbBase.lastIndexOf(".")) : thumbBase;
+
+      if (!existingFiles.has(wallpaperName)) {
+        continue;
+      }
 
       items.push({
         fileName: wallpaperName,


### PR DESCRIPTION
@sivansh11 mentioned an issue with showing cards for files, that are not present in the currently selected wallpaper directory (problem: all thumbnails in cache dir were taken). Added a comparison with current wallpaper directory's existing files to solve this.

Also removed unused wallpaper dir option in settings.