### PR TITLE
fix(arch-updater): Query sync database instead of local database and fix flatpak check

### DIFF
--- a/arch-updater/Main.qml
+++ b/arch-updater/Main.qml
@@ -241,7 +241,7 @@ Item {
     // Output format: application\tname\tnewver\toldver
     Process {
         id: getFlatpakUpdates
-        command: ["sh", "-c", "flatpak update --no-deploy --noninteractive >/dev/null 2>&1; join -t'\t' -j1 <(flatpak remote-ls --updates --app --columns=application,name,version 2>/dev/null | sort -t'\t' -k1,1) <(flatpak list --app --columns=application,version 2>/dev/null | sort -t'\t' -k1,1)"]
+        command: ["sh", "-c", "flatpak update --no-deploy --noninteractive >/dev/null 2>&1; join -t'\t' -j1 <(flatpak remote-ls --updates --columns=application,name,version 2>/dev/null | sort -t'\t' -k1,1) <(flatpak list --columns=application,version 2>/dev/null | sort -t'\t' -k1,1)"]
         onExited: (exitCode, exitStatus) => {
             if (exitCode !== 0) {
                 Logger.w("Arch Updater", "Flatpak check exited with code " + exitCode)

--- a/arch-updater/Main.qml
+++ b/arch-updater/Main.qml
@@ -67,7 +67,7 @@ Item {
         switch (source) {
             case "system":
                 checkRepo.run(["sh", "-c", "pacman -Si " + id + " 2>/dev/null | awk '/^Repository/{print $3; exit}'"], output => {
-                    var repo = output
+                    var repo = output.trim()
                     switch (repo) {
                         case "cachyos-znver4":
                             var url = "https://packages.cachyos.org/package/cachyos-znver4/x86_64_v4/" + id

--- a/arch-updater/Main.qml
+++ b/arch-updater/Main.qml
@@ -236,11 +236,12 @@ Item {
     }
 
     // Single process for all flatpak update data
+    // Refreshes metadata using --no-deploy first so that the new version numbers get fetched
     // Joins remote (new) versions with installed (old) versions by application ID
     // Output format: application\tname\tnewver\toldver
     Process {
         id: getFlatpakUpdates
-        command: ["sh", "-c", "join -t'\t' -j1 <(flatpak remote-ls --updates --columns=application,name,version 2>/dev/null | sort -t'\t' -k1,1) <(flatpak list --columns=application,version 2>/dev/null | sort -t'\t' -k1,1)"]
+        command: ["sh", "-c", "flatpak update --no-deploy --noninteractive >/dev/null 2>&1; join -t'\t' -j1 <(flatpak remote-ls --updates --app --columns=application,name,version 2>/dev/null | sort -t'\t' -k1,1) <(flatpak list --app --columns=application,version 2>/dev/null | sort -t'\t' -k1,1)"]
         onExited: (exitCode, exitStatus) => {
             if (exitCode !== 0) {
                 Logger.w("Arch Updater", "Flatpak check exited with code " + exitCode)
@@ -265,7 +266,7 @@ Item {
                     // Expected format: application\tname\tnewver\toldver
                     if (parts.length >= 4) {
                         names.push(parts[1])
-                        rows.push({id: parts[0], name: parts[1], oldVer: parts[2], newVer: parts[3], source: "flatpak" })
+                        rows.push({id: parts[0], name: parts[1], oldVer: parts[3], newVer: parts[2], source: "flatpak" })
                     }
                 }
 

--- a/arch-updater/Main.qml
+++ b/arch-updater/Main.qml
@@ -66,7 +66,7 @@ Item {
         // Opens the page for the package
         switch (source) {
             case "system":
-                checkRepo.run(["sh", "-c", "pacman -Qi " + id + " | awk 'FNR <= 1 {print $4}'"], output => {
+                checkRepo.run(["sh", "-c", "pacman -Si " + id + " 2>/dev/null | awk '/^Repository/{print $3; exit}'"], output => {
                     var repo = output
                     switch (repo) {
                         case "cachyos-znver4":

--- a/arch-updater/Panel.qml
+++ b/arch-updater/Panel.qml
@@ -52,7 +52,7 @@ Item {
                 root.pluginApi.mainInstance.copy(text) // Copy text
             }
             else if (action === "open") {
-                Logger.d("Arch Updater", "open")
+                Logger.d("Arch Updater", "Open URL")
                 root.pluginApi.mainInstance.openURL(source, packageID) // Open link
             }
         }

--- a/arch-updater/manifest.json
+++ b/arch-updater/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "arch-updater",
   "name": "Arch Updater",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "minNoctaliaVersion": "3.6.0",
   "author": "Ast",
   "license": "MIT",


### PR DESCRIPTION
Now checks the source repo using pacman -Si as -Qi would sometimes return "None".
Refreshes app metadata for flatpaks before checking the version to prevent stale version numbers from being used, also swaps new/old versions as they were the wrong way round.