### PR TITLE
Fix exchange rate fetching

### DIFF
--- a/currency-exchange/Main.qml
+++ b/currency-exchange/Main.qml
@@ -93,7 +93,7 @@ Item {
   Process {
     id: apiProcess
 
-    command: ["curl", "-sf", "--connect-timeout", "5", "--max-time", "10", "https://api.frankfurter.app/latest?from=USD"]
+    command: ["curl", "-sf", "--connect-timeout", "5", "--max-time", "10", "-L", "https://api.frankfurter.app/latest?from=USD"]
     running: false
 
     stdout: StdioCollector {

--- a/currency-exchange/manifest.json
+++ b/currency-exchange/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "currency-exchange",
   "name": "Currency Exchange",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Currency conversion utility via launcher and bar widget",
   "tags": [
     "Launcher",


### PR DESCRIPTION
I'm not sure if this has always been the case but https://api.frankfurter.app/latest?from=USD returns HTTP status code of [301 (Moved Permanently)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/301).

```
~ ❯ curl -I "https://api.frankfurter.app/latest?from=USD"
HTTP/2 301
date: Mon, 04 May 2026 03:05:28 GMT
location: https://api.frankfurter.dev/v1/latest?from=USD
report-to: {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=HDYYmEu59C84I1DWAEHTtg488MBuYRZ4D4c04By9uVslAuns3GXvk9ZJIfISfn%2BHKImfMo5FRA4Be1NGWPCMzPfUQaqkXQsf3ab1ewVXwt2auSg4pGAlYpmgBmEYhsxy%2FElqnfQ7"}]}
nel: {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}
server: cloudflare
cf-ray: 9f6448b14b72f2d6-NRT
```

Adding [`-L`](https://curl.se/docs/manpage.html#-L) flag allows curl to follow the redirection.

```
~ ❯ curl -sf --connect-timeout 5 --max-time 10 -L "https://api.frankfurter.app/latest?from=USD"
{"amount":1.0,"base":"USD","date":"2026-04-30","rates":{"AUD":1.399,"BRL":4.9814,"CAD":1.3668,"CHF":0.78534,"CNY":6.8287,"CZK":20.822,"DKK":6.3849,"EUR":0.85455,"GBP":0.74026,"HKD":7.833,"HUF":311.78,"IDR":17346,"ILS":2.9527,"INR":94.92,"ISK":123.06,"JPY":156.56,"KRW":1477.0,"MXN":17.5158,"MYR":3.97,"NOK":9.3252,"NZD":1.7054,"PHP":61.458,"PLN":3.6408,"RON":4.4286,"SEK":9.2766,"SGD":1.2762,"THB":32.545,"TRY":45.185,"ZAR":16.7903}}%
```

CC @balor @ItsLemmy 