### PR TITLE
feat(network-manager-vpn): Add shortcut to control center

### DIFF
--- a/network-manager-vpn/ControlCenterWidget.qml
+++ b/network-manager-vpn/ControlCenterWidget.qml
@@ -19,11 +19,11 @@ NIconButtonHot {
         ? pluginApi?.tr("common.connected")
         : pluginApi?.tr("common.disconnected")
 
-colorFg: {
-    const key = connectedCount > 0 ? connectedColor : disconnectedColor;
-    if (!key || key === "none") return Color.mPrimary;
-    return Color.resolveColorKeyOptional(key) ?? Color.mPrimary;
-}
+    colorFg: {
+        const key = connectedCount > 0 ? connectedColor : disconnectedColor;
+        if (!key || key === "none") return Color.mPrimary;
+        return Color.resolveColorKeyOptional(key) ?? Color.mPrimary;
+    }
 
     onClicked: pluginApi?.togglePanel(screen, this)
 }

--- a/network-manager-vpn/ControlCenterWidget.qml
+++ b/network-manager-vpn/ControlCenterWidget.qml
@@ -1,0 +1,19 @@
+import QtQuick
+import Quickshell
+import qs.Widgets
+
+NIconButtonHot {
+    property ShellScreen screen
+    property var pluginApi: null
+
+    readonly property var main: pluginApi?.mainInstance ?? ({})
+    readonly property real connectedCount: main.connectedCount ?? 0
+    readonly property bool isLoading: main.isLoading ?? false
+
+    icon: isLoading ? "reload" : connectedCount > 0 ? "shield-lock" : "shield"
+    tooltipText: connectedCount > 0
+        ? pluginApi?.tr("common.connected")
+        : pluginApi?.tr("common.disconnected")
+
+    onClicked: pluginApi?.togglePanel(screen, this)
+}

--- a/network-manager-vpn/ControlCenterWidget.qml
+++ b/network-manager-vpn/ControlCenterWidget.qml
@@ -12,14 +12,18 @@ NIconButtonHot {
     readonly property bool isLoading: main.isLoading ?? false
     readonly property var pluginSettings: pluginApi?.pluginSettings ?? ({})
     readonly property string connectedColor: pluginSettings.connectedColor
-    readonly property string disconnectedColor: pluginSettings.disconnectedColor
+    readonly property string disconnectedColor: pluginSettings.disconnectedColor 
 
     icon: isLoading ? "reload" : connectedCount > 0 ? "shield-lock" : "shield"
     tooltipText: connectedCount > 0
         ? pluginApi?.tr("common.connected")
         : pluginApi?.tr("common.disconnected")
 
-    colorFg: Color.resolveColorKeyOptional(connectedCount > 0 ? connectedColor : disconnectedColor) ?? Color.mPrimary
+colorFg: {
+    const key = connectedCount > 0 ? connectedColor : disconnectedColor;
+    if (!key || key === "none") return Color.mPrimary;
+    return Color.resolveColorKeyOptional(key) ?? Color.mPrimary;
+}
 
     onClicked: pluginApi?.togglePanel(screen, this)
 }

--- a/network-manager-vpn/ControlCenterWidget.qml
+++ b/network-manager-vpn/ControlCenterWidget.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import Quickshell
 import qs.Widgets
+import qs.Commons
 
 NIconButtonHot {
     property ShellScreen screen
@@ -9,11 +10,16 @@ NIconButtonHot {
     readonly property var main: pluginApi?.mainInstance ?? ({})
     readonly property real connectedCount: main.connectedCount ?? 0
     readonly property bool isLoading: main.isLoading ?? false
+    readonly property var pluginSettings: pluginApi?.pluginSettings ?? ({})
+    readonly property string connectedColor: pluginSettings.connectedColor
+    readonly property string disconnectedColor: pluginSettings.disconnectedColor
 
     icon: isLoading ? "reload" : connectedCount > 0 ? "shield-lock" : "shield"
     tooltipText: connectedCount > 0
         ? pluginApi?.tr("common.connected")
         : pluginApi?.tr("common.disconnected")
+
+    colorFg: Color.resolveColorKeyOptional(connectedCount > 0 ? connectedColor : disconnectedColor) ?? Color.mPrimary
 
     onClicked: pluginApi?.togglePanel(screen, this)
 }

--- a/network-manager-vpn/manifest.json
+++ b/network-manager-vpn/manifest.json
@@ -15,6 +15,7 @@
   "entryPoints": {
     "main": "Main.qml",
     "barWidget": "BarWidget.qml",
+    "controlCenterWidget": "ControlCenterWidget.qml",
     "panel": "Panel.qml",
     "settings": "Settings.qml"
   },

--- a/network-manager-vpn/manifest.json
+++ b/network-manager-vpn/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "network-manager-vpn",
   "name": "Network Manager VPN",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "minNoctaliaVersion": "3.6.0",
   "author": "nZO",
   "license": "MIT",


### PR DESCRIPTION
## Summary
Add a shortcut to Network Manager VPN inside the control center

## Why
Felt like having this personally and decided to share

## What Changed

It's now possible to add Network Manager VPN to the control center's shortcuts. It displays the current connection status and can open the VPN menu on click.

<img width="194" height="139" alt="disconnected" src="https://github.com/user-attachments/assets/528d32e3-a54a-4791-bd0b-80bb404ef2f0" />

<img width="211" height="162" alt="connected-hover" src="https://github.com/user-attachments/assets/f3a3c78c-8f82-4142-94ff-5c2a2d632bfc" />