### PR TITLE
fix(video-wallpaper): respect disabled mpvpaper state on startup

### DIFF
--- a/video-wallpaper/main/Mpvpaper.qml
+++ b/video-wallpaper/main/Mpvpaper.qml
@@ -66,6 +66,8 @@ Item {
     }
 
     function activateMpvpaper() {
+        if (!root.enabled || root.currentWallpaper == "") return;
+
         // Just call this again if we are still checking
         if (mpvCheck.running) {
             Qt.callLater(activateMpvpaper);

--- a/video-wallpaper/manifest.json
+++ b/video-wallpaper/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "video-wallpaper",
   "name": "Video Wallpaper",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "minNoctaliaVersion": "3.6.0",
   "author": "spiros132",
   "license": "MIT",


### PR DESCRIPTION
Prior to this commit, Mpvpaper.qml would call activateMpvpaper() unconditionally on startup. This meant that it would activate mpvpaper even if the "Enabled" setting had been toggled off, or even if the user had never selected a wallpaper file.

This commit adds a guard in activateMpvpaper() that returns early when the plugin is disabled or no wallpaper is  selected.