### PR TITLE
fix(video-wallpaper): include gif & webm wallpapers

### DIFF
--- a/video-wallpaper/Main.qml
+++ b/video-wallpaper/Main.qml
@@ -223,7 +223,7 @@ Item {
     FolderModel {
         id: rootFolderModel
         folder: root.wallpapersFolder
-        filters: ["*.mp4", "*.avi", "*.mov"]
+        filters: ["*.mp4", "*.avi", "*.mov", "*.webm", "*.gif"]
     }
 
     FolderModel {

--- a/video-wallpaper/Panel.qml
+++ b/video-wallpaper/Panel.qml
@@ -94,7 +94,7 @@ Item {
                     text:        root.pluginApi?.tr("panel.tool_row.refresh.text")
                     tooltipText: root.pluginApi?.tr("panel.tool_row.refresh.tooltip")
 
-                    onClicked: { 
+                    onClicked: {
                         if(root.pluginApi.mainInstance == null) {
                             Logger.e("video-wallpaper", "Main instance is null, so can't call thumbRegenerate");
                         }
@@ -164,7 +164,7 @@ Item {
     FolderModel {
         id: folderModel
         folder: root.wallpapersFolder
-        filters: ["*.mp4", "*.avi", "*.mov"]
+        filters: ["*.mp4", "*.avi", "*.mov", "*.webm", "*.gif"]
     }
 
     NFilePicker {

--- a/video-wallpaper/manifest.json
+++ b/video-wallpaper/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "video-wallpaper",
   "name": "Video Wallpaper",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "minNoctaliaVersion": "3.6.0",
   "author": "spiros132",
   "license": "MIT",


### PR DESCRIPTION
This commit allows .webm and .gif files to be selected from the selection panel.

Both backends (qt6-multimedia and mpvpaper) already support GIF and VP8/VP9 WebM wallpapers, and those files can already be used by editing settings.json. This change adds *.gif and *.webm to the selection panel’s file picker filters so those files appear in the UI and can be selected.