### PR TITLE
feat(tailscale): add optional node search

### DIFF
--- a/tailscale/Panel.qml
+++ b/tailscale/Panel.qml
@@ -25,6 +25,7 @@ Item {
   property var selectedPeer: null
   property var selectedPeerDelegate: null
   property var sendTargetPeer: null
+  property string searchQuery: ""
 
   NFilePicker {
     id: sendFilePicker
@@ -53,6 +54,30 @@ Item {
   function normalizeFqdn(fqdn) {
     if (!fqdn) return ""
     return fqdn.endsWith(".") ? fqdn.slice(0, -1) : fqdn
+  }
+
+  function peerMatchesSearch(peer, query) {
+    var trimmedQuery = (query || "").trim().toLowerCase()
+    if (trimmedQuery === "") return true
+
+    var ipv4s = filterIPv4(peer?.TailscaleIPs || []).join(" ")
+    var fqdn = normalizeFqdn(peer?.DNSName)
+    var tsName = mainInstance ? mainInstance.tailscaleName(peer?.DNSName) : ""
+    var searchableText = [
+      peer?.HostName || "",
+      fqdn,
+      tsName,
+      ipv4s,
+      peer?.OS || ""
+    ].join(" ").toLowerCase()
+
+    var tokens = trimmedQuery.split(/\s+/)
+    for (var i = 0; i < tokens.length; i++) {
+      if (searchableText.indexOf(tokens[i]) === -1) {
+        return false
+      }
+    }
+    return true
   }
 
   function getOSIcon(os) {
@@ -253,6 +278,11 @@ Item {
     pluginApi?.manifest?.metadata?.defaultSettings?.hideMullvadExitNodes ??
     true
 
+  readonly property bool showSearchBar:
+    pluginApi?.pluginSettings?.showSearchBar ??
+    pluginApi?.manifest?.metadata?.defaultSettings?.showSearchBar ??
+    false
+
   readonly property string terminalCommand:
     pluginApi?.pluginSettings?.terminalCommand ||
     pluginApi?.manifest?.metadata?.defaultSettings?.terminalCommand ||
@@ -305,8 +335,23 @@ Item {
     return peers
   }
 
+  readonly property var filteredPeerList: {
+    var query = searchQuery.trim()
+    if (!showSearchBar || query === "") return sortedPeerList
+    return sortedPeerList.filter(function(peer) {
+      return peerMatchesSearch(peer, query)
+    })
+  }
+
+  readonly property bool searchActive: showSearchBar && searchQuery.trim() !== ""
+  readonly property bool searchHasNoResults:
+    searchActive &&
+    (mainInstance?.tailscaleRunning ?? false) &&
+    sortedPeerList.length > 0 &&
+    filteredPeerList.length === 0
+
   property real contentPreferredWidth: panelReady ? 400 * Style.uiScaleRatio : 0
-  property real contentPreferredHeight: panelReady ? Math.min(560, 260 + sortedPeerList.length * 48) * Style.uiScaleRatio : 0
+  property real contentPreferredHeight: panelReady ? Math.min(620, 310 + sortedPeerList.length * 48) * Style.uiScaleRatio : 0
 
   anchors.fill: parent
 
@@ -481,11 +526,27 @@ Item {
             }
           }
 
+          NTextInput {
+            id: searchInput
+            Layout.fillWidth: true
+            visible: root.showSearchBar && (root.mainInstance?.tailscaleRunning ?? false) && root.sortedPeerList.length > 0
+            placeholderText: root.pluginApi?.tr("panel.search-placeholder")
+            inputIconName: "search"
+            text: root.searchQuery
+            onTextChanged: root.searchQuery = searchInput.text
+
+            Keys.onEscapePressed: {
+              if (searchInput.text !== "") {
+                searchInput.text = ""
+              }
+            }
+          }
+
           Rectangle {
             Layout.fillWidth: true
             Layout.preferredHeight: 1
             color: Qt.alpha(Color.mOnSurface, 0.1)
-            visible: (mainInstance?.tailscaleRunning ?? false) && (mainInstance?.peerList?.length ?? 0) > 0
+            visible: (root.mainInstance?.tailscaleRunning ?? false) && root.sortedPeerList.length > 0
           }
 
           Flickable {
@@ -505,7 +566,7 @@ Item {
               spacing: Style.marginS
 
               Repeater {
-                model: sortedPeerList
+                model: root.filteredPeerList
 
                 delegate: ItemDelegate {
                   id: peerDelegate
@@ -598,8 +659,8 @@ Item {
                 Layout.fillWidth: true
                 Layout.alignment: Qt.AlignHCenter
                 Layout.topMargin: Style.marginL
-                text: pluginApi?.tr("panel.no-peers")
-                visible: !(mainInstance?.tailscaleRunning ?? false) || (mainInstance?.peerList?.length ?? 0) === 0
+                text: root.searchHasNoResults ? root.pluginApi?.tr("panel.no-search-results") : root.pluginApi?.tr("panel.no-peers")
+                visible: !(root.mainInstance?.tailscaleRunning ?? false) || root.sortedPeerList.length === 0 || root.searchHasNoResults
                 pointSize: Style.fontSizeM
                 color: Color.mOnSurfaceVariant
                 horizontalAlignment: Text.AlignHCenter

--- a/tailscale/README.md
+++ b/tailscale/README.md
@@ -13,6 +13,7 @@ A Tailscale status plugin for Noctalia that shows your Tailscale connection stat
 - **Peer Count**: Displays the number of connected devices in your tailnet
 - **Quick Toggle**: Click to connect/disconnect Tailscale
 - **Peer Context Menu**: Right-click a peer in the panel to copy its IP or FQDN, launch SSH/ping actions, use it as an exit node, or send a file via Taildrop
+- **Node Search**: Optionally filter the panel node list by hostname, DNS name, Tailscale name, IP address, or OS
 - **Taildrop Receive**: Toggle file receiving from the panel
 - **Exit Node Management**: Activate/deactivate exit nodes from the panel
 - **Context Menu**: Right-click for additional options (connect, disconnect, refresh, settings)
@@ -65,6 +66,7 @@ Right-click any online peer in the panel and choose **Send File**. A file picker
 | `showPeerCount` | `true` | Display the number of connected peers |
 | `hideDisconnected` | `false` | Hide disconnected peers from the panel list |
 | `hideMullvadExitNodes` | `true` | Hide Mullvad VPN exit nodes from the peer list |
+| `showSearchBar` | `false` | Show a search field above the panel node list |
 | `terminalCommand` | `""` | Terminal for SSH/ping (e.g. `ghostty`, `alacritty`) |
 | `sshUsername` | `""` | Username for SSH connections (leave empty for system default) |
 | `pingCount` | `5` | Number of pings to send when pinging a peer |
@@ -99,7 +101,8 @@ qs -c noctalia-shell ipc call plugin:tailscale <command>
 1. **Click** the icon to open the Tailscale panel
 2. **Right-click the bar widget** to open the context menu (connect/disconnect, settings)
 3. **Right-click a peer** in the panel to copy its IP/FQDN, SSH, ping, set as exit node, or send a file
-4. **Receive via Taildrop**: click "Receive via Taildrop" in the panel to fetch any pending incoming files
+4. **Search nodes**: if enabled in settings, type in the panel search box to filter by hostname, DNS name, Tailscale name, IP address, or OS
+5. **Receive via Taildrop**: click "Receive via Taildrop" in the panel to fetch any pending incoming files
 
 ## Troubleshooting
 

--- a/tailscale/Settings.qml
+++ b/tailscale/Settings.qml
@@ -40,6 +40,11 @@ ColumnLayout {
     pluginApi?.manifest?.metadata?.defaultSettings?.hideMullvadExitNodes ??
     true
 
+  property bool editShowSearchBar:
+    pluginApi?.pluginSettings?.showSearchBar ??
+    pluginApi?.manifest?.metadata?.defaultSettings?.showSearchBar ??
+    false
+
   property string editTerminalCommand:
     pluginApi?.pluginSettings?.terminalCommand ||
     pluginApi?.manifest?.metadata?.defaultSettings?.terminalCommand ||
@@ -173,6 +178,15 @@ ColumnLayout {
       }
     }
   }
+
+  NToggle {
+    Layout.fillWidth: true
+    label: pluginApi?.tr("settings.show-search-bar")
+    description: pluginApi?.tr("settings.show-search-bar-desc")
+    checked: root.editShowSearchBar
+    onToggled: checked => root.editShowSearchBar = checked
+  }
+
 
   NToggle {
     Layout.fillWidth: true
@@ -334,6 +348,7 @@ ColumnLayout {
     pluginApi.pluginSettings.showPeerCount = root.editShowPeerCount
     pluginApi.pluginSettings.hideDisconnected = root.editHideDisconnected
     pluginApi.pluginSettings.hideMullvadExitNodes = root.editHideMullvadExitNodes
+    pluginApi.pluginSettings.showSearchBar = root.editShowSearchBar
     pluginApi.pluginSettings.terminalCommand = root.editTerminalCommand
     pluginApi.pluginSettings.sshUsername = root.editSshUsername
     pluginApi.pluginSettings.pingCount = root.editPingCount

--- a/tailscale/TailscaleIcon.qml
+++ b/tailscale/TailscaleIcon.qml
@@ -6,6 +6,7 @@ import qs.Widgets
 
 Item {
   id: root
+  property var pluginApi: null
 
   property real pointSize: Style.fontSizeL
   property bool applyUiScale: true

--- a/tailscale/i18n/de.json
+++ b/tailscale/i18n/de.json
@@ -15,6 +15,8 @@
     "hide-disconnected-desc": "Nur Online Peers im Panel anzeigen",
     "hide-mullvad-exit-nodes": "Mullvad-Ausgangsknoten ausblenden",
     "hide-mullvad-exit-nodes-desc": "Mullvad-VPN-Ausgangsknoten aus der Peer-Liste ausblenden",
+    "show-search-bar": "Suchleiste anzeigen",
+    "show-search-bar-desc": "Zeigt ein Suchfeld über der Knotenliste im Panel an",
     "terminal": "Terminal Konfiguration",
     "terminal-command": "Terminal Befehl",
     "terminal-command-desc": "Befehl zum Starten eines Terminals für SSH/Ping (z.B. 'ghostty', 'alacritty', 'kitty')",
@@ -80,6 +82,8 @@
     "not-connected": "Nicht verbunden",
     "not-authenticated": "Nicht authentifiziert",
     "no-peers": "Keine verbundenen Peers",
+    "search-placeholder": "Knoten suchen...",
+    "no-search-results": "Keine Knoten entsprechen deiner Suche",
     "admin-console": "Admin Konsole",
     "terminal-warning": {
       "title": "Terminal nicht konfiguriert",

--- a/tailscale/i18n/en.json
+++ b/tailscale/i18n/en.json
@@ -15,6 +15,8 @@
     "hide-disconnected-desc": "Only show online peers in the panel",
     "hide-mullvad-exit-nodes": "Hide Mullvad Exit Nodes",
     "hide-mullvad-exit-nodes-desc": "Hide Mullvad VPN exit nodes from the peer list",
+    "show-search-bar": "Show Search Bar",
+    "show-search-bar-desc": "Display a search field above the panel node list",
     "terminal": "Terminal Configuration",
     "terminal-command": "Terminal Command",
     "ssh-username": "SSH Username",
@@ -80,6 +82,8 @@
     "not-connected": "Not connected",
     "not-authenticated": "Not authenticated",
     "no-peers": "No connected peers",
+    "search-placeholder": "Search nodes...",
+    "no-search-results": "No nodes match your search",
     "admin-console": "Admin Console",
     "terminal-warning": {
       "title": "Terminal Not Configured",

--- a/tailscale/i18n/fr.json
+++ b/tailscale/i18n/fr.json
@@ -15,6 +15,8 @@
     "hide-disconnected-desc": "Afficher uniquement les pairs en ligne dans le panneau",
     "hide-mullvad-exit-nodes": "Masquer les nœuds de sortie Mullvad",
     "hide-mullvad-exit-nodes-desc": "Masquer les nœuds de sortie Mullvad VPN de la liste des pairs",
+    "show-search-bar": "Afficher la barre de recherche",
+    "show-search-bar-desc": "Afficher un champ de recherche au-dessus de la liste des nœuds du panneau",
     "terminal": "Configuration du terminal",
     "terminal-command": "Commande du terminal",
     "terminal-command-desc": "Commande pour lancer le terminal pour SSH/ping (ex : 'ghostty', 'alacritty', 'kitty')",
@@ -80,6 +82,8 @@
     "not-connected": "Non connecté",
     "not-authenticated": "Non authentifié",
     "no-peers": "Aucun pair connecté",
+    "search-placeholder": "Rechercher des nœuds...",
+    "no-search-results": "Aucun nœud ne correspond à votre recherche",
     "admin-console": "Console d'administration",
     "terminal-warning": {
       "title": "Terminal non configuré",

--- a/tailscale/i18n/sv.json
+++ b/tailscale/i18n/sv.json
@@ -15,6 +15,8 @@
     "hide-disconnected-desc": "Visa endast online peers i panelen",
     "hide-mullvad-exit-nodes": "Dölj Mullvad-utgångsnoder",
     "hide-mullvad-exit-nodes-desc": "Dölj Mullvad VPN-utgångsnoder från peer-listan",
+    "show-search-bar": "Visa sökfält",
+    "show-search-bar-desc": "Visa ett sökfält ovanför nodlistan i panelen",
     "terminal": "Terminalkonfiguration",
     "terminal-command": "Terminalkommando",
     "terminal-command-desc": "Kommando för att starta terminal för SSH/ping (t.ex. 'ghostty', 'alacritty', 'kitty')",
@@ -80,6 +82,8 @@
     "not-connected": "Ej ansluten",
     "not-authenticated": "Ej autentiserad",
     "no-peers": "Inga anslutna peers",
+    "search-placeholder": "Sök noder...",
+    "no-search-results": "Inga noder matchar din sökning",
     "admin-console": "Administrationskonsol",
     "terminal-warning": {
       "title": "Terminal ej konfigurerad",

--- a/tailscale/i18n/vi.json
+++ b/tailscale/i18n/vi.json
@@ -15,6 +15,8 @@
     "hide-disconnected-desc": "Chỉ hiển thị các thiết bị đang trực tuyến trong bảng",
     "hide-mullvad-exit-nodes": "Ẩn exit node Mullvad",
     "hide-mullvad-exit-nodes-desc": "Ẩn các exit node VPN Mullvad khỏi danh sách thiết bị",
+    "show-search-bar": "Hiển thị thanh tìm kiếm",
+    "show-search-bar-desc": "Hiển thị ô tìm kiếm phía trên danh sách nút trong bảng",
     "terminal": "Cấu hình terminal",
     "terminal-command": "Lệnh terminal",
     "terminal-command-desc": "Lệnh để mở terminal cho SSH/ping (ví dụ: 'ghostty', 'alacritty', 'kitty')",
@@ -80,6 +82,8 @@
     "not-connected": "Chưa kết nối",
     "not-authenticated": "Chưa xác thực",
     "no-peers": "Không có thiết bị nào đang kết nối",
+    "search-placeholder": "Tìm kiếm nút...",
+    "no-search-results": "Không có nút nào khớp với tìm kiếm của bạn",
     "admin-console": "Bảng điều khiển quản trị",
     "terminal-warning": {
       "title": "Chưa cấu hình terminal",

--- a/tailscale/i18n/zh-CN.json
+++ b/tailscale/i18n/zh-CN.json
@@ -15,6 +15,8 @@
     "hide-disconnected-desc": "在面板中仅显示在线对等设备",
     "hide-mullvad-exit-nodes": "隐藏Mullvad出口节点",
     "hide-mullvad-exit-nodes-desc": "从对等设备列表中隐藏Mullvad VPN出口节点",
+    "show-search-bar": "显示搜索栏",
+    "show-search-bar-desc": "在面板节点列表上方显示搜索字段",
     "terminal": "终端配置",
     "terminal-command": "终端命令",
     "terminal-command-desc": "启动终端以进行SSH/ping的命令（例如，'ghostty'、'alacritty'、'kitty'）",
@@ -80,6 +82,8 @@
     "not-connected": "未连接",
     "not-authenticated": "未认证",
     "no-peers": "没有连接的对等设备",
+    "search-placeholder": "搜索节点...",
+    "no-search-results": "没有节点匹配您的搜索",
     "admin-console": "管理控制台",
     "terminal-warning": {
       "title": "终端未配置",

--- a/tailscale/manifest.json
+++ b/tailscale/manifest.json
@@ -29,6 +29,7 @@
       "showPeerCount": true,
       "hideDisconnected": false,
       "hideMullvadExitNodes": true,
+      "showSearchBar": false,
       "terminalCommand": "",
       "sshUsername": "",
       "pingCount": 5,

--- a/tailscale/manifest.json
+++ b/tailscale/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "tailscale",
   "name": "Tailscale",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "minNoctaliaVersion": "4.0.0",
   "author": "nineluj",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Adds an optional search bar to the Tailscale panel node list.

- Adds `showSearchBar` plugin setting, defaulting to `false`
- Adds a Settings toggle to enable/disable the search bar
- Filters nodes by hostname, DNS name, Tailscale short name, IPv4 address, and OS
- Bypasses filtering entirely when the search bar is disabled