### PR TITLE
feat(keybind-cheatsheet): Hyprland Lua config support + undescribed-bind editing

### DIFF
--- a/keybind-cheatsheet/CHANGELOG.md
+++ b/keybind-cheatsheet/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [3.6.0] - 2026-05-17
+
+### Features
+
+**Hyprland Lua config support (`hyprland.lua`)**
+- Hyprland 0.55+ replaces hyprlang `.conf` with a Lua config. Added a second Hyprland parsing tor that queries `hyprctl binds -j` for the authoritative, already-evaluated bind list — correctly handling `require()`, `for` loops, and multi-key chords that cannot be recovered by static text parsing
+- Categories are recovered by lightly scanning `hyprland.lua` (and its `require()` modules) for `-- N. NAME` headers and `description = "..."` literals, with a prefix heuristic for loop-generated binds (e.g. `"Workspace " .. i`)
+- Parser mode setting `auto` / `lua` / `conf`: `auto` uses the Lua tor when `hyprland.lua` exists, otherwise the existing `.conf` parser
+- The legacy `.conf` parser is **kept unchanged as a fallback** for users still on hyprlang configs
+
+**Add description / hide binds without a description**
+- Binds with no description are now surfaced in a dedicated "Without Description" section instead of being dropped
+- Each undescribed bind can be given a custom description inline, or hidden, directly from the panel
+- Overrides are keyed by a stable bind identity (`submap|modmask|key|flags|dispatcher`) that excludes the unstable `__lua` registry ref, so they survive Hyprland restarts
+- New settings: `showUndescribedBinds` toggle, a hidden/custom-override summary, "Restore hidden" and "Clear all overrides" actions
+
+**`refresh` IPC**
+- Added `refresh` to the plugin IPC handler so the cheatsheet can be re-parsed from a keybind, e.g. `qs ipc call plugin:keybind-cheatsheet refresh`
+
+### Bug Fixes
+
+**Settings height field binding loop**
+- Fixed a `text` binding loop on the window-height input (reactive binding written back from `onTextChanged`); the field is now seeded once via `Component.onCompleted`
+
+### Settings
+
+- New "Hyprland Lua Path" + parser-mode controls and an "Undescribed Binds" section
+- Added i18n keys across all 20 language files (English fallback, Polish localized)
+
 ## [3.4.0] - 2026-04-07
 
 ### Bug Fixes

--- a/keybind-cheatsheet/Main.qml
+++ b/keybind-cheatsheet/Main.qml
@@ -86,10 +86,14 @@ Item {
     if (niriReadProcess.running) niriReadProcess.running = false;
     if (hyprGlobProcess.running) hyprGlobProcess.running = false;
     if (hyprReadProcess.running) hyprReadProcess.running = false;
+    if (hyprDetectProcess.running) hyprDetectProcess.running = false;
+    if (hyprLuaReadProcess.running) hyprLuaReadProcess.running = false;
+    if (hyprctlBindsProcess.running) hyprctlBindsProcess.running = false;
 
     // Clear process buffers
     niriGlobProcess.expandedFiles = [];
     hyprGlobProcess.expandedFiles = [];
+    hyprctlChunks = [];
     currentLines = [];
   }
 
@@ -100,6 +104,10 @@ Item {
     currentLines = [];
     collectedBinds = {};
     parseDepthCounter = 0;
+    luaCategoryHeaders = [];
+    descToCategory = ({});
+    prefixToCategory = [];
+    hyprctlChunks = [];
   }
 
   // Refresh function - accessible from mainInstance
@@ -173,18 +181,65 @@ Item {
     if (CompositorService.isHyprland) {
       filePath = pluginApi?.pluginSettings?.hyprlandConfigPath || (homeDir + "/.config/hypr/hyprland.conf");
       filePath = filePath.replace(/^~/, homeDir);
-    } else if (CompositorService.isNiri) {
+      hyprConfPath = filePath;
+
+      var luaPath = pluginApi?.pluginSettings?.hyprlandLuaConfigPath || (homeDir + "/.config/hypr/hyprland.lua");
+      hyprLuaPath = luaPath.replace(/^~/, homeDir);
+
+      var mode = pluginApi?.pluginSettings?.hyprlandParserMode || "auto";
+      if (mode === "conf") {
+        startHyprlandConfTor();
+      } else if (mode === "lua") {
+        startHyprlandLuaTor();
+      } else {
+        // auto: prefer lua if hyprland.lua exists, else fall back to .conf
+        hyprDetectProcess.command = ["sh", "-c", '[ -f "$1" ] && echo lua || echo conf', "sh", hyprLuaPath];
+        hyprDetectProcess.running = true;
+      }
+      return;
+    }
+
+    if (CompositorService.isNiri) {
       filePath = pluginApi?.pluginSettings?.niriConfigPath || (homeDir + "/.config/niri/config.kdl");
       filePath = filePath.replace(/^~/, homeDir);
-    }
-
-    filesToParse = [filePath];
-
-    if (CompositorService.isHyprland) {
-      parseNextHyprlandFile();
-    } else {
+      filesToParse = [filePath];
       parseNextNiriFile();
     }
+  }
+
+  // ========== HYPRLAND TOR SELECTION ==========
+  property string hyprConfPath: ""
+  property string hyprLuaPath: ""
+
+  Process {
+    id: hyprDetectProcess
+    running: false
+    property string result: ""
+    stdout: SplitParser {
+      onRead: data => { hyprDetectProcess.result = data.trim(); }
+    }
+    onExited: {
+      if (result === "lua") {
+        root.startHyprlandLuaTor();
+      } else {
+        root.startHyprlandConfTor();
+      }
+    }
+  }
+
+  function startHyprlandConfTor() {
+    filesToParse = [hyprConfPath];
+    parseNextHyprlandFile();
+  }
+
+  function startHyprlandLuaTor() {
+    // Read hyprland.lua + required modules to recover category headers,
+    // then query hyprctl for the authoritative (loop/require-expanded) binds.
+    luaCategoryHeaders = [];
+    descToCategory = ({});
+    prefixToCategory = [];
+    filesToParse = [hyprLuaPath];
+    parseNextHyprLuaFile();
   }
 
   function getDirectoryFromPath(filePath) {
@@ -469,6 +524,233 @@ Item {
       if (categoryOrder.indexOf(cat) === -1 && collectedBinds[cat].length > 0) {
         categories.push({ "title": cat, "binds": collectedBinds[cat] });
       }
+    }
+
+    saveToDb(categories);
+    isCurrentlyParsing = false;
+    clearParsingData();
+  }
+
+  // ========== HYPRLAND LUA TOR (hyprctl binds -j) ==========
+  property var luaCategoryHeaders: []   // ordered category titles from `-- N. NAME`
+  property var descToCategory: ({})     // exact description -> category
+  property var prefixToCategory: []     // [{prefix, category}] for loop-built binds
+  property var hyprctlChunks: []
+
+  function parseNextHyprLuaFile() {
+    if (parseDepthCounter >= maxParseDepth) {
+      runHyprctlBinds();
+      return;
+    }
+    parseDepthCounter++;
+
+    if (filesToParse.length === 0) {
+      runHyprctlBinds();
+      return;
+    }
+
+    var nextFile = filesToParse.shift();
+    if (parsedFiles[nextFile]) {
+      parseNextHyprLuaFile();
+      return;
+    }
+    parsedFiles[nextFile] = true;
+    currentLines = [];
+    hyprLuaReadProcess.currentFilePath = nextFile;
+    hyprLuaReadProcess.command = ["cat", nextFile];
+    hyprLuaReadProcess.running = true;
+  }
+
+  Process {
+    id: hyprLuaReadProcess
+    property string currentFilePath: ""
+    running: false
+
+    stdout: SplitParser {
+      onRead: data => {
+        if (root.currentLines.length < 10000) root.currentLines.push(data);
+      }
+    }
+
+    onExited: (exitCode, exitStatus) => {
+      if (exitCode === 0 && root.currentLines.length > 0) {
+        var currentCategory = null;
+        for (var i = 0; i < root.currentLines.length; i++) {
+          var line = root.currentLines[i];
+
+          // require("module") / require 'module' -> sibling <module>.lua
+          var reqMatch = line.match(/require\s*\(?\s*["']([^"']+)["']/);
+          if (reqMatch) {
+            var mod = reqMatch[1];
+            if (!mod.endsWith(".lua")) mod = mod + ".lua";
+            var resolved = root.resolveRelativePath(currentFilePath, mod);
+            if (!root.parsedFiles[resolved] && root.filesToParse.indexOf(resolved) === -1) {
+              root.filesToParse.push(resolved);
+            }
+          }
+
+          // Category header: -- 1. NAME
+          var headMatch = line.match(/^\s*--\s*\d+\.\s*(.+?)\s*$/);
+          if (headMatch) {
+            currentCategory = headMatch[1].trim();
+            if (root.luaCategoryHeaders.indexOf(currentCategory) === -1) {
+              root.luaCategoryHeaders.push(currentCategory);
+            }
+            continue;
+          }
+
+          // description = "..." / desc = '...'
+          var dMatch = line.match(/(?:description|desc)\s*=\s*["']([^"']*)["']/);
+          if (dMatch && currentCategory) {
+            var lit = dMatch[1];
+            if (line.indexOf("..") !== -1) {
+              // Concatenated/dynamic description (e.g. "Workspace " .. i)
+              var pfx = lit.trim();
+              if (pfx.length > 0) root.prefixToCategory.push({ prefix: pfx, category: currentCategory });
+            } else if (lit.length > 0 && root.descToCategory[lit] === undefined) {
+              root.descToCategory[lit] = currentCategory;
+            }
+          }
+        }
+      }
+      root.currentLines = [];
+      root.parseNextHyprLuaFile();
+    }
+  }
+
+  function runHyprctlBinds() {
+    hyprctlChunks = [];
+    hyprctlBindsProcess.command = ["hyprctl", "binds", "-j"];
+    hyprctlBindsProcess.running = true;
+  }
+
+  Process {
+    id: hyprctlBindsProcess
+    running: false
+
+    stdout: SplitParser {
+      onRead: data => {
+        if (root.hyprctlChunks.length < 20000) root.hyprctlChunks.push(data);
+      }
+    }
+
+    onExited: (exitCode, exitStatus) => {
+      if (exitCode !== 0 || root.hyprctlChunks.length === 0) {
+        Logger.e("keybind-cheatsheet", "hyprctl binds -j failed (exit " + exitCode + ")");
+        root.hyprctlChunks = [];
+        root.saveToDb([{
+          "title": root.pluginApi?.tr("error.unsupported-compositor"),
+          "binds": [{ "keys": "hyprctl", "desc": root.pluginApi?.tr("error.hyprctl-failed") }]
+        }]);
+        root.isCurrentlyParsing = false;
+        root.clearParsingData();
+        return;
+      }
+
+      var binds = [];
+      try {
+        binds = JSON.parse(root.hyprctlChunks.join("\n"));
+      } catch (e) {
+        Logger.e("keybind-cheatsheet", "hyprctl JSON parse failed: " + e);
+        binds = [];
+      }
+      root.hyprctlChunks = [];
+      root.buildCategoriesFromHyprctl(binds);
+    }
+  }
+
+  // Hyprland modifier bitmask (see HL_MODIFIER_*)
+  function decodeModmask(mask) {
+    var m = [];
+    if (mask & 64) m.push("Super");   // LOGO / SUPER / META
+    if (mask & 1)  m.push("Shift");
+    if (mask & 4)  m.push("Ctrl");
+    if (mask & 8)  m.push("Alt");
+    if (mask & 16) m.push("Mod2");
+    if (mask & 32) m.push("Mod3");
+    if (mask & 128) m.push("Mod5");
+    return m;
+  }
+
+  function computeBindId(b) {
+    // `arg` is an unstable lua registry ref for __lua binds — exclude it there.
+    var disp = (b.dispatcher === "__lua") ? "__lua" : (b.dispatcher + ":" + (b.arg || ""));
+    var flags = (b.release ? 1 : 0) + "" + (b.mouse ? 1 : 0) + (b.longPress ? 1 : 0);
+    return [b.submap || "", b.modmask, b.key, flags, disp].join("|");
+  }
+
+  function categoryForDesc(desc) {
+    if (descToCategory[desc] !== undefined) return descToCategory[desc];
+    for (var i = 0; i < prefixToCategory.length; i++) {
+      if (desc.indexOf(prefixToCategory[i].prefix) === 0) return prefixToCategory[i].category;
+    }
+    return null;
+  }
+
+  function buildCategoriesFromHyprctl(binds) {
+    var overrides = pluginApi?.pluginSettings?.bindOverrides || ({});
+    var showUndescribed = pluginApi?.pluginSettings?.showUndescribedBinds ?? true;
+
+    var byCat = ({});
+    var otherTitle = pluginApi?.tr("panel.other");
+    var undescTitle = pluginApi?.tr("panel.undescribed");
+
+    for (var i = 0; i < binds.length; i++) {
+      var b = binds[i];
+      if (!b || b.key === undefined) continue;
+
+      var bindId = computeBindId(b);
+      var ov = overrides[bindId];
+      if (ov && ov.hidden === true) continue;
+
+      var rawDesc = (b.has_description && b.description) ? b.description : "";
+      if (ov && ov.desc) rawDesc = ov.desc;
+      var undescribed = (rawDesc === "");
+
+      if (undescribed && !showUndescribed) continue;
+
+      var keyName = formatSpecialKey(b.key);
+      if (keyName === b.key) keyName = formatSpecialKey(String(b.key).toUpperCase());
+      var mods = decodeModmask(b.modmask);
+      var fullKey = mods.length > 0 ? (mods.join(" + ") + " + " + keyName) : keyName;
+
+      var cat;
+      if (undescribed) {
+        cat = undescTitle;
+      } else {
+        cat = categoryForDesc(rawDesc) || otherTitle;
+      }
+
+      if (!byCat[cat]) byCat[cat] = [];
+      byCat[cat].push({
+        "keys": fullKey,
+        "desc": undescribed ? "" : rawDesc,
+        "bindId": bindId,
+        "undescribed": undescribed
+      });
+    }
+
+    // Emit categories in lua header order, then Other, then Undescribed last.
+    var categories = [];
+    for (var h = 0; h < luaCategoryHeaders.length; h++) {
+      var t = luaCategoryHeaders[h];
+      if (byCat[t] && byCat[t].length > 0) {
+        categories.push({ "title": t, "binds": byCat[t] });
+        delete byCat[t];
+      }
+    }
+    if (byCat[otherTitle] && byCat[otherTitle].length > 0) {
+      categories.push({ "title": otherTitle, "binds": byCat[otherTitle] });
+      delete byCat[otherTitle];
+    }
+    var undesc = byCat[undescTitle];
+    if (undesc && undesc.length > 0) delete byCat[undescTitle];
+    // Any leftover categories (shouldn't normally happen)
+    for (var k in byCat) {
+      if (byCat[k] && byCat[k].length > 0) categories.push({ "title": k, "binds": byCat[k] });
+    }
+    if (undesc && undesc.length > 0) {
+      categories.push({ "title": undescTitle, "binds": undesc });
     }
 
     saveToDb(categories);
@@ -861,6 +1143,10 @@ Item {
           root.pluginApi.togglePanel(screen);
         });
       }
+    }
+
+    function refresh() {
+      root.refresh();
     }
   }
 }

--- a/keybind-cheatsheet/Panel.qml
+++ b/keybind-cheatsheet/Panel.qml
@@ -357,7 +357,7 @@ Item {
         Layout.fillWidth: true
         Layout.alignment: Qt.AlignVCenter
         text: itemData.desc
-        font.pointSize: 9
+        font.pointSize: Style.fontSizeXS
         color: Color.mOnSurface
         elide: Text.ElideRight
       }
@@ -368,7 +368,7 @@ Item {
         Layout.fillWidth: true
         Layout.alignment: Qt.AlignVCenter
         text: pluginApi?.tr("panel.no-description")
-        font.pointSize: 9
+        font.pointSize: Style.fontSizeXS
         font.italic: true
         color: Color.mOnSurfaceVariant
         elide: Text.ElideRight

--- a/keybind-cheatsheet/Panel.qml
+++ b/keybind-cheatsheet/Panel.qml
@@ -321,9 +321,13 @@ Item {
   Component {
     id: bindComponent
     RowLayout {
+      id: bindRow
       spacing: Style.marginS
       height: 22
       Layout.bottomMargin: 1
+
+      property bool editing: false
+
       Flow {
         Layout.preferredWidth: 220
         Layout.alignment: Qt.AlignVCenter
@@ -346,13 +350,77 @@ Item {
           }
         }
       }
+
+      // Described bind: plain text (unchanged behaviour)
       NText {
+        visible: !itemData.undescribed
         Layout.fillWidth: true
         Layout.alignment: Qt.AlignVCenter
         text: itemData.desc
         font.pointSize: 9
         color: Color.mOnSurface
         elide: Text.ElideRight
+      }
+
+      // Undescribed bind: placeholder + add-description / hide actions
+      NText {
+        visible: itemData.undescribed && !bindRow.editing
+        Layout.fillWidth: true
+        Layout.alignment: Qt.AlignVCenter
+        text: pluginApi?.tr("panel.no-description")
+        font.pointSize: 9
+        font.italic: true
+        color: Color.mOnSurfaceVariant
+        elide: Text.ElideRight
+
+        MouseArea {
+          anchors.fill: parent
+          cursorShape: Qt.PointingHandCursor
+          onClicked: { bindRow.editing = true; descInput.text = ""; descInput.inputItem.forceActiveFocus(); }
+        }
+      }
+
+      NTextInput {
+        id: descInput
+        visible: itemData.undescribed && bindRow.editing
+        Layout.fillWidth: true
+        Layout.preferredHeight: Style.baseWidgetSize
+        placeholderText: pluginApi?.tr("panel.add-description-placeholder")
+      }
+
+      NIconButton {
+        visible: itemData.undescribed && bindRow.editing
+        Layout.preferredHeight: 18
+        icon: "check"
+        tooltipText: pluginApi?.tr("panel.save-description")
+        onClicked: {
+          root.saveBindDescription(itemData.bindId, descInput.text);
+          bindRow.editing = false;
+        }
+      }
+
+      NIconButton {
+        visible: itemData.undescribed && bindRow.editing
+        Layout.preferredHeight: 18
+        icon: "close"
+        tooltipText: pluginApi?.tr("panel.cancel")
+        onClicked: { bindRow.editing = false; }
+      }
+
+      NIconButton {
+        visible: itemData.undescribed && !bindRow.editing
+        Layout.preferredHeight: 18
+        icon: "edit"
+        tooltipText: pluginApi?.tr("panel.add-description")
+        onClicked: { bindRow.editing = true; descInput.text = ""; descInput.inputItem.forceActiveFocus(); }
+      }
+
+      NIconButton {
+        visible: itemData.undescribed && !bindRow.editing
+        Layout.preferredHeight: 18
+        icon: "eye-off"
+        tooltipText: pluginApi?.tr("panel.hide-bind")
+        onClicked: { root.hideBind(itemData.bindId); }
       }
     }
   }
@@ -369,6 +437,39 @@ Item {
     return Color.mPrimaryContainer ?? "#6C757D";
   }
 
+  // ===== Bind override helpers (shared keyed map in plugin settings) =====
+  function _cloneOverrides() {
+    if (!pluginApi || !pluginApi.pluginSettings) return ({});
+    var src = pluginApi.pluginSettings.bindOverrides || ({});
+    try { return JSON.parse(JSON.stringify(src)); } catch (e) { return ({}); }
+  }
+
+  function saveBindDescription(bindId, desc) {
+    if (!pluginApi || !bindId) return;
+    var o = _cloneOverrides();
+    if (!o[bindId]) o[bindId] = ({});
+    var trimmed = (desc || "").trim();
+    if (trimmed.length === 0) {
+      delete o[bindId].desc;
+      if (Object.keys(o[bindId]).length === 0) delete o[bindId];
+    } else {
+      o[bindId].desc = trimmed;
+    }
+    pluginApi.pluginSettings.bindOverrides = o;
+    pluginApi.saveSettings();
+    pluginApi.mainInstance?.refresh();
+  }
+
+  function hideBind(bindId) {
+    if (!pluginApi || !bindId) return;
+    var o = _cloneOverrides();
+    if (!o[bindId]) o[bindId] = ({});
+    o[bindId].hidden = true;
+    pluginApi.pluginSettings.bindOverrides = o;
+    pluginApi.saveSettings();
+    pluginApi.mainInstance?.refresh();
+  }
+
   function buildColumnItems(categoryIndices) {
     var result = [];
     if (!categoryIndices) return result;
@@ -381,11 +482,15 @@ Item {
       result.push({ type: "header", title: cat.title });
       var term = root.searchText.toLowerCase()
       for (var j = 0; j < cat.binds.length; j++) {
-        if (!term || cat.binds[j].desc.toLowerCase().indexOf(term) !== -1) {
+        var bnd = cat.binds[j];
+        var isUndesc = bnd.undescribed === true;
+        if (!term || (bnd.desc && bnd.desc.toLowerCase().indexOf(term) !== -1) || (isUndesc && bnd.keys.toLowerCase().indexOf(term) !== -1)) {
           result.push({
             type: "bind",
-            keys: cat.binds[j].keys,
-            desc: cat.binds[j].desc
+            keys: bnd.keys,
+            desc: bnd.desc,
+            bindId: bnd.bindId || "",
+            undescribed: isUndesc
           });
         }
       }

--- a/keybind-cheatsheet/Settings.qml
+++ b/keybind-cheatsheet/Settings.qml
@@ -69,6 +69,9 @@ Item {
   property int editColumnCount: cfg.columnCount ?? defaults.columnCount ?? 3
   property string editModKeyVariable: cfg.modKeyVariable || defaults.modKeyVariable || "$mod"
   property string editHyprlandConfigPath: cfg.hyprlandConfigPath || defaults.hyprlandConfigPath || "~/.config/hypr/hyprland.conf"
+  property string editHyprlandLuaConfigPath: cfg.hyprlandLuaConfigPath || defaults.hyprlandLuaConfigPath || "~/.config/hypr/hyprland.lua"
+  property string editHyprlandParserMode: cfg.hyprlandParserMode || defaults.hyprlandParserMode || "auto"
+  property bool editShowUndescribedBinds: cfg.showUndescribedBinds ?? defaults.showUndescribedBinds ?? true
   property string editNiriConfigPath: cfg.niriConfigPath || defaults.niriConfigPath || "~/.config/niri/config.kdl"
 
   // Header
@@ -164,7 +167,7 @@ Item {
           id: heightInput
           Layout.preferredWidth: 100 * Style.uiScaleRatio
           Layout.preferredHeight: Style.baseWidgetSize
-          text: root.editWindowHeight > 0 ? root.editWindowHeight.toString() : "850"
+          Component.onCompleted: text = root.editWindowHeight > 0 ? root.editWindowHeight.toString() : "850"
           enabled: !autoHeightToggle.checked
           opacity: enabled ? 1.0 : 0.5
 
@@ -364,6 +367,67 @@ Item {
         }
       }
 
+      // Hyprland Lua path + parser mode
+      ColumnLayout {
+        spacing: Style.marginXS
+
+        RowLayout {
+          spacing: Style.marginS
+          NIcon {
+            icon: "terminal"
+            pointSize: Style.fontSizeM
+            color: Color.mPrimary
+          }
+          NText {
+            text: rootItem.pluginApi?.tr("settings.hyprland-lua-path")
+            color: Color.mOnSurface
+            pointSize: Style.fontSizeM
+            font.weight: Style.fontWeightBold
+          }
+        }
+
+        NTextInput {
+          id: hyprlandLuaPathInput
+          Layout.fillWidth: true
+          Layout.preferredHeight: Style.baseWidgetSize
+          text: root.editHyprlandLuaConfigPath
+          placeholderText: "~/.config/hypr/hyprland.lua"
+
+          onTextChanged: {
+            if (text.length > 0) root.editHyprlandLuaConfigPath = text;
+          }
+        }
+
+        RowLayout {
+          spacing: Style.marginM
+          NText {
+            text: rootItem.pluginApi?.tr("settings.hyprland-parser-mode")
+            color: Color.mOnSurface
+            pointSize: Style.fontSizeM
+          }
+          NComboBox {
+            id: parserModeCombo
+            Layout.preferredWidth: 180 * Style.uiScaleRatio
+            Layout.preferredHeight: Style.baseWidgetSize
+            model: ListModel {
+              ListElement { name: "Auto"; key: "auto" }
+              ListElement { name: "Lua (hyprctl)"; key: "lua" }
+              ListElement { name: "Legacy .conf"; key: "conf" }
+            }
+            currentKey: root.editHyprlandParserMode
+            onSelected: key => { root.editHyprlandParserMode = key; }
+          }
+        }
+
+        NText {
+          Layout.fillWidth: true
+          text: rootItem.pluginApi?.tr("settings.hyprland-lua-hint")
+          color: Color.mOnSurfaceVariant
+          pointSize: Style.fontSizeXS
+          wrapMode: Text.WordWrap
+        }
+      }
+
       Rectangle {
         Layout.preferredHeight: 1
         color: Color.mOutline
@@ -407,6 +471,99 @@ Item {
           color: Color.mOnSurfaceVariant
           pointSize: Style.fontSizeXS
           wrapMode: Text.WordWrap
+        }
+      }
+    }
+  }
+
+  // Undescribed / hidden binds (Hyprland lua tor)
+  NBox {
+    Layout.fillWidth: true
+    Layout.preferredHeight: undescContent.implicitHeight + Style.marginM * 2
+    color: Color.mSurfaceVariant
+
+    ColumnLayout {
+      id: undescContent
+      anchors.fill: parent
+      anchors.margins: Style.marginM
+      spacing: Style.marginS
+
+      function overrideCount(kind) {
+        var o = rootItem.pluginApi?.pluginSettings?.bindOverrides || ({});
+        var n = 0;
+        for (var k in o) {
+          if (kind === "hidden" && o[k] && o[k].hidden === true) n++;
+          else if (kind === "desc" && o[k] && o[k].desc) n++;
+        }
+        return n;
+      }
+
+      NText {
+        Layout.fillWidth: true
+        text: rootItem.pluginApi?.tr("settings.undescribed-title")
+        pointSize: Style.fontSizeL
+        font.weight: Style.fontWeightBold
+        color: Color.mOnSurface
+      }
+
+      NToggle {
+        label: rootItem.pluginApi?.tr("settings.show-undescribed")
+        checked: root.editShowUndescribedBinds
+        onToggled: function(checked) { root.editShowUndescribedBinds = checked; }
+      }
+
+      NText {
+        Layout.fillWidth: true
+        text: rootItem.pluginApi?.tr("settings.show-undescribed-hint")
+        color: Color.mOnSurfaceVariant
+        pointSize: Style.fontSizeXS
+        wrapMode: Text.WordWrap
+      }
+
+      NText {
+        Layout.fillWidth: true
+        text: rootItem.pluginApi?.tr("settings.overrides-summary")
+              .replace("{hidden}", undescContent.overrideCount("hidden"))
+              .replace("{custom}", undescContent.overrideCount("desc"))
+        color: Color.mOnSurfaceVariant
+        pointSize: Style.fontSizeS
+        wrapMode: Text.WordWrap
+      }
+
+      RowLayout {
+        spacing: Style.marginM
+
+        NButton {
+          text: rootItem.pluginApi?.tr("settings.restore-hidden")
+          icon: "eye"
+          onClicked: {
+            var o = rootItem.pluginApi?.pluginSettings?.bindOverrides || ({});
+            var next = ({});
+            for (var k in o) {
+              var e = ({});
+              if (o[k] && o[k].desc) e.desc = o[k].desc;
+              if (Object.keys(e).length > 0) next[k] = e;
+            }
+            if (rootItem.pluginApi && rootItem.pluginApi.pluginSettings) {
+              rootItem.pluginApi.pluginSettings.bindOverrides = next;
+              rootItem.pluginApi.saveSettings();
+              rootItem.pluginApi.mainInstance?.refresh();
+            }
+            ToastService.showNotice(rootItem.pluginApi?.tr("settings.restore-hidden-message"));
+          }
+        }
+
+        NButton {
+          text: rootItem.pluginApi?.tr("settings.clear-overrides")
+          icon: "rotate"
+          onClicked: {
+            if (rootItem.pluginApi && rootItem.pluginApi.pluginSettings) {
+              rootItem.pluginApi.pluginSettings.bindOverrides = ({});
+              rootItem.pluginApi.saveSettings();
+              rootItem.pluginApi.mainInstance?.refresh();
+            }
+            ToastService.showNotice(rootItem.pluginApi?.tr("settings.clear-overrides-message"));
+          }
         }
       }
     }
@@ -456,12 +613,16 @@ Item {
             root.editColumnCount = defaults.columnCount || 3;
             root.editModKeyVariable = defaults.modKeyVariable || "$mod";
             root.editHyprlandConfigPath = defaults.hyprlandConfigPath || "~/.config/hypr/hyprland.conf";
+            root.editHyprlandLuaConfigPath = defaults.hyprlandLuaConfigPath || "~/.config/hypr/hyprland.lua";
+            root.editHyprlandParserMode = defaults.hyprlandParserMode || "auto";
+            root.editShowUndescribedBinds = defaults.showUndescribedBinds ?? true;
             root.editNiriConfigPath = defaults.niriConfigPath || "~/.config/niri/config.kdl";
 
             widthInput.text = root.editWindowWidth.toString();
             heightInput.text = "850";
             modVarInput.text = root.editModKeyVariable;
             hyprlandPathInput.text = root.editHyprlandConfigPath;
+            hyprlandLuaPathInput.text = root.editHyprlandLuaConfigPath;
             niriPathInput.text = root.editNiriConfigPath;
 
             if (rootItem.pluginApi && rootItem.pluginApi.pluginSettings) {
@@ -558,6 +719,9 @@ Item {
     pluginApi.pluginSettings.columnCount = root.editColumnCount;
     pluginApi.pluginSettings.modKeyVariable = root.editModKeyVariable;
     pluginApi.pluginSettings.hyprlandConfigPath = root.editHyprlandConfigPath;
+    pluginApi.pluginSettings.hyprlandLuaConfigPath = root.editHyprlandLuaConfigPath;
+    pluginApi.pluginSettings.hyprlandParserMode = root.editHyprlandParserMode;
+    pluginApi.pluginSettings.showUndescribedBinds = root.editShowUndescribedBinds;
     pluginApi.pluginSettings.niriConfigPath = root.editNiriConfigPath;
     pluginApi.saveSettings();
     ToastService.showNotice(

--- a/keybind-cheatsheet/i18n/de.json
+++ b/keybind-cheatsheet/i18n/de.json
@@ -9,7 +9,8 @@
     "mango-not-supported": "MangoWC wird nicht unterstützt",
     "mango-detail": "Das MangoWC-Konfigurationsformat ist mit diesem Plugin nicht kompatibel",
     "unknown-compositor": "Unbekannter Compositor erkannt",
-    "unknown-detail": "Dieses Plugin unterstützt nur Niri und Hyprland als Compositor"
+    "unknown-detail": "Dieses Plugin unterstützt nur Niri und Hyprland als Compositor",
+    "hyprctl-failed": "hyprctl binds failed - is Hyprland running?"
   },
   "panel": {
     "loading": "Laden...",
@@ -19,7 +20,15 @@
     "workspace-switching": "ARBEITSBEREICHE - WECHSELN",
     "workspace-moving": "ARBEITSBEREICHE - VERSCHIEBEN",
     "workspace-mouse": "ARBEITSBEREICHE - MAUS",
-    "search-placeholder": "Tastenbelegung suchen..."
+    "search-placeholder": "Tastenbelegung suchen...",
+    "other": "Other",
+    "undescribed": "Without Description",
+    "no-description": "(no description)",
+    "add-description": "Add description",
+    "add-description-placeholder": "Description...",
+    "save-description": "Save",
+    "cancel": "Cancel",
+    "hide-bind": "Hide this bind"
   },
   "settings": {
     "title": "Tastenkürzel-Ubersicht Einstellungen",
@@ -51,7 +60,18 @@
     "width-range": "px (400-3000)",
     "height-range": "px (300-2000)",
     "hyprland-path": "Hyprland Pfad",
-    "niri-path": "Niri Pfad"
+    "niri-path": "Niri Pfad",
+    "hyprland-lua-path": "Hyprland Lua Path",
+    "hyprland-parser-mode": "Parser:",
+    "hyprland-lua-hint": "Auto: uses hyprland.lua via `hyprctl binds` when it exists, otherwise the legacy .conf parser.",
+    "undescribed-title": "Undescribed Binds",
+    "show-undescribed": "Show binds without a description",
+    "show-undescribed-hint": "When enabled, binds with no description appear in a dedicated section where you can add a description or hide them.",
+    "overrides-summary": "Hidden: {hidden} - Custom descriptions: {custom}",
+    "restore-hidden": "Restore hidden",
+    "restore-hidden-message": "Hidden binds restored.",
+    "clear-overrides": "Clear all overrides",
+    "clear-overrides-message": "All bind overrides cleared."
   },
   "barwidget": {
     "tooltip": "Tastenkürzel-Spickzettel",

--- a/keybind-cheatsheet/i18n/en.json
+++ b/keybind-cheatsheet/i18n/en.json
@@ -9,7 +9,8 @@
     "mango-not-supported": "MangoWC is not supported",
     "mango-detail": "MangoWC config format is not compatible with this plugin",
     "unknown-compositor": "Unknown compositor detected",
-    "unknown-detail": "This plugin only supports Hyprland and Niri compositors"
+    "unknown-detail": "This plugin only supports Hyprland and Niri compositors",
+    "hyprctl-failed": "hyprctl binds failed - is Hyprland running?"
   },
   "panel": {
     "loading": "Loading...",
@@ -19,7 +20,15 @@
     "workspace-switching": "WORKSPACES - SWITCHING",
     "workspace-moving": "WORKSPACES - MOVING",
     "workspace-mouse": "WORKSPACES - MOUSE",
-    "search-placeholder": "Search keybinds..."
+    "search-placeholder": "Search keybinds...",
+    "other": "Other",
+    "undescribed": "Without Description",
+    "no-description": "(no description)",
+    "add-description": "Add description",
+    "add-description-placeholder": "Description...",
+    "save-description": "Save",
+    "cancel": "Cancel",
+    "hide-bind": "Hide this bind"
   },
   "settings": {
     "title": "Keybind Cheatsheet Settings",
@@ -51,7 +60,18 @@
     "width-range": "px (400-3000)",
     "height-range": "px (300-2000)",
     "hyprland-path": "Hyprland Path",
-    "niri-path": "Niri Path"
+    "niri-path": "Niri Path",
+    "hyprland-lua-path": "Hyprland Lua Path",
+    "hyprland-parser-mode": "Parser:",
+    "hyprland-lua-hint": "Auto: uses hyprland.lua via `hyprctl binds` when it exists, otherwise the legacy .conf parser.",
+    "undescribed-title": "Undescribed Binds",
+    "show-undescribed": "Show binds without a description",
+    "show-undescribed-hint": "When enabled, binds with no description appear in a dedicated section where you can add a description or hide them.",
+    "overrides-summary": "Hidden: {hidden} - Custom descriptions: {custom}",
+    "restore-hidden": "Restore hidden",
+    "restore-hidden-message": "Hidden binds restored.",
+    "clear-overrides": "Clear all overrides",
+    "clear-overrides-message": "All bind overrides cleared."
   },
   "barwidget": {
     "tooltip": "Keybind Cheatsheet",

--- a/keybind-cheatsheet/i18n/es.json
+++ b/keybind-cheatsheet/i18n/es.json
@@ -9,7 +9,8 @@
     "mango-not-supported": "MangoWC no es compatible",
     "mango-detail": "El formato de configuración de MangoWC no es compatible con este plugin",
     "unknown-compositor": "Compositor desconocido detectado",
-    "unknown-detail": "Este plugin solo admite los compositores Hyprland y Niri"
+    "unknown-detail": "Este plugin solo admite los compositores Hyprland y Niri",
+    "hyprctl-failed": "hyprctl binds failed - is Hyprland running?"
   },
   "panel": {
     "loading": "Cargando...",
@@ -19,7 +20,15 @@
     "workspace-switching": "ESPACIOS DE TRABAJO - CAMBIAR",
     "workspace-moving": "ESPACIOS DE TRABAJO - MOVER",
     "workspace-mouse": "ESPACIOS DE TRABAJO - RATÓN",
-    "search-placeholder": "Buscar atajos..."
+    "search-placeholder": "Buscar atajos...",
+    "other": "Other",
+    "undescribed": "Without Description",
+    "no-description": "(no description)",
+    "add-description": "Add description",
+    "add-description-placeholder": "Description...",
+    "save-description": "Save",
+    "cancel": "Cancel",
+    "hide-bind": "Hide this bind"
   },
   "settings": {
     "title": "Configuracion de Atajos de Teclado",
@@ -51,7 +60,18 @@
     "width-range": "px (400-3000)",
     "height-range": "px (300-2000)",
     "hyprland-path": "Ruta Hyprland",
-    "niri-path": "Ruta Niri"
+    "niri-path": "Ruta Niri",
+    "hyprland-lua-path": "Hyprland Lua Path",
+    "hyprland-parser-mode": "Parser:",
+    "hyprland-lua-hint": "Auto: uses hyprland.lua via `hyprctl binds` when it exists, otherwise the legacy .conf parser.",
+    "undescribed-title": "Undescribed Binds",
+    "show-undescribed": "Show binds without a description",
+    "show-undescribed-hint": "When enabled, binds with no description appear in a dedicated section where you can add a description or hide them.",
+    "overrides-summary": "Hidden: {hidden} - Custom descriptions: {custom}",
+    "restore-hidden": "Restore hidden",
+    "restore-hidden-message": "Hidden binds restored.",
+    "clear-overrides": "Clear all overrides",
+    "clear-overrides-message": "All bind overrides cleared."
   },
   "barwidget": {
     "tooltip": "Hoja de trucos de atajos",

--- a/keybind-cheatsheet/i18n/fr.json
+++ b/keybind-cheatsheet/i18n/fr.json
@@ -9,7 +9,8 @@
     "mango-not-supported": "MangoWC n'est pas pris en charge",
     "mango-detail": "Le format de configuration MangoWC n'est pas compatible avec ce plugin",
     "unknown-compositor": "Compositeur inconnu détecté",
-    "unknown-detail": "Ce plugin ne prend en charge que les compositeurs Hyprland et Niri"
+    "unknown-detail": "Ce plugin ne prend en charge que les compositeurs Hyprland et Niri",
+    "hyprctl-failed": "hyprctl binds failed - is Hyprland running?"
   },
   "panel": {
     "loading": "Chargement...",
@@ -19,7 +20,15 @@
     "workspace-switching": "ESPACES DE TRAVAIL - BASCULER",
     "workspace-moving": "ESPACES DE TRAVAIL - DÉPLACER",
     "workspace-mouse": "ESPACES DE TRAVAIL - SOURIS",
-    "search-placeholder": "Rechercher des raccourcis..."
+    "search-placeholder": "Rechercher des raccourcis...",
+    "other": "Other",
+    "undescribed": "Without Description",
+    "no-description": "(no description)",
+    "add-description": "Add description",
+    "add-description-placeholder": "Description...",
+    "save-description": "Save",
+    "cancel": "Cancel",
+    "hide-bind": "Hide this bind"
   },
   "settings": {
     "title": "Parametres des Raccourcis Clavier",
@@ -51,7 +60,18 @@
     "width-range": "px (400-3000)",
     "height-range": "px (300-2000)",
     "hyprland-path": "Chemin Hyprland",
-    "niri-path": "Chemin Niri"
+    "niri-path": "Chemin Niri",
+    "hyprland-lua-path": "Hyprland Lua Path",
+    "hyprland-parser-mode": "Parser:",
+    "hyprland-lua-hint": "Auto: uses hyprland.lua via `hyprctl binds` when it exists, otherwise the legacy .conf parser.",
+    "undescribed-title": "Undescribed Binds",
+    "show-undescribed": "Show binds without a description",
+    "show-undescribed-hint": "When enabled, binds with no description appear in a dedicated section where you can add a description or hide them.",
+    "overrides-summary": "Hidden: {hidden} - Custom descriptions: {custom}",
+    "restore-hidden": "Restore hidden",
+    "restore-hidden-message": "Hidden binds restored.",
+    "clear-overrides": "Clear all overrides",
+    "clear-overrides-message": "All bind overrides cleared."
   },
   "barwidget": {
     "tooltip": "Aide-mémoire des raccourcis",

--- a/keybind-cheatsheet/i18n/hn.json
+++ b/keybind-cheatsheet/i18n/hn.json
@@ -9,7 +9,8 @@
     "mango-not-supported": "MangoWC समर्थित छैन",
     "mango-detail": "MangoWC कन्फिगरेसन ढाँचा यो प्लगइनसँग मिल्दैन",
     "unknown-compositor": "अज्ञात कम्पोजिटर पत्ता लाग्यो",
-    "unknown-detail": "यो प्लगइनले Hyprland र Niri कम्पोजिटरहरू मात्र समर्थन गर्दछ"
+    "unknown-detail": "यो प्लगइनले Hyprland र Niri कम्पोजिटरहरू मात्र समर्थन गर्दछ",
+    "hyprctl-failed": "hyprctl binds failed - is Hyprland running?"
   },
   "panel": {
     "loading": "लोड हो रहा है...",
@@ -19,7 +20,15 @@
     "workspace-switching": "कार्यक्षेत्र - स्विच करना",
     "workspace-moving": "कार्यक्षेत्र - स्थानांतरण",
     "workspace-mouse": "कार्यक्षेत्र - माउस",
-    "search-placeholder": "कीबाइंड खोजें..."
+    "search-placeholder": "कीबाइंड खोजें...",
+    "other": "Other",
+    "undescribed": "Without Description",
+    "no-description": "(no description)",
+    "add-description": "Add description",
+    "add-description-placeholder": "Description...",
+    "save-description": "Save",
+    "cancel": "Cancel",
+    "hide-bind": "Hide this bind"
   },
   "settings": {
     "title": "कीबाइंड चीटशीट सेटिंग्स",
@@ -51,7 +60,18 @@
     "width-range": "px (400-3000)",
     "height-range": "px (300-2000)",
     "hyprland-path": "Hyprland पथ",
-    "niri-path": "Niri पथ"
+    "niri-path": "Niri पथ",
+    "hyprland-lua-path": "Hyprland Lua Path",
+    "hyprland-parser-mode": "Parser:",
+    "hyprland-lua-hint": "Auto: uses hyprland.lua via `hyprctl binds` when it exists, otherwise the legacy .conf parser.",
+    "undescribed-title": "Undescribed Binds",
+    "show-undescribed": "Show binds without a description",
+    "show-undescribed-hint": "When enabled, binds with no description appear in a dedicated section where you can add a description or hide them.",
+    "overrides-summary": "Hidden: {hidden} - Custom descriptions: {custom}",
+    "restore-hidden": "Restore hidden",
+    "restore-hidden-message": "Hidden binds restored.",
+    "clear-overrides": "Clear all overrides",
+    "clear-overrides-message": "All bind overrides cleared."
   },
   "barwidget": {
     "tooltip": "कीबाइंड चीटशीट",

--- a/keybind-cheatsheet/i18n/hu.json
+++ b/keybind-cheatsheet/i18n/hu.json
@@ -9,7 +9,8 @@
     "mango-not-supported": "A MangoWC nem támogatott",
     "mango-detail": "A MangoWC konfigurációs formátum nem kompatibilis ezzel a bővítménnyel",
     "unknown-compositor": "Ismeretlen kompozitor észlelve",
-    "unknown-detail": "Ez a bővítmény csak a Hyprland és Niri kompozitorokat támogatja"
+    "unknown-detail": "Ez a bővítmény csak a Hyprland és Niri kompozitorokat támogatja",
+    "hyprctl-failed": "hyprctl binds failed - is Hyprland running?"
   },
   "panel": {
     "loading": "Betoltes...",
@@ -19,7 +20,15 @@
     "workspace-switching": "MUNKATERÜLETEK - VÁLTÁS",
     "workspace-moving": "MUNKATERÜLETEK - ÁTHELYEZÉS",
     "workspace-mouse": "MUNKATERÜLETEK - EGÉR",
-    "search-placeholder": "Billentyűparancsok keresése..."
+    "search-placeholder": "Billentyűparancsok keresése...",
+    "other": "Other",
+    "undescribed": "Without Description",
+    "no-description": "(no description)",
+    "add-description": "Add description",
+    "add-description-placeholder": "Description...",
+    "save-description": "Save",
+    "cancel": "Cancel",
+    "hide-bind": "Hide this bind"
   },
   "settings": {
     "title": "Billentyuparancsok Beallitasai",
@@ -51,7 +60,18 @@
     "width-range": "px (400-3000)",
     "height-range": "px (300-2000)",
     "hyprland-path": "Hyprland útvonal",
-    "niri-path": "Niri útvonal"
+    "niri-path": "Niri útvonal",
+    "hyprland-lua-path": "Hyprland Lua Path",
+    "hyprland-parser-mode": "Parser:",
+    "hyprland-lua-hint": "Auto: uses hyprland.lua via `hyprctl binds` when it exists, otherwise the legacy .conf parser.",
+    "undescribed-title": "Undescribed Binds",
+    "show-undescribed": "Show binds without a description",
+    "show-undescribed-hint": "When enabled, binds with no description appear in a dedicated section where you can add a description or hide them.",
+    "overrides-summary": "Hidden: {hidden} - Custom descriptions: {custom}",
+    "restore-hidden": "Restore hidden",
+    "restore-hidden-message": "Hidden binds restored.",
+    "clear-overrides": "Clear all overrides",
+    "clear-overrides-message": "All bind overrides cleared."
   },
   "barwidget": {
     "tooltip": "Billentyűparancs súgó",

--- a/keybind-cheatsheet/i18n/it.json
+++ b/keybind-cheatsheet/i18n/it.json
@@ -9,7 +9,8 @@
     "mango-not-supported": "MangoWC non è supportato",
     "mango-detail": "Il formato di configurazione MangoWC non è compatibile con questo plugin",
     "unknown-compositor": "Rilevato compositor sconosciuto",
-    "unknown-detail": "Questo plugin supporta solo i compositor Hyprland e Niri"
+    "unknown-detail": "Questo plugin supporta solo i compositor Hyprland e Niri",
+    "hyprctl-failed": "hyprctl binds failed - is Hyprland running?"
   },
   "panel": {
     "loading": "Caricamento...",
@@ -19,7 +20,15 @@
     "workspace-switching": "SPAZI DI LAVORO - CAMBIO",
     "workspace-moving": "SPAZI DI LAVORO - SPOSTAMENTO",
     "workspace-mouse": "SPAZI DI LAVORO - MOUSE",
-    "search-placeholder": "Cerca scorciatoie..."
+    "search-placeholder": "Cerca scorciatoie...",
+    "other": "Other",
+    "undescribed": "Without Description",
+    "no-description": "(no description)",
+    "add-description": "Add description",
+    "add-description-placeholder": "Description...",
+    "save-description": "Save",
+    "cancel": "Cancel",
+    "hide-bind": "Hide this bind"
   },
   "settings": {
     "title": "Impostazioni Scorciatoie da Tastiera",
@@ -51,7 +60,18 @@
     "width-range": "px (400-3000)",
     "height-range": "px (300-2000)",
     "hyprland-path": "Percorso Hyprland",
-    "niri-path": "Percorso Niri"
+    "niri-path": "Percorso Niri",
+    "hyprland-lua-path": "Hyprland Lua Path",
+    "hyprland-parser-mode": "Parser:",
+    "hyprland-lua-hint": "Auto: uses hyprland.lua via `hyprctl binds` when it exists, otherwise the legacy .conf parser.",
+    "undescribed-title": "Undescribed Binds",
+    "show-undescribed": "Show binds without a description",
+    "show-undescribed-hint": "When enabled, binds with no description appear in a dedicated section where you can add a description or hide them.",
+    "overrides-summary": "Hidden: {hidden} - Custom descriptions: {custom}",
+    "restore-hidden": "Restore hidden",
+    "restore-hidden-message": "Hidden binds restored.",
+    "clear-overrides": "Clear all overrides",
+    "clear-overrides-message": "All bind overrides cleared."
   },
   "barwidget": {
     "tooltip": "Scheda scorciatoie",

--- a/keybind-cheatsheet/i18n/ja.json
+++ b/keybind-cheatsheet/i18n/ja.json
@@ -9,7 +9,8 @@
     "mango-not-supported": "MangoWCはサポートされていません",
     "mango-detail": "MangoWCの設定形式はこのプラグインと互換性がありません",
     "unknown-compositor": "不明なコンポジターが検出されました",
-    "unknown-detail": "このプラグインはHyprlandとNiriコンポジターのみをサポートしています"
+    "unknown-detail": "このプラグインはHyprlandとNiriコンポジターのみをサポートしています",
+    "hyprctl-failed": "hyprctl binds failed - is Hyprland running?"
   },
   "panel": {
     "loading": "読み込み中...",
@@ -19,7 +20,15 @@
     "workspace-switching": "ワークスペース - 切り替え",
     "workspace-moving": "ワークスペース - 移動",
     "workspace-mouse": "ワークスペース - マウス",
-    "search-placeholder": "キーバインドを検索..."
+    "search-placeholder": "キーバインドを検索...",
+    "other": "Other",
+    "undescribed": "Without Description",
+    "no-description": "(no description)",
+    "add-description": "Add description",
+    "add-description-placeholder": "Description...",
+    "save-description": "Save",
+    "cancel": "Cancel",
+    "hide-bind": "Hide this bind"
   },
   "settings": {
     "title": "キーバインド一覧の設定",
@@ -51,7 +60,18 @@
     "width-range": "px (400-3000)",
     "height-range": "px (300-2000)",
     "hyprland-path": "Hyprland パス",
-    "niri-path": "Niri パス"
+    "niri-path": "Niri パス",
+    "hyprland-lua-path": "Hyprland Lua Path",
+    "hyprland-parser-mode": "Parser:",
+    "hyprland-lua-hint": "Auto: uses hyprland.lua via `hyprctl binds` when it exists, otherwise the legacy .conf parser.",
+    "undescribed-title": "Undescribed Binds",
+    "show-undescribed": "Show binds without a description",
+    "show-undescribed-hint": "When enabled, binds with no description appear in a dedicated section where you can add a description or hide them.",
+    "overrides-summary": "Hidden: {hidden} - Custom descriptions: {custom}",
+    "restore-hidden": "Restore hidden",
+    "restore-hidden-message": "Hidden binds restored.",
+    "clear-overrides": "Clear all overrides",
+    "clear-overrides-message": "All bind overrides cleared."
   },
   "barwidget": {
     "tooltip": "キーバインドチートシート",

--- a/keybind-cheatsheet/i18n/ko-KR.json
+++ b/keybind-cheatsheet/i18n/ko-KR.json
@@ -9,7 +9,8 @@
     "mango-not-supported": "MangoWC는 지원되지 않습니다",
     "mango-detail": "MangoWC 구성 형식은 이 플러그인과 호환되지 않습니다",
     "unknown-compositor": "알 수 없는 컴포지터가 감지되었습니다",
-    "unknown-detail": "이 플러그인은 Hyprland 및 Niri 컴포지터만 지원합니다"
+    "unknown-detail": "이 플러그인은 Hyprland 및 Niri 컴포지터만 지원합니다",
+    "hyprctl-failed": "hyprctl binds failed - is Hyprland running?"
   },
   "panel": {
     "loading": "로딩 중...",
@@ -19,7 +20,15 @@
     "workspace-switching": "작업공간 - 전환",
     "workspace-moving": "작업공간 - 이동",
     "workspace-mouse": "작업공간 - 마우스",
-    "search-placeholder": "단축키 검색..."
+    "search-placeholder": "단축키 검색...",
+    "other": "Other",
+    "undescribed": "Without Description",
+    "no-description": "(no description)",
+    "add-description": "Add description",
+    "add-description-placeholder": "Description...",
+    "save-description": "Save",
+    "cancel": "Cancel",
+    "hide-bind": "Hide this bind"
   },
   "settings": {
     "title": "키바인드 치트시트 설정",
@@ -51,7 +60,18 @@
     "width-range": "px (400-3000)",
     "height-range": "px (300-2000)",
     "hyprland-path": "Hyprland 경로",
-    "niri-path": "Niri 경로"
+    "niri-path": "Niri 경로",
+    "hyprland-lua-path": "Hyprland Lua Path",
+    "hyprland-parser-mode": "Parser:",
+    "hyprland-lua-hint": "Auto: uses hyprland.lua via `hyprctl binds` when it exists, otherwise the legacy .conf parser.",
+    "undescribed-title": "Undescribed Binds",
+    "show-undescribed": "Show binds without a description",
+    "show-undescribed-hint": "When enabled, binds with no description appear in a dedicated section where you can add a description or hide them.",
+    "overrides-summary": "Hidden: {hidden} - Custom descriptions: {custom}",
+    "restore-hidden": "Restore hidden",
+    "restore-hidden-message": "Hidden binds restored.",
+    "clear-overrides": "Clear all overrides",
+    "clear-overrides-message": "All bind overrides cleared."
   },
   "barwidget": {
     "tooltip": "키바인드 치트시트",

--- a/keybind-cheatsheet/i18n/ku.json
+++ b/keybind-cheatsheet/i18n/ku.json
@@ -9,7 +9,8 @@
     "mango-not-supported": "MangoWC پشتگیری ناکرێت",
     "mango-detail": "فۆرماتی ڕێکخستنی MangoWC لەگەڵ ئەم پێوەکراوەدا گونجاو نییە",
     "unknown-compositor": "کۆمپۆزیتەرێکی نەناسراو دۆزرایەوە",
-    "unknown-detail": "ئەم پێوەکراوە تەنها کۆمپۆزیتەرەکانی Hyprland و Niri پشتگیری دەکات"
+    "unknown-detail": "ئەم پێوەکراوە تەنها کۆمپۆزیتەرەکانی Hyprland و Niri پشتگیری دەکات",
+    "hyprctl-failed": "hyprctl binds failed - is Hyprland running?"
   },
   "panel": {
     "loading": "Barkirin...",
@@ -19,7 +20,15 @@
     "workspace-switching": "QADÊN XEBATÊ - GUHEZTIN",
     "workspace-moving": "QADÊN XEBATÊ - VEGUHESTIN",
     "workspace-mouse": "QADÊN XEBATÊ - MIŞK",
-    "search-placeholder": "Bişkokan lêbigere..."
+    "search-placeholder": "Bişkokan lêbigere...",
+    "other": "Other",
+    "undescribed": "Without Description",
+    "no-description": "(no description)",
+    "add-description": "Add description",
+    "add-description-placeholder": "Description...",
+    "save-description": "Save",
+    "cancel": "Cancel",
+    "hide-bind": "Hide this bind"
   },
   "settings": {
     "title": "Mîhengên Kurterêyên Klavyeyê",
@@ -51,7 +60,18 @@
     "width-range": "px (400-3000)",
     "height-range": "px (300-2000)",
     "hyprland-path": "Rêça Hyprland",
-    "niri-path": "Rêça Niri"
+    "niri-path": "Rêça Niri",
+    "hyprland-lua-path": "Hyprland Lua Path",
+    "hyprland-parser-mode": "Parser:",
+    "hyprland-lua-hint": "Auto: uses hyprland.lua via `hyprctl binds` when it exists, otherwise the legacy .conf parser.",
+    "undescribed-title": "Undescribed Binds",
+    "show-undescribed": "Show binds without a description",
+    "show-undescribed-hint": "When enabled, binds with no description appear in a dedicated section where you can add a description or hide them.",
+    "overrides-summary": "Hidden: {hidden} - Custom descriptions: {custom}",
+    "restore-hidden": "Restore hidden",
+    "restore-hidden-message": "Hidden binds restored.",
+    "clear-overrides": "Clear all overrides",
+    "clear-overrides-message": "All bind overrides cleared."
   },
   "barwidget": {
     "tooltip": "Çavkaniya Kurterêyan",

--- a/keybind-cheatsheet/i18n/nl.json
+++ b/keybind-cheatsheet/i18n/nl.json
@@ -9,7 +9,8 @@
     "mango-not-supported": "MangoWC wordt niet ondersteund",
     "mango-detail": "Het MangoWC-configuratieformaat is niet compatibel met deze plugin",
     "unknown-compositor": "Onbekende compositor gedetecteerd",
-    "unknown-detail": "Deze plugin ondersteunt alleen Hyprland- en Niri-compositors"
+    "unknown-detail": "Deze plugin ondersteunt alleen Hyprland- en Niri-compositors",
+    "hyprctl-failed": "hyprctl binds failed - is Hyprland running?"
   },
   "panel": {
     "loading": "Laden...",
@@ -19,7 +20,15 @@
     "workspace-switching": "WERKRUIMTEN - WISSELEN",
     "workspace-moving": "WERKRUIMTEN - VERPLAATSEN",
     "workspace-mouse": "WERKRUIMTEN - MUIS",
-    "search-placeholder": "Sneltoetsen zoeken..."
+    "search-placeholder": "Sneltoetsen zoeken...",
+    "other": "Other",
+    "undescribed": "Without Description",
+    "no-description": "(no description)",
+    "add-description": "Add description",
+    "add-description-placeholder": "Description...",
+    "save-description": "Save",
+    "cancel": "Cancel",
+    "hide-bind": "Hide this bind"
   },
   "settings": {
     "title": "Sneltoetsen Overzicht Instellingen",
@@ -51,7 +60,18 @@
     "width-range": "px (400-3000)",
     "height-range": "px (300-2000)",
     "hyprland-path": "Hyprland pad",
-    "niri-path": "Niri pad"
+    "niri-path": "Niri pad",
+    "hyprland-lua-path": "Hyprland Lua Path",
+    "hyprland-parser-mode": "Parser:",
+    "hyprland-lua-hint": "Auto: uses hyprland.lua via `hyprctl binds` when it exists, otherwise the legacy .conf parser.",
+    "undescribed-title": "Undescribed Binds",
+    "show-undescribed": "Show binds without a description",
+    "show-undescribed-hint": "When enabled, binds with no description appear in a dedicated section where you can add a description or hide them.",
+    "overrides-summary": "Hidden: {hidden} - Custom descriptions: {custom}",
+    "restore-hidden": "Restore hidden",
+    "restore-hidden-message": "Hidden binds restored.",
+    "clear-overrides": "Clear all overrides",
+    "clear-overrides-message": "All bind overrides cleared."
   },
   "barwidget": {
     "tooltip": "Sneltoetsen Spiekbriefje",

--- a/keybind-cheatsheet/i18n/nn-NO.json
+++ b/keybind-cheatsheet/i18n/nn-NO.json
@@ -9,7 +9,8 @@
     "mango-not-supported": "MangoWC er ikkje støtta",
     "mango-detail": "MangoWC-konfigurasjonsformatet er ikkje kompatibelt med denne plugin-en",
     "unknown-compositor": "Ukjend compositor oppdaga",
-    "unknown-detail": "Denne plugin-en støttar berre Hyprland- og Niri-compositorar"
+    "unknown-detail": "Denne plugin-en støttar berre Hyprland- og Niri-compositorar",
+    "hyprctl-failed": "hyprctl binds failed - is Hyprland running?"
   },
   "panel": {
     "loading": "Lastar...",
@@ -19,7 +20,15 @@
     "workspace-switching": "ARBEIDSOMRÅDE - BYTTE",
     "workspace-moving": "ARBEIDSOMRÅDE - FLYTTE",
     "workspace-mouse": "ARBEIDSOMRÅDE - MUS",
-    "search-placeholder": "Søk etter snarveiar..."
+    "search-placeholder": "Søk etter snarveiar...",
+    "other": "Other",
+    "undescribed": "Without Description",
+    "no-description": "(no description)",
+    "add-description": "Add description",
+    "add-description-placeholder": "Description...",
+    "save-description": "Save",
+    "cancel": "Cancel",
+    "hide-bind": "Hide this bind"
   },
   "settings": {
     "title": "Tastesnarveg-jukselapp Innstillingar",
@@ -51,7 +60,18 @@
     "width-range": "px (400-3000)",
     "height-range": "px (300-2000)",
     "hyprland-path": "Hyprland-sti",
-    "niri-path": "Niri-sti"
+    "niri-path": "Niri-sti",
+    "hyprland-lua-path": "Hyprland Lua Path",
+    "hyprland-parser-mode": "Parser:",
+    "hyprland-lua-hint": "Auto: uses hyprland.lua via `hyprctl binds` when it exists, otherwise the legacy .conf parser.",
+    "undescribed-title": "Undescribed Binds",
+    "show-undescribed": "Show binds without a description",
+    "show-undescribed-hint": "When enabled, binds with no description appear in a dedicated section where you can add a description or hide them.",
+    "overrides-summary": "Hidden: {hidden} - Custom descriptions: {custom}",
+    "restore-hidden": "Restore hidden",
+    "restore-hidden-message": "Hidden binds restored.",
+    "clear-overrides": "Clear all overrides",
+    "clear-overrides-message": "All bind overrides cleared."
   },
   "barwidget": {
     "tooltip": "Tastesnarveg-jukselapp",

--- a/keybind-cheatsheet/i18n/pl.json
+++ b/keybind-cheatsheet/i18n/pl.json
@@ -9,7 +9,8 @@
     "mango-not-supported": "MangoWC nie jest obsługiwany",
     "mango-detail": "Format konfiguracji MangoWC nie jest kompatybilny z tą wtyczką",
     "unknown-compositor": "Wykryto nieznany kompozytor",
-    "unknown-detail": "Ta wtyczka obsługuje tylko kompozytory Hyprland i Niri"
+    "unknown-detail": "Ta wtyczka obsługuje tylko kompozytory Hyprland i Niri",
+    "hyprctl-failed": "hyprctl binds nie powiodło się - czy Hyprland działa?"
   },
   "panel": {
     "loading": "Ladowanie...",
@@ -19,7 +20,15 @@
     "workspace-switching": "OBSZARY ROBOCZE - PRZEŁĄCZANIE",
     "workspace-moving": "OBSZARY ROBOCZE - PRZENOSZENIE",
     "workspace-mouse": "OBSZARY ROBOCZE - MYSZ",
-    "search-placeholder": "Szukaj skrótów..."
+    "search-placeholder": "Szukaj skrótów...",
+    "other": "Inne",
+    "undescribed": "Bez opisu",
+    "no-description": "(brak opisu)",
+    "add-description": "Dodaj opis",
+    "add-description-placeholder": "Opis...",
+    "save-description": "Zapisz",
+    "cancel": "Anuluj",
+    "hide-bind": "Ukryj ten skrót"
   },
   "settings": {
     "title": "Ustawienia Skrotow Klawiszowych",
@@ -51,7 +60,18 @@
     "width-range": "px (400-3000)",
     "height-range": "px (300-2000)",
     "hyprland-path": "Ścieżka Hyprland",
-    "niri-path": "Ścieżka Niri"
+    "niri-path": "Ścieżka Niri",
+    "hyprland-lua-path": "Ścieżka Hyprland Lua",
+    "hyprland-parser-mode": "Parser:",
+    "hyprland-lua-hint": "Auto: używa hyprland.lua przez `hyprctl binds` jeśli istnieje, w innym wypadku starego parsera .conf.",
+    "undescribed-title": "Skróty bez opisu",
+    "show-undescribed": "Pokaż skróty bez opisu",
+    "show-undescribed-hint": "Gdy włączone, skróty bez opisu pojawiają się w osobnej sekcji, gdzie można dodać opis lub je ukryć.",
+    "overrides-summary": "Ukryte: {hidden} - Własne opisy: {custom}",
+    "restore-hidden": "Przywróć ukryte",
+    "restore-hidden-message": "Ukryte skróty przywrócone.",
+    "clear-overrides": "Wyczyść wszystkie nadpisania",
+    "clear-overrides-message": "Wszystkie nadpisania skrótów wyczyszczone."
   },
   "barwidget": {
     "tooltip": "Ściągawka skrótów klawiszowych",

--- a/keybind-cheatsheet/i18n/pt.json
+++ b/keybind-cheatsheet/i18n/pt.json
@@ -9,7 +9,8 @@
     "mango-not-supported": "MangoWC não é suportado",
     "mango-detail": "O formato de configuração do MangoWC não é compatível com este plugin",
     "unknown-compositor": "Compositor desconhecido detectado",
-    "unknown-detail": "Este plugin suporta apenas os compositores Hyprland e Niri"
+    "unknown-detail": "Este plugin suporta apenas os compositores Hyprland e Niri",
+    "hyprctl-failed": "hyprctl binds failed - is Hyprland running?"
   },
   "panel": {
     "loading": "Carregando...",
@@ -19,7 +20,15 @@
     "workspace-switching": "ESPAÇOS DE TRABALHO - ALTERNAR",
     "workspace-moving": "ESPAÇOS DE TRABALHO - MOVER",
     "workspace-mouse": "ESPAÇOS DE TRABALHO - MOUSE",
-    "search-placeholder": "Pesquisar atalhos..."
+    "search-placeholder": "Pesquisar atalhos...",
+    "other": "Other",
+    "undescribed": "Without Description",
+    "no-description": "(no description)",
+    "add-description": "Add description",
+    "add-description-placeholder": "Description...",
+    "save-description": "Save",
+    "cancel": "Cancel",
+    "hide-bind": "Hide this bind"
   },
   "settings": {
     "title": "Configuracoes de Atalhos de Teclado",
@@ -51,7 +60,18 @@
     "width-range": "px (400-3000)",
     "height-range": "px (300-2000)",
     "hyprland-path": "Caminho Hyprland",
-    "niri-path": "Caminho Niri"
+    "niri-path": "Caminho Niri",
+    "hyprland-lua-path": "Hyprland Lua Path",
+    "hyprland-parser-mode": "Parser:",
+    "hyprland-lua-hint": "Auto: uses hyprland.lua via `hyprctl binds` when it exists, otherwise the legacy .conf parser.",
+    "undescribed-title": "Undescribed Binds",
+    "show-undescribed": "Show binds without a description",
+    "show-undescribed-hint": "When enabled, binds with no description appear in a dedicated section where you can add a description or hide them.",
+    "overrides-summary": "Hidden: {hidden} - Custom descriptions: {custom}",
+    "restore-hidden": "Restore hidden",
+    "restore-hidden-message": "Hidden binds restored.",
+    "clear-overrides": "Clear all overrides",
+    "clear-overrides-message": "All bind overrides cleared."
   },
   "barwidget": {
     "tooltip": "Folha de dicas de atalhos",

--- a/keybind-cheatsheet/i18n/ru.json
+++ b/keybind-cheatsheet/i18n/ru.json
@@ -9,7 +9,8 @@
     "mango-not-supported": "MangoWC не поддерживается",
     "mango-detail": "Формат конфигурации MangoWC несовместим с этим плагином",
     "unknown-compositor": "Обнаружен неизвестный композитор",
-    "unknown-detail": "Этот плагин поддерживает только композиторы Hyprland и Niri"
+    "unknown-detail": "Этот плагин поддерживает только композиторы Hyprland и Niri",
+    "hyprctl-failed": "hyprctl binds failed - is Hyprland running?"
   },
   "panel": {
     "loading": "Загрузка...",
@@ -19,7 +20,15 @@
     "workspace-switching": "РАБОЧИЕ ОБЛАСТИ - ПЕРЕКЛЮЧЕНИЕ",
     "workspace-moving": "РАБОЧИЕ ОБЛАСТИ - ПЕРЕМЕЩЕНИЕ",
     "workspace-mouse": "РАБОЧИЕ ОБЛАСТИ - МЫШЬ",
-    "search-placeholder": "Поиск сочетаний клавиш..."
+    "search-placeholder": "Поиск сочетаний клавиш...",
+    "other": "Other",
+    "undescribed": "Without Description",
+    "no-description": "(no description)",
+    "add-description": "Add description",
+    "add-description-placeholder": "Description...",
+    "save-description": "Save",
+    "cancel": "Cancel",
+    "hide-bind": "Hide this bind"
   },
   "settings": {
     "title": "Настройки горячих клавиш",
@@ -51,7 +60,18 @@
     "width-range": "px (400-3000)",
     "height-range": "px (300-2000)",
     "hyprland-path": "Путь Hyprland",
-    "niri-path": "Путь Niri"
+    "niri-path": "Путь Niri",
+    "hyprland-lua-path": "Hyprland Lua Path",
+    "hyprland-parser-mode": "Parser:",
+    "hyprland-lua-hint": "Auto: uses hyprland.lua via `hyprctl binds` when it exists, otherwise the legacy .conf parser.",
+    "undescribed-title": "Undescribed Binds",
+    "show-undescribed": "Show binds without a description",
+    "show-undescribed-hint": "When enabled, binds with no description appear in a dedicated section where you can add a description or hide them.",
+    "overrides-summary": "Hidden: {hidden} - Custom descriptions: {custom}",
+    "restore-hidden": "Restore hidden",
+    "restore-hidden-message": "Hidden binds restored.",
+    "clear-overrides": "Clear all overrides",
+    "clear-overrides-message": "All bind overrides cleared."
   },
   "barwidget": {
     "tooltip": "Шпаргалка горячих клавиш",

--- a/keybind-cheatsheet/i18n/sv.json
+++ b/keybind-cheatsheet/i18n/sv.json
@@ -9,7 +9,8 @@
     "mango-not-supported": "MangoWC stöds inte",
     "mango-detail": "MangoWC-konfigurationsformatet är inte kompatibelt med detta plugin",
     "unknown-compositor": "Okänd compositor upptäckt",
-    "unknown-detail": "Detta plugin stöder endast Hyprland- och Niri-compositors"
+    "unknown-detail": "Detta plugin stöder endast Hyprland- och Niri-compositors",
+    "hyprctl-failed": "hyprctl binds failed - is Hyprland running?"
   },
   "panel": {
     "loading": "Laddar...",
@@ -19,7 +20,15 @@
     "workspace-switching": "ARBETSYTOR - BYTA",
     "workspace-moving": "ARBETSYTOR - FLYTTA",
     "workspace-mouse": "ARBETSYTOR - MUS",
-    "search-placeholder": "Sök tangentbindningar..."
+    "search-placeholder": "Sök tangentbindningar...",
+    "other": "Other",
+    "undescribed": "Without Description",
+    "no-description": "(no description)",
+    "add-description": "Add description",
+    "add-description-placeholder": "Description...",
+    "save-description": "Save",
+    "cancel": "Cancel",
+    "hide-bind": "Hide this bind"
   },
   "settings": {
     "title": "Tangentbordsgenvägar Inställningar",
@@ -51,7 +60,18 @@
     "width-range": "px (400-3000)",
     "height-range": "px (300-2000)",
     "hyprland-path": "Hyprland-sökväg",
-    "niri-path": "Niri-sökväg"
+    "niri-path": "Niri-sökväg",
+    "hyprland-lua-path": "Hyprland Lua Path",
+    "hyprland-parser-mode": "Parser:",
+    "hyprland-lua-hint": "Auto: uses hyprland.lua via `hyprctl binds` when it exists, otherwise the legacy .conf parser.",
+    "undescribed-title": "Undescribed Binds",
+    "show-undescribed": "Show binds without a description",
+    "show-undescribed-hint": "When enabled, binds with no description appear in a dedicated section where you can add a description or hide them.",
+    "overrides-summary": "Hidden: {hidden} - Custom descriptions: {custom}",
+    "restore-hidden": "Restore hidden",
+    "restore-hidden-message": "Hidden binds restored.",
+    "clear-overrides": "Clear all overrides",
+    "clear-overrides-message": "All bind overrides cleared."
   },
   "barwidget": {
     "tooltip": "Tangentbordsgenvägar",

--- a/keybind-cheatsheet/i18n/tr.json
+++ b/keybind-cheatsheet/i18n/tr.json
@@ -9,7 +9,8 @@
     "mango-not-supported": "MangoWC desteklenmiyor",
     "mango-detail": "MangoWC yapılandırma formatı bu eklentiyle uyumlu değil",
     "unknown-compositor": "Bilinmeyen kompozitör algılandı",
-    "unknown-detail": "Bu eklenti yalnızca Hyprland ve Niri kompozitörlerini destekler"
+    "unknown-detail": "Bu eklenti yalnızca Hyprland ve Niri kompozitörlerini destekler",
+    "hyprctl-failed": "hyprctl binds failed - is Hyprland running?"
   },
   "panel": {
     "loading": "Yukleniyor...",
@@ -19,7 +20,15 @@
     "workspace-switching": "ÇALIŞMA ALANLARI - GEÇİŞ",
     "workspace-moving": "ÇALIŞMA ALANLARI - TAŞIMA",
     "workspace-mouse": "ÇALIŞMA ALANLARI - FARE",
-    "search-placeholder": "Kısayol ara..."
+    "search-placeholder": "Kısayol ara...",
+    "other": "Other",
+    "undescribed": "Without Description",
+    "no-description": "(no description)",
+    "add-description": "Add description",
+    "add-description-placeholder": "Description...",
+    "save-description": "Save",
+    "cancel": "Cancel",
+    "hide-bind": "Hide this bind"
   },
   "settings": {
     "title": "Klavye Kisayollari Ayarlari",
@@ -51,7 +60,18 @@
     "width-range": "px (400-3000)",
     "height-range": "px (300-2000)",
     "hyprland-path": "Hyprland yolu",
-    "niri-path": "Niri yolu"
+    "niri-path": "Niri yolu",
+    "hyprland-lua-path": "Hyprland Lua Path",
+    "hyprland-parser-mode": "Parser:",
+    "hyprland-lua-hint": "Auto: uses hyprland.lua via `hyprctl binds` when it exists, otherwise the legacy .conf parser.",
+    "undescribed-title": "Undescribed Binds",
+    "show-undescribed": "Show binds without a description",
+    "show-undescribed-hint": "When enabled, binds with no description appear in a dedicated section where you can add a description or hide them.",
+    "overrides-summary": "Hidden: {hidden} - Custom descriptions: {custom}",
+    "restore-hidden": "Restore hidden",
+    "restore-hidden-message": "Hidden binds restored.",
+    "clear-overrides": "Clear all overrides",
+    "clear-overrides-message": "All bind overrides cleared."
   },
   "barwidget": {
     "tooltip": "Kısayol Kopya Kağıdı",

--- a/keybind-cheatsheet/i18n/uk-UA.json
+++ b/keybind-cheatsheet/i18n/uk-UA.json
@@ -9,7 +9,8 @@
     "mango-not-supported": "MangoWC не підтримується",
     "mango-detail": "Формат конфігурації MangoWC несумісний з цим плагіном",
     "unknown-compositor": "Виявлено невідомий композитор",
-    "unknown-detail": "Цей плагін підтримує лише композитори Hyprland та Niri"
+    "unknown-detail": "Цей плагін підтримує лише композитори Hyprland та Niri",
+    "hyprctl-failed": "hyprctl binds failed - is Hyprland running?"
   },
   "panel": {
     "loading": "Завантаження...",
@@ -19,7 +20,15 @@
     "workspace-switching": "РОБОЧІ ОБЛАСТІ - ПЕРЕМИКАННЯ",
     "workspace-moving": "РОБОЧІ ОБЛАСТІ - ПЕРЕМІЩЕННЯ",
     "workspace-mouse": "РОБОЧІ ОБЛАСТІ - МИША",
-    "search-placeholder": "Пошук сполучень клавіш..."
+    "search-placeholder": "Пошук сполучень клавіш...",
+    "other": "Other",
+    "undescribed": "Without Description",
+    "no-description": "(no description)",
+    "add-description": "Add description",
+    "add-description-placeholder": "Description...",
+    "save-description": "Save",
+    "cancel": "Cancel",
+    "hide-bind": "Hide this bind"
   },
   "settings": {
     "title": "Налаштування гарячих клавіш",
@@ -51,7 +60,18 @@
     "width-range": "px (400-3000)",
     "height-range": "px (300-2000)",
     "hyprland-path": "Шлях Hyprland",
-    "niri-path": "Шлях Niri"
+    "niri-path": "Шлях Niri",
+    "hyprland-lua-path": "Hyprland Lua Path",
+    "hyprland-parser-mode": "Parser:",
+    "hyprland-lua-hint": "Auto: uses hyprland.lua via `hyprctl binds` when it exists, otherwise the legacy .conf parser.",
+    "undescribed-title": "Undescribed Binds",
+    "show-undescribed": "Show binds without a description",
+    "show-undescribed-hint": "When enabled, binds with no description appear in a dedicated section where you can add a description or hide them.",
+    "overrides-summary": "Hidden: {hidden} - Custom descriptions: {custom}",
+    "restore-hidden": "Restore hidden",
+    "restore-hidden-message": "Hidden binds restored.",
+    "clear-overrides": "Clear all overrides",
+    "clear-overrides-message": "All bind overrides cleared."
   },
   "barwidget": {
     "tooltip": "Шпаргалка гарячих клавіш",

--- a/keybind-cheatsheet/i18n/zh-CN.json
+++ b/keybind-cheatsheet/i18n/zh-CN.json
@@ -9,7 +9,8 @@
     "mango-not-supported": "不支持 MangoWC",
     "mango-detail": "MangoWC 配置格式与此插件不兼容",
     "unknown-compositor": "检测到未知的合成器",
-    "unknown-detail": "此插件仅支持 Hyprland 和 Niri 合成器"
+    "unknown-detail": "此插件仅支持 Hyprland 和 Niri 合成器",
+    "hyprctl-failed": "hyprctl binds failed - is Hyprland running?"
   },
   "panel": {
     "loading": "加载中...",
@@ -19,7 +20,15 @@
     "workspace-switching": "工作区 - 切换",
     "workspace-moving": "工作区 - 移动",
     "workspace-mouse": "工作区 - 鼠标",
-    "search-placeholder": "搜索按键绑定..."
+    "search-placeholder": "搜索按键绑定...",
+    "other": "Other",
+    "undescribed": "Without Description",
+    "no-description": "(no description)",
+    "add-description": "Add description",
+    "add-description-placeholder": "Description...",
+    "save-description": "Save",
+    "cancel": "Cancel",
+    "hide-bind": "Hide this bind"
   },
   "settings": {
     "title": "快捷键速查表设置",
@@ -51,7 +60,18 @@
     "width-range": "px (400-3000)",
     "height-range": "px (300-2000)",
     "hyprland-path": "Hyprland 路径",
-    "niri-path": "Niri 路径"
+    "niri-path": "Niri 路径",
+    "hyprland-lua-path": "Hyprland Lua Path",
+    "hyprland-parser-mode": "Parser:",
+    "hyprland-lua-hint": "Auto: uses hyprland.lua via `hyprctl binds` when it exists, otherwise the legacy .conf parser.",
+    "undescribed-title": "Undescribed Binds",
+    "show-undescribed": "Show binds without a description",
+    "show-undescribed-hint": "When enabled, binds with no description appear in a dedicated section where you can add a description or hide them.",
+    "overrides-summary": "Hidden: {hidden} - Custom descriptions: {custom}",
+    "restore-hidden": "Restore hidden",
+    "restore-hidden-message": "Hidden binds restored.",
+    "clear-overrides": "Clear all overrides",
+    "clear-overrides-message": "All bind overrides cleared."
   },
   "barwidget": {
     "tooltip": "快捷键速查表",

--- a/keybind-cheatsheet/i18n/zh-TW.json
+++ b/keybind-cheatsheet/i18n/zh-TW.json
@@ -9,7 +9,8 @@
     "mango-not-supported": "不支援 MangoWC",
     "mango-detail": "MangoWC 設定格式與此外掛程式不相容",
     "unknown-compositor": "偵測到未知的合成器",
-    "unknown-detail": "此外掛程式僅支援 Hyprland 和 Niri 合成器"
+    "unknown-detail": "此外掛程式僅支援 Hyprland 和 Niri 合成器",
+    "hyprctl-failed": "hyprctl binds failed - is Hyprland running?"
   },
   "panel": {
     "loading": "載入中...",
@@ -19,7 +20,15 @@
     "workspace-switching": "工作區 - 切換",
     "workspace-moving": "工作區 - 移動",
     "workspace-mouse": "工作區 - 滑鼠",
-    "search-placeholder": "搜尋按鍵綁定..."
+    "search-placeholder": "搜尋按鍵綁定...",
+    "other": "Other",
+    "undescribed": "Without Description",
+    "no-description": "(no description)",
+    "add-description": "Add description",
+    "add-description-placeholder": "Description...",
+    "save-description": "Save",
+    "cancel": "Cancel",
+    "hide-bind": "Hide this bind"
   },
   "settings": {
     "title": "快捷鍵速查表設定",
@@ -51,7 +60,18 @@
     "width-range": "px (400-3000)",
     "height-range": "px (300-2000)",
     "hyprland-path": "Hyprland 路徑",
-    "niri-path": "Niri 路徑"
+    "niri-path": "Niri 路徑",
+    "hyprland-lua-path": "Hyprland Lua Path",
+    "hyprland-parser-mode": "Parser:",
+    "hyprland-lua-hint": "Auto: uses hyprland.lua via `hyprctl binds` when it exists, otherwise the legacy .conf parser.",
+    "undescribed-title": "Undescribed Binds",
+    "show-undescribed": "Show binds without a description",
+    "show-undescribed-hint": "When enabled, binds with no description appear in a dedicated section where you can add a description or hide them.",
+    "overrides-summary": "Hidden: {hidden} - Custom descriptions: {custom}",
+    "restore-hidden": "Restore hidden",
+    "restore-hidden-message": "Hidden binds restored.",
+    "clear-overrides": "Clear all overrides",
+    "clear-overrides-message": "All bind overrides cleared."
   },
   "barwidget": {
     "tooltip": "快捷鍵速查表",

--- a/keybind-cheatsheet/manifest.json
+++ b/keybind-cheatsheet/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "keybind-cheatsheet",
   "name": "Keybind Cheatsheet",
-  "version": "3.4.0",
+  "version": "3.6.0",
   "minNoctaliaVersion": "3.6.0",
   "author": "blacku",
   "license": "MIT",
@@ -27,6 +27,10 @@
       "columnCount": 3,
       "modKeyVariable": "$mod",
       "hyprlandConfigPath": "~/.config/hypr/hyprland.conf",
+      "hyprlandLuaConfigPath": "~/.config/hypr/hyprland.lua",
+      "hyprlandParserMode": "auto",
+      "showUndescribedBinds": true,
+      "bindOverrides": {},
       "niriConfigPath": "~/.config/niri/config.kdl"
     }
   }


### PR DESCRIPTION
## Summary

- **Hyprland Lua config (`hyprland.lua`) support.** Hyprland 0.55+ moved from hyprlang `.conf` to a Lua config. Adds a second Hyprland parsing tor that queries `hyprctl binds -j` for the authoritative, already-evaluated bind list — correctly handling `require()`, `for` loops and multi-key chords that static text parsing cannot recover. Categories are recovered by a light scan of `hyprland.lua` + its `require()` modules (`-- N. NAME` headers + `description` literals, with a prefix heuristic for loop-built binds).
- **`.conf` parser kept unchanged as a fallback.** Parser mode `auto`/`lua`/`conf`; `auto` uses the Lua tor when `hyprland.lua` exists, otherwise the existing hyprlang parser. Users on hyprlang are unaffected.
- **Add description / hide for binds without a description.** Undescribed binds are surfaced in a dedicated section instead of being dropped; each can get a custom description inline or be hidden. Overrides are keyed by a stable identity (`submap|modmask|key|flags|dispatcher`, excluding the unstable `__lua` registry ref) so they survive Hyprland restarts. New `showUndescribedBinds` toggle + restore/clear actions in Settings.
- **`refresh` IPC** added so the cheatsheet can be re-parsed from a keybind.
- Fixes a `text` binding loop on the window-height settings field.
- Bumps to **3.6.0**; i18n synced across all 20 languages (English fallback, Polish localized); CHANGELOG updated.

## Test plan

- [x] Lua tor end-to-end verified on Hyprland 0.55.1: categories from `-- N.` headers, loop-built `Workspace 1-5` correctly categorized, multi-key chords resolved
- [x] Undescribed bind (temp `hl.bind` without `description`) → appears in "Without Description"; desc-override moves it out; hidden-override removes it; `showUndescribedBinds=false` hides the section
- [x] `.conf` parser regression: `conf` mode still parses hyprlang configs unchanged
- [x] `qmllint` clean (syntax); widget APIs and icon names verified against noctalia-shell source
- [x] All 21 JSON files valid and structurally identical to `en.json`
- [ ] Reviewer: visual check of inline edit / hide buttons in the panel