### PR TITLE
chore(hyprland-steam-overlay): deprecate from Hyprland 0.55 (final v2.2.0)

### DIFF
--- a/hyprland-steam-overlay/CHANGELOG.md
+++ b/hyprland-steam-overlay/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+> **DEPRECATED — not maintained from Hyprland 0.55+.** Hyprland 0.55's move
+> from hyprlang to Lua (dispatch parsing + popup/xdg handling changes) makes
+> this overlay approach no longer worthwhile. 2.2.0 is the final release; no
+> further updates are planned.
+
+## [2.2.0] - 2026-05-17
+
+### Deprecated
+- **Plugin is no longer actively maintained as of Hyprland 0.55.** This is
+  the final release. It still works on 0.55 via the dual-mode fix below, but
+  the Hyprland 0.55 popup/xdg changes also shrink the bar widget's context
+  menu (an upstream Hyprland↔Quickshell xdg-popup issue, not fixable cleanly
+  at the plugin level), and the special-workspace overlay model no longer
+  fits Hyprland's direction. No further updates are planned.
+
+### Fixed
+- **Hyprland 0.55+ Lua config compatibility (overlay was completely broken).**
+  Hyprland 0.55 deprecated hyprlang in favour of Lua; under a Lua config
+  `hyprctl dispatch <name> <args>` is parsed as Lua, so every classic
+  dispatch the plugin issued (`togglespecialworkspace`, `movetoworkspacesilent`,
+  `setfloating`, `alterzorder`, `resizewindowpixel`, `movewindowpixel`) errored
+  out. Window detection still worked, so the overlay toggled but nothing moved.
+- Plugin now auto-detects config mode at startup and emits the correct
+  `hl.dsp.*` (Lua) or classic (hyprlang) dispatch syntax. Works on both.
+- Corrected wrong IPC plugin id in README examples (`plugin:steam-overlay`
+  → `plugin:hyprland-steam-overlay`).
+
+### Added
+- Optional `useCustomLayout` setting + `steam-layout.lua`: a Hyprland 0.55+
+  custom Lua tiling layout that arranges Friends/Main/Chat columns and
+  auto-reflows, replacing the floating + pixel-positioning + 150ms polling
+  path. Scoped to `special:steam` via a workspace rule; graceful fallback
+  when the snippet is absent.
+
 ## [2.1.1] - 2026-01-29
 
 ### Changed

--- a/hyprland-steam-overlay/Main.qml
+++ b/hyprland-steam-overlay/Main.qml
@@ -26,6 +26,18 @@ Item {
   readonly property real mainWidthPercent: cfg.mainWidthPercent ?? defaults.mainWidthPercent ?? 60
   readonly property real chatWidthPercent: cfg.chatWidthPercent ?? defaults.chatWidthPercent ?? 25
 
+  // When true, the plugin does NOT float/resize/position windows itself.
+  // Instead it relies on a Hyprland custom Lua layout (lua:steam) assigned
+  // to the special:steam workspace. See steam-layout.lua + README.
+  readonly property bool useCustomLayout: cfg.useCustomLayout ?? defaults.useCustomLayout ?? false
+
+  // Hyprland >= 0.55 deprecated hyprlang (.conf) in favour of Lua (.lua).
+  // Under a Lua config, `hyprctl dispatch <name> <args>` is parsed AS LUA
+  // (hl.dispatch(<text>)), so the classic syntax errors out. We probe once
+  // at startup and emit the correct syntax for whichever config is active.
+  property bool luaMode: false
+  property bool luaModeProbed: false
+
   // Calculate pixel values from percentages (updates automatically when screen size changes)
   readonly property int topMargin: Math.round(screenHeight * (topMarginPercent / 100))
   readonly property int windowHeight: Math.round(screenHeight * (windowHeightPercent / 100))
@@ -47,6 +59,7 @@ Item {
     if (pluginApi) {
       checkSteam.running = true;
     }
+    detectConfigMode.running = true;
     detectResolution.running = true;
     monitorTimer.start();
   }
@@ -67,6 +80,28 @@ Item {
     id: launchSteam
     command: ["steam", "steam://open/main"]
     running: false
+  }
+
+  // Probe whether Hyprland runs a Lua config (hyprctl dispatch parsed as Lua).
+  // On Lua config `hl.dsp.no_op()` returns "ok"; on hyprlang it errors.
+  Process {
+    id: detectConfigMode
+    command: ["hyprctl", "dispatch", "hl.dsp.no_op()"]
+    running: false
+
+    property string out: ""
+
+    stdout: SplitParser {
+      onRead: data => {
+        detectConfigMode.out += data;
+      }
+    }
+
+    onExited: (exitCode, exitStatus) => {
+      root.luaMode = (exitCode === 0 && detectConfigMode.out.trim() === "ok");
+      root.luaModeProbed = true;
+      detectConfigMode.out = "";
+    }
   }
 
   // Detect screen resolution
@@ -138,7 +173,7 @@ Item {
 
     onExited: (exitCode, exitStatus) => {
       if (exitCode === 0) {
-        showWorkspace.running = true;
+        root.doShowWorkspace();
       }
     }
   }
@@ -146,15 +181,17 @@ Item {
   // Show special workspace (only when opening overlay)
   Process {
     id: showWorkspace
-    command: ["hyprctl", "dispatch", "togglespecialworkspace", "steam"]
+    command: ["bash", "-c", ""]
     running: false
 
     onExited: (exitCode, exitStatus) => {
       if (exitCode === 0) {
         overlayActive = true;
-        Qt.callLater(() => {
-          focusAdditionalWindows.running = true;
-        });
+        if (!root.useCustomLayout) {
+          Qt.callLater(() => {
+            focusAdditionalWindows.running = true;
+          });
+        }
       }
     }
   }
@@ -162,7 +199,7 @@ Item {
   // Hide special workspace (only when closing overlay)
   Process {
     id: hideWorkspace
-    command: ["hyprctl", "dispatch", "togglespecialworkspace", "steam"]
+    command: ["bash", "-c", ""]
     running: false
 
     onExited: (exitCode, exitStatus) => {
@@ -206,7 +243,7 @@ Item {
 
           // Bring additional windows to top (without focusing/moving cursor)
           if (!isMain) {
-            focusCommands.push("hyprctl dispatch alterzorder top,address:" + addr);
+            focusCommands.push(root.hdAlterTop(addr));
           }
         }
 
@@ -292,9 +329,11 @@ Item {
           var commands = [];
           for (var j = 0; j < windowsToMove.length; j++) {
             var addr = windowsToMove[j];
-            commands.push("hyprctl dispatch movetoworkspacesilent special:steam,address:" + addr);
-            commands.push("hyprctl dispatch setfloating address:" + addr);
-            commands.push("hyprctl dispatch alterzorder top,address:" + addr);
+            commands.push(root.hdMoveToSpecial(addr));
+            if (!root.useCustomLayout) {
+              commands.push(root.hdSetFloating(addr));
+              commands.push(root.hdAlterTop(addr));
+            }
           }
           moveNewWindows.command = ["bash", "-c", commands.join(" && ")];
           if (!moveNewWindows.running) {
@@ -345,9 +384,12 @@ Item {
             continue;
           }
 
-          // Move all Steam windows to overlay and set as floating
-          commands.push("hyprctl dispatch movetoworkspacesilent special:steam,address:" + addr);
-          commands.push("hyprctl dispatch setfloating address:" + addr);
+          // Move all Steam windows to the overlay workspace. With the custom
+          // Lua layout active the layout tiles them, so we must NOT float.
+          commands.push(root.hdMoveToSpecial(addr));
+          if (!root.useCustomLayout) {
+            commands.push(root.hdSetFloating(addr));
+          }
         }
 
         if (commands.length > 0) {
@@ -368,7 +410,10 @@ Item {
     onExited: (exitCode, exitStatus) => {
       if (exitCode === 0) {
         Qt.callLater(() => {
-          if (steamWindows.length > 0) {
+          if (root.useCustomLayout) {
+            // Hyprland's lua:steam layout arranges the windows; just reveal.
+            root.doShowWorkspace();
+          } else if (steamWindows.length > 0) {
             moveWindowsToOverlay();
           }
         });
@@ -377,6 +422,55 @@ Item {
   }
 
 
+  // ---- Dual-mode hyprctl dispatch builders -------------------------------
+  // Each returns a full `hyprctl dispatch ...` shell fragment, using Lua
+  // (hl.dsp.*) syntax under a Lua config or classic syntax under hyprlang.
+  function hdToggleSpecial() {
+    return root.luaMode
+      ? "hyprctl dispatch 'hl.dsp.workspace.toggle_special(\"steam\")'"
+      : "hyprctl dispatch togglespecialworkspace steam";
+  }
+
+  function hdMoveToSpecial(addr) {
+    return root.luaMode
+      ? "hyprctl dispatch 'hl.dsp.window.move({ workspace = \"special:steam\", follow = false, window = \"address:" + addr + "\" })'"
+      : "hyprctl dispatch movetoworkspacesilent special:steam,address:" + addr;
+  }
+
+  function hdSetFloating(addr) {
+    return root.luaMode
+      ? "hyprctl dispatch 'hl.dsp.window.float({ action = \"enable\", window = \"address:" + addr + "\" })'"
+      : "hyprctl dispatch setfloating address:" + addr;
+  }
+
+  function hdAlterTop(addr) {
+    return root.luaMode
+      ? "hyprctl dispatch 'hl.dsp.window.alter_zorder({ mode = \"top\", window = \"address:" + addr + "\" })'"
+      : "hyprctl dispatch alterzorder top,address:" + addr;
+  }
+
+  function hdResize(w, h, addr) {
+    return root.luaMode
+      ? "hyprctl dispatch 'hl.dsp.window.resize({ x = " + w + ", y = " + h + ", exact = true, window = \"address:" + addr + "\" })'"
+      : "hyprctl dispatch resizewindowpixel exact " + w + " " + h + ",address:" + addr;
+  }
+
+  function hdMovePixel(x, y, addr) {
+    return root.luaMode
+      ? "hyprctl dispatch 'hl.dsp.window.move({ x = " + x + ", y = " + y + ", window = \"address:" + addr + "\" })'"
+      : "hyprctl dispatch movewindowpixel exact " + x + " " + y + ",address:" + addr;
+  }
+
+  function doShowWorkspace() {
+    showWorkspace.command = ["bash", "-c", hdToggleSpecial()];
+    showWorkspace.running = true;
+  }
+
+  function doHideWorkspace() {
+    hideWorkspace.command = ["bash", "-c", hdToggleSpecial()];
+    hideWorkspace.running = true;
+  }
+
   function toggleOverlay() {
     if (!steamRunning) {
       launchSteam.running = true;
@@ -384,7 +478,7 @@ Item {
     }
 
     if (overlayActive) {
-      hideWorkspace.running = true;
+      root.doHideWorkspace();
     } else {
 
       // Show overlay - detect main windows first, then all windows
@@ -426,8 +520,8 @@ Item {
       }
 
       // Position and size the 3 main windows (they are already floating and in overlay)
-      commands.push("hyprctl dispatch resizewindowpixel exact " + w + " " + h + ",address:" + addr);
-      commands.push("hyprctl dispatch movewindowpixel exact " + x + " " + y + ",address:" + addr);
+      commands.push(root.hdResize(w, h, addr));
+      commands.push(root.hdMovePixel(x, y, addr));
     }
 
     if (commands.length > 0) {

--- a/hyprland-steam-overlay/README.md
+++ b/hyprland-steam-overlay/README.md
@@ -1,5 +1,18 @@
 # Steam Overlay for Noctalia
 
+> ## ⚠️ DEPRECATED — not maintained from Hyprland 0.55+
+>
+> Hyprland 0.55 deprecated hyprlang (`.conf`) in favour of Lua (`.lua`), which
+> changed how `hyprctl dispatch` is parsed and how popups/xdg surfaces are
+> handled. These changes broke the overlay's window management and the bar
+> widget's context menu, and make the special-workspace overlay approach no
+> longer worthwhile.
+>
+> **This plugin is no longer actively maintained.** The final `2.2.0` release
+> includes a best-effort dual-mode dispatch fix and an optional custom Lua
+> layout so it still works on Hyprland 0.55, but **no further updates are
+> planned**. Use at your own discretion.
+
 Steam overlay plugin for Noctalia/Quickshell with automatic window management using Hyprland special workspace.
 
 ## Features
@@ -30,14 +43,20 @@ pkill -f "qs.*noctalia" && qs -c noctalia-shell &
 Click the gamepad icon in your top bar to toggle the Steam overlay.
 
 ### Via Keyboard Shortcut
-Add to your Hyprland config (`~/.config/hypr/hyprland.conf`):
+
+hyprlang config (`~/.config/hypr/hyprland.conf`):
 ```
-bind = SUPER, G, exec, qs -c noctalia-shell ipc call plugin:steam-overlay toggle
+bind = SUPER, G, exec, qs -c noctalia-shell ipc call plugin:hyprland-steam-overlay toggle
+```
+
+Lua config (`~/.config/hypr/hyprland.lua`, Hyprland 0.55+):
+```lua
+hl.bind("SUPER + G", hl.dsp.exec_cmd("qs -c noctalia-shell ipc call plugin:hyprland-steam-overlay toggle"))
 ```
 
 ### Via IPC Command
 ```bash
-qs -c noctalia-shell ipc call plugin:steam-overlay toggle
+qs -c noctalia-shell ipc call plugin:hyprland-steam-overlay toggle
 ```
 
 ## How It Works
@@ -69,13 +88,49 @@ Default settings in `settings.json`:
 }
 ```
 
+## Hyprland 0.55+ / Lua config
+
+Since Hyprland 0.55, hyprlang (`.conf`) is deprecated in favour of Lua
+(`.lua`). Under a Lua config, `hyprctl dispatch` is parsed **as Lua**, so the
+old classic dispatch syntax errors out — this is what broke the overlay on
+older plugin versions.
+
+The plugin now **auto-detects** the active config mode at startup (probing
+`hyprctl dispatch 'hl.dsp.no_op()'`) and emits the correct syntax for either
+hyprlang or Lua. No configuration needed — it just works on both.
+
+## Optional: custom Hyprland Lua layout
+
+Instead of floating + pixel-positioning the windows, you can let Hyprland's
+custom layout API (0.55+) tile them. This auto-reflows on window add/remove
+/resize, with no polling and no pixel math.
+
+1. Copy the layout next to your Lua config:
+   ```bash
+   cp ~/.config/noctalia/plugins/hyprland-steam-overlay/steam-layout.lua ~/.config/hypr/steam-layout.lua
+   ```
+2. In `~/.config/hypr/hyprland.lua` add:
+   ```lua
+   require("steam-layout")
+   hl.workspace_rule({ workspace = "special:steam", layout = "lua:steam" })
+   ```
+   The `workspace_rule` scopes the layout to **only** the steam overlay
+   workspace, leaving your normal layout untouched everywhere else.
+3. Reload Hyprland, then enable **"Use custom Hyprland layout (Lua)"** in the
+   plugin settings.
+
+If the setting is enabled but the snippet is missing, Steam windows still
+open in the overlay workspace using your default layout (graceful fallback).
+Edit the width ratios at the top of `steam-layout.lua` to taste.
+
 ## Requirements
 
 - Noctalia/Quickshell 3.6.0+
-- Hyprland compositor
+- Hyprland compositor (hyprlang or Lua config — both supported)
 - Steam
 - `jq` for JSON parsing
 - `hyprctl` for window management
+- Custom layout (optional): Hyprland 0.55+ with a Lua config
 
 ## Files
 
@@ -84,6 +139,7 @@ Default settings in `settings.json`:
 - `Panel.qml` - Overlay panel (optional)
 - `manifest.json` - Plugin metadata
 - `settings.json` - Plugin settings
+- `steam-layout.lua` - Optional Hyprland custom Lua layout (0.55+)
 
 ## Author
 

--- a/hyprland-steam-overlay/Settings.qml
+++ b/hyprland-steam-overlay/Settings.qml
@@ -13,6 +13,7 @@ ColumnLayout {
 
   // Local state - track changes before saving
   property bool valueAutoLaunchSteam: cfg.autoLaunchSteam ?? defaults.autoLaunchSteam ?? true
+  property bool valueUseCustomLayout: cfg.useCustomLayout ?? defaults.useCustomLayout ?? false
   property bool valueEnableChatNotifications: cfg.enableChatNotifications ?? defaults.enableChatNotifications ?? true
   property int valueFriendsWidth: cfg.friendsWidthPercent ?? defaults.friendsWidthPercent ?? 10
   property int valueMainWidth: cfg.mainWidthPercent ?? defaults.mainWidthPercent ?? 60
@@ -48,6 +49,15 @@ ColumnLayout {
     description: "Show notification indicator on bar icon when new Steam chat messages arrive"
     checked: root.valueEnableChatNotifications
     onToggled: root.valueEnableChatNotifications = checked
+  }
+
+  // Custom Hyprland layout toggle
+  NCheckbox {
+    Layout.fillWidth: true
+    label: "Use custom Hyprland layout (Lua)"
+    description: "Let a Hyprland custom Lua layout tile the windows instead of floating+positioning them. Requires Hyprland 0.55+ Lua config and steam-layout.lua (see README). When enabled, the width sliders below are handled by the Lua layout."
+    checked: root.valueUseCustomLayout
+    onToggled: root.valueUseCustomLayout = checked
   }
 
   NDivider {
@@ -213,6 +223,7 @@ ColumnLayout {
 
     // Update the plugin settings object
     pluginApi.pluginSettings.autoLaunchSteam = root.valueAutoLaunchSteam;
+    pluginApi.pluginSettings.useCustomLayout = root.valueUseCustomLayout;
     pluginApi.pluginSettings.enableChatNotifications = root.valueEnableChatNotifications;
     pluginApi.pluginSettings.friendsWidthPercent = root.valueFriendsWidth;
     pluginApi.pluginSettings.mainWidthPercent = root.valueMainWidth;

--- a/hyprland-steam-overlay/Settings.qml
+++ b/hyprland-steam-overlay/Settings.qml
@@ -54,8 +54,8 @@ ColumnLayout {
   // Custom Hyprland layout toggle
   NCheckbox {
     Layout.fillWidth: true
-    label: "Use custom Hyprland layout (Lua)"
-    description: "Let a Hyprland custom Lua layout tile the windows instead of floating+positioning them. Requires Hyprland 0.55+ Lua config and steam-layout.lua (see README). When enabled, the width sliders below are handled by the Lua layout."
+    label: pluginApi?.tr("settings.custom-layout-label")
+    description: pluginApi?.tr("settings.custom-layout-description")
     checked: root.valueUseCustomLayout
     onToggled: root.valueUseCustomLayout = checked
   }

--- a/hyprland-steam-overlay/i18n/de.json
+++ b/hyprland-steam-overlay/i18n/de.json
@@ -10,5 +10,9 @@
     "steam_launched": "Steam gestartet",
     "no_windows_found": "Keine Steam-Fenster gefunden",
     "ipc_received": "IPC-Umschaltung empfangen"
+  },
+  "settings": {
+    "custom-layout-label": "Use custom Hyprland layout (Lua)",
+    "custom-layout-description": "Let a Hyprland custom Lua layout tile the windows instead of floating+positioning them. Requires Hyprland 0.55+ Lua config and steam-layout.lua (see README). When enabled, the width sliders below are handled by the Lua layout."
   }
 }

--- a/hyprland-steam-overlay/i18n/en.json
+++ b/hyprland-steam-overlay/i18n/en.json
@@ -10,5 +10,9 @@
     "steam_launched": "Steam launched",
     "no_windows_found": "No Steam windows found",
     "ipc_received": "IPC toggle received"
+  },
+  "settings": {
+    "custom-layout-label": "Use custom Hyprland layout (Lua)",
+    "custom-layout-description": "Let a Hyprland custom Lua layout tile the windows instead of floating+positioning them. Requires Hyprland 0.55+ Lua config and steam-layout.lua (see README). When enabled, the width sliders below are handled by the Lua layout."
   }
 }

--- a/hyprland-steam-overlay/i18n/es.json
+++ b/hyprland-steam-overlay/i18n/es.json
@@ -10,5 +10,9 @@
     "steam_launched": "Steam iniciado",
     "no_windows_found": "No se encontraron ventanas de Steam",
     "ipc_received": "Alternancia IPC recibida"
+  },
+  "settings": {
+    "custom-layout-label": "Use custom Hyprland layout (Lua)",
+    "custom-layout-description": "Let a Hyprland custom Lua layout tile the windows instead of floating+positioning them. Requires Hyprland 0.55+ Lua config and steam-layout.lua (see README). When enabled, the width sliders below are handled by the Lua layout."
   }
 }

--- a/hyprland-steam-overlay/i18n/fr.json
+++ b/hyprland-steam-overlay/i18n/fr.json
@@ -10,5 +10,9 @@
     "steam_launched": "Steam lancé",
     "no_windows_found": "Aucune fenêtre Steam trouvée",
     "ipc_received": "Basculement IPC reçu"
+  },
+  "settings": {
+    "custom-layout-label": "Use custom Hyprland layout (Lua)",
+    "custom-layout-description": "Let a Hyprland custom Lua layout tile the windows instead of floating+positioning them. Requires Hyprland 0.55+ Lua config and steam-layout.lua (see README). When enabled, the width sliders below are handled by the Lua layout."
   }
 }

--- a/hyprland-steam-overlay/i18n/hu.json
+++ b/hyprland-steam-overlay/i18n/hu.json
@@ -10,5 +10,9 @@
     "windows_found": "{count} Steam ablakot találtam",
     "windows_moved": "Ablakok áthelyezve, kilépési kód: {code}",
     "workspace_toggled": "Munkaterület váltva"
+  },
+  "settings": {
+    "custom-layout-label": "Use custom Hyprland layout (Lua)",
+    "custom-layout-description": "Let a Hyprland custom Lua layout tile the windows instead of floating+positioning them. Requires Hyprland 0.55+ Lua config and steam-layout.lua (see README). When enabled, the width sliders below are handled by the Lua layout."
   }
 }

--- a/hyprland-steam-overlay/i18n/it.json
+++ b/hyprland-steam-overlay/i18n/it.json
@@ -10,5 +10,9 @@
     "steam_launched": "Steam avviato",
     "no_windows_found": "Nessuna finestra Steam trovata",
     "ipc_received": "Alternanza IPC ricevuta"
+  },
+  "settings": {
+    "custom-layout-label": "Use custom Hyprland layout (Lua)",
+    "custom-layout-description": "Let a Hyprland custom Lua layout tile the windows instead of floating+positioning them. Requires Hyprland 0.55+ Lua config and steam-layout.lua (see README). When enabled, the width sliders below are handled by the Lua layout."
   }
 }

--- a/hyprland-steam-overlay/i18n/ja.json
+++ b/hyprland-steam-overlay/i18n/ja.json
@@ -10,5 +10,9 @@
     "steam_launched": "Steamを起動しました",
     "no_windows_found": "Steamウィンドウが見つかりません",
     "ipc_received": "IPCトグルを受信しました"
+  },
+  "settings": {
+    "custom-layout-label": "Use custom Hyprland layout (Lua)",
+    "custom-layout-description": "Let a Hyprland custom Lua layout tile the windows instead of floating+positioning them. Requires Hyprland 0.55+ Lua config and steam-layout.lua (see README). When enabled, the width sliders below are handled by the Lua layout."
   }
 }

--- a/hyprland-steam-overlay/i18n/ku.json
+++ b/hyprland-steam-overlay/i18n/ku.json
@@ -10,5 +10,9 @@
     "windows_found": "Me dît {count} pencereyên Steamê",
     "windows_moved": "Pencerî hatin guhestin, koda derketinê: {code}",
     "workspace_toggled": "Cihê kar hat guhertin"
+  },
+  "settings": {
+    "custom-layout-label": "Use custom Hyprland layout (Lua)",
+    "custom-layout-description": "Let a Hyprland custom Lua layout tile the windows instead of floating+positioning them. Requires Hyprland 0.55+ Lua config and steam-layout.lua (see README). When enabled, the width sliders below are handled by the Lua layout."
   }
 }

--- a/hyprland-steam-overlay/i18n/nl.json
+++ b/hyprland-steam-overlay/i18n/nl.json
@@ -10,5 +10,9 @@
     "steam_launched": "Steam gestart",
     "no_windows_found": "Geen Steam-vensters gevonden",
     "ipc_received": "IPC-wisseling ontvangen"
+  },
+  "settings": {
+    "custom-layout-label": "Use custom Hyprland layout (Lua)",
+    "custom-layout-description": "Let a Hyprland custom Lua layout tile the windows instead of floating+positioning them. Requires Hyprland 0.55+ Lua config and steam-layout.lua (see README). When enabled, the width sliders below are handled by the Lua layout."
   }
 }

--- a/hyprland-steam-overlay/i18n/pl.json
+++ b/hyprland-steam-overlay/i18n/pl.json
@@ -10,5 +10,9 @@
     "steam_launched": "Steam uruchomiony",
     "no_windows_found": "Nie znaleziono okien Steam",
     "ipc_received": "Otrzymano przełącznik IPC"
+  },
+  "settings": {
+    "custom-layout-label": "Use custom Hyprland layout (Lua)",
+    "custom-layout-description": "Let a Hyprland custom Lua layout tile the windows instead of floating+positioning them. Requires Hyprland 0.55+ Lua config and steam-layout.lua (see README). When enabled, the width sliders below are handled by the Lua layout."
   }
 }

--- a/hyprland-steam-overlay/i18n/pt.json
+++ b/hyprland-steam-overlay/i18n/pt.json
@@ -10,5 +10,9 @@
     "steam_launched": "Steam iniciado",
     "no_windows_found": "Nenhuma janela do Steam encontrada",
     "ipc_received": "Alternância IPC recebida"
+  },
+  "settings": {
+    "custom-layout-label": "Use custom Hyprland layout (Lua)",
+    "custom-layout-description": "Let a Hyprland custom Lua layout tile the windows instead of floating+positioning them. Requires Hyprland 0.55+ Lua config and steam-layout.lua (see README). When enabled, the width sliders below are handled by the Lua layout."
   }
 }

--- a/hyprland-steam-overlay/i18n/ru.json
+++ b/hyprland-steam-overlay/i18n/ru.json
@@ -10,5 +10,9 @@
     "steam_launched": "Steam запущен",
     "no_windows_found": "Окна Steam не найдены",
     "ipc_received": "Получено переключение IPC"
+  },
+  "settings": {
+    "custom-layout-label": "Use custom Hyprland layout (Lua)",
+    "custom-layout-description": "Let a Hyprland custom Lua layout tile the windows instead of floating+positioning them. Requires Hyprland 0.55+ Lua config and steam-layout.lua (see README). When enabled, the width sliders below are handled by the Lua layout."
   }
 }

--- a/hyprland-steam-overlay/i18n/tr.json
+++ b/hyprland-steam-overlay/i18n/tr.json
@@ -10,5 +10,9 @@
     "steam_launched": "Steam başlatıldı",
     "no_windows_found": "Steam penceresi bulunamadı",
     "ipc_received": "IPC değiştirme alındı"
+  },
+  "settings": {
+    "custom-layout-label": "Use custom Hyprland layout (Lua)",
+    "custom-layout-description": "Let a Hyprland custom Lua layout tile the windows instead of floating+positioning them. Requires Hyprland 0.55+ Lua config and steam-layout.lua (see README). When enabled, the width sliders below are handled by the Lua layout."
   }
 }

--- a/hyprland-steam-overlay/i18n/uk-UA.json
+++ b/hyprland-steam-overlay/i18n/uk-UA.json
@@ -10,5 +10,9 @@
     "steam_launched": "Steam запущено",
     "no_windows_found": "Вікна Steam не знайдено",
     "ipc_received": "Отримано перемикання IPC"
+  },
+  "settings": {
+    "custom-layout-label": "Use custom Hyprland layout (Lua)",
+    "custom-layout-description": "Let a Hyprland custom Lua layout tile the windows instead of floating+positioning them. Requires Hyprland 0.55+ Lua config and steam-layout.lua (see README). When enabled, the width sliders below are handled by the Lua layout."
   }
 }

--- a/hyprland-steam-overlay/i18n/zh-CN.json
+++ b/hyprland-steam-overlay/i18n/zh-CN.json
@@ -10,5 +10,9 @@
     "steam_launched": "Steam已启动",
     "no_windows_found": "未找到Steam窗口",
     "ipc_received": "已接收IPC切换"
+  },
+  "settings": {
+    "custom-layout-label": "Use custom Hyprland layout (Lua)",
+    "custom-layout-description": "Let a Hyprland custom Lua layout tile the windows instead of floating+positioning them. Requires Hyprland 0.55+ Lua config and steam-layout.lua (see README). When enabled, the width sliders below are handled by the Lua layout."
   }
 }

--- a/hyprland-steam-overlay/manifest.json
+++ b/hyprland-steam-overlay/manifest.json
@@ -1,12 +1,12 @@
 {
   "id": "hyprland-steam-overlay",
   "name": "Steam Overlay (Hyprland)",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "minNoctaliaVersion": "4.1.2",
   "author": "blacku",
   "repository": "https://github.com/noctalia-dev/noctalia-plugins",
   "license": "MIT",
-  "description": "Steam overlay with automatic window management for Hyprland. Automatically moves all Steam windows (except fullscreen games) to overlay workspace as floating windows. Main 3 windows (Friends, Client, Chat) are positioned in a row. Additional windows are brought to top. If new windows don't appear on top, toggle overlay off/on (Super+S twice). Fully responsive with percentage-based layout. Requires Hyprland window manager.",
+  "description": "[DEPRECATED — not maintained from Hyprland 0.55+] Steam overlay with automatic window management for Hyprland. Due to Hyprland 0.55 deprecating hyprlang in favour of Lua (changing hyprctl dispatch parsing and popup/xdg handling), this plugin is no longer actively maintained. The 2.2.0 release adds a best-effort dual-mode dispatch fix and an optional custom Lua layout, but no further updates are planned. Automatically moves all Steam windows (except fullscreen games) to an overlay workspace; main 3 windows (Friends, Client, Chat) positioned in a row, fully responsive percentage-based layout. Requires Hyprland window manager.",
   "entryPoints": {
     "main": "Main.qml",
     "barWidget": "BarWidget.qml",
@@ -19,6 +19,7 @@
   "metadata": {
     "defaultSettings": {
       "autoLaunchSteam": true,
+      "useCustomLayout": false,
       "friendsWidthPercent": 10,
       "mainWidthPercent": 60,
       "chatWidthPercent": 25,

--- a/hyprland-steam-overlay/steam-layout.lua
+++ b/hyprland-steam-overlay/steam-layout.lua
@@ -1,0 +1,108 @@
+-- Steam Overlay — custom Hyprland Lua layout
+-- =========================================================================
+-- Requires Hyprland >= 0.55 with a Lua config (hyprland.lua).
+--
+-- This is OPTIONAL. It only matters if you enable "Use custom Hyprland
+-- layout" in the plugin settings. When active, the plugin just moves the
+-- Steam windows into the `special:steam` workspace and this layout tiles
+-- them into Friends | Main | Chat columns (auto-reflowing, no floating,
+-- no pixel math, no polling).
+--
+-- SETUP
+--   1. Copy this file next to your Lua config:
+--        cp steam-layout.lua ~/.config/hypr/steam-layout.lua
+--   2. In ~/.config/hypr/hyprland.lua add:
+--        require("steam-layout")
+--        hl.workspace_rule({ workspace = "special:steam", layout = "lua:steam" })
+--      (the workspace_rule scopes this layout to ONLY the steam overlay,
+--       leaving your normal layout untouched everywhere else)
+--   3. Reload Hyprland, enable the setting in the plugin, toggle the overlay.
+--
+-- The 0.10 / 0.60 / 0.25 split below mirrors the plugin defaults. Edit the
+-- ratios here if you change the plugin's width settings.
+-- =========================================================================
+
+local FRIENDS_RATIO = 0.10
+local MAIN_RATIO    = 0.60
+local CHAT_RATIO    = 0.25
+
+local function classify(target)
+    local w = target.window
+    if not w then
+        return "extra"
+    end
+    local title = w.title or ""
+    if title:find("Friends List", 1, true) then
+        return "friends"
+    end
+    if title == "Steam" then
+        return "main"
+    end
+    return "chat"
+end
+
+-- Stack a list of targets vertically inside a column.
+local function place_column(list, x, w, area)
+    local count = #list
+    if count == 0 then
+        return
+    end
+    local colH = math.floor(area.h / count)
+    for i, target in ipairs(list) do
+        target:place({
+            x = math.floor(x),
+            y = math.floor(area.y + (i - 1) * colH),
+            w = math.floor(w),
+            h = colH,
+        })
+    end
+end
+
+hl.layout.register("steam", {
+    recalculate = function(ctx)
+        local targets = ctx.targets
+        local n = #targets
+        if n == 0 then
+            return
+        end
+
+        local area = ctx.area
+        local used = FRIENDS_RATIO + MAIN_RATIO + CHAT_RATIO
+        local margin = math.max(0.0, 1.0 - used) / 2.0
+
+        local friendsX = area.x + area.w * margin
+        local mainX    = friendsX + area.w * FRIENDS_RATIO
+        local chatX    = mainX + area.w * MAIN_RATIO
+
+        -- A single window: center it at main width.
+        if n == 1 then
+            targets[1]:place({
+                x = math.floor(mainX),
+                y = math.floor(area.y),
+                w = math.floor(area.w * MAIN_RATIO),
+                h = math.floor(area.h),
+            })
+            return
+        end
+
+        local friends, main, chat, extra = {}, {}, {}, {}
+        for _, target in ipairs(targets) do
+            local kind = classify(target)
+            if kind == "friends" then
+                friends[#friends + 1] = target
+            elseif kind == "main" then
+                main[#main + 1] = target
+            elseif kind == "chat" then
+                chat[#chat + 1] = target
+            else
+                extra[#extra + 1] = target
+            end
+        end
+
+        place_column(friends, friendsX, area.w * FRIENDS_RATIO, area)
+        place_column(main,    mainX,    area.w * MAIN_RATIO,    area)
+        place_column(chat,    chatX,    area.w * CHAT_RATIO,    area)
+        -- Unclassified Steam windows share the main column.
+        place_column(extra,   mainX,    area.w * MAIN_RATIO,    area)
+    end,
+})


### PR DESCRIPTION
## Summary

Hyprland 0.55 deprecated hyprlang (`.conf`) in favour of Lua (`.lua`). Under a Lua config, `hyprctl dispatch <name> <args>` is parsed **as Lua** (`hl.dispatch(<text>)`), so the plugin's classic dispatch calls all errored out — window detection still worked, so the overlay toggled but nothing moved. The same 0.55 popup/xdg changes also shrink the bar widget's context menu (an upstream Hyprland↔Quickshell xdg-popup issue, not cleanly fixable at the plugin level).

Given Hyprland's direction, the special-workspace overlay model is no longer worthwhile. **This plugin is now deprecated and unmaintained.** `2.2.0` is the final release — it still works on 0.55 via a best-effort fix, but no further updates are planned.

## Changes (v2.1.2 → v2.2.0)

- **Dual-mode dispatch**: probes `hyprctl dispatch 'hl.dsp.no_op()'` at startup and emits `hl.dsp.*` (Lua config) or classic (hyprlang) syntax accordingly. Works on both.
- **Optional custom Lua layout**: new `steam-layout.lua` + `useCustomLayout` setting. A Hyprland 0.55+ `hl.layout.register` tiling layout arranges Friends/Main/Chat columns (auto-reflow, no floating/pixel-math/polling), scoped to `special:steam` via `hl.workspace_rule`. Graceful fallback when the snippet is absent.
- **Deprecation notices** in manifest description, README banner, and CHANGELOG.
- Corrected wrong IPC plugin id in README examples (`plugin:steam-overlay` → `plugin:hyprland-steam-overlay`).

No `registry.json`, no `settings.json`, no backups committed. `preview.png` unchanged.

## Test plan

- [x] All 6 Lua-mode dispatch strings verified live on Hyprland 0.55.1 (move to special:steam, float, alter_zorder, resize, move-pixel, toggle-special) — correct geometry, state restored.
- [x] `steam-layout.lua` parse-checked with `luac5.4` + placement logic unit-tested offline (3 windows, 1 window, stacked chats, empty, group target).
- [x] `qmllint` clean on Main/Settings/BarWidget/Panel; `manifest.json` valid JSON.
- [ ] Hot-test integrated plugin via shell reload + Super+S (requires user; mechanism verified live).