### PR TITLE
feat(tailscale): make bar icon easier to read

### DIFF
--- a/tailscale/BarWidget.qml
+++ b/tailscale/BarWidget.qml
@@ -18,6 +18,8 @@ Item {
   readonly property bool pillDirection: BarService.getPillDirection(root)
 
   readonly property var mainInstance: pluginApi?.mainInstance
+  readonly property bool tailscaleConnected: mainInstance?.tailscaleRunning ?? false
+  readonly property bool tailscaleConnecting: (mainInstance?.isRefreshing ?? false) && !(mainInstance?.tailscaleRunning ?? false)
 
   readonly property bool barIsVertical: Settings.data.bar.position === "left" || Settings.data.bar.position === "right"
 
@@ -50,12 +52,10 @@ Item {
       TailscaleIcon {
         pointSize: Style.fontSizeL
         applyUiScale: false
-        crossed: !(mainInstance?.tailscaleRunning ?? false)
-        color: {
-          if (mainInstance?.tailscaleRunning ?? false) return Color.mOnPrimary
-          return mouseArea.containsMouse ? Color.mOnHover : Color.mOnSurface
-        }
-        opacity: 1.0
+        connected: root.tailscaleConnected
+        connecting: root.tailscaleConnecting
+        hovered: mouseArea.containsMouse
+        litColor: Color.mPrimary
       }
 
       // Show details when not in compact mode and there's something to show

--- a/tailscale/TailscaleIcon.qml
+++ b/tailscale/TailscaleIcon.qml
@@ -1,43 +1,71 @@
 import QtQuick
 import QtQuick.Layouts
-import QtQuick.Effects
 import qs.Commons
-import qs.Widgets
 
 Item {
   id: root
-  property var pluginApi: null
 
   property real pointSize: Style.fontSizeL
   property bool applyUiScale: true
-  property color color: Color.mOnSurface
-  property bool crossed: false
+  property bool connected: false
+  property bool connecting: false
+  property bool hovered: false
+  property color litColor: Color.mPrimary
+  property color dimColor: Color.mOnSurface
+  property real dimOpacity: hovered ? 0.78 : 0.38
 
-  implicitWidth: Math.max(1, applyUiScale ? root.pointSize * Style.uiScaleRatio : root.pointSize)
-  implicitHeight: Math.max(1, applyUiScale ? root.pointSize * Style.uiScaleRatio : root.pointSize)
+  readonly property real iconSize: Math.max(1, applyUiScale ? root.pointSize * Style.uiScaleRatio : root.pointSize)
+  readonly property real dotSize: Math.max(3, iconSize * 0.22)
+  readonly property real dotGap: Math.max(2, iconSize * 0.17)
+  readonly property int activeConnectingDot: connecting ? connectingFrame % 9 : -1
 
-  Image {
-    id: iconImage
-    anchors.fill: parent
-    source: Qt.resolvedUrl("icons/tailscale.svg")
-    fillMode: Image.PreserveAspectFit
-    smooth: true
-    mipmap: true
+  property int connectingFrame: 0
 
-    layer.enabled: true
-    layer.effect: MultiEffect {
-      colorization: 1.0
-      colorizationColor: root.color
-    }
+  implicitWidth: iconSize
+  implicitHeight: iconSize
+
+  Timer {
+    interval: 420
+    running: root.connecting && !root.connected
+    repeat: true
+    onTriggered: root.connectingFrame = (root.connectingFrame + 5) % 9
   }
 
-  Rectangle {
-    visible: root.crossed
+  GridLayout {
     anchors.centerIn: parent
-    width: parent.width * 1.2
-    height: parent.height * 0.15
-    radius: height / 2
-    color: root.color
-    rotation: -45
+    columns: 3
+    rowSpacing: root.dotGap
+    columnSpacing: root.dotGap
+
+    Repeater {
+      model: 9
+
+      Rectangle {
+        required property int index
+
+        readonly property bool connectedLit: root.connected && (index === 3 || index === 4 || index === 5 || index === 7)
+        readonly property bool connectingLit: root.connecting
+          && !root.connected
+          && (index === root.activeConnectingDot
+            || index === (root.activeConnectingDot + 4) % 9
+            || index === (root.activeConnectingDot + 7) % 9)
+        readonly property bool lit: connectedLit || connectingLit
+
+        Layout.preferredWidth: root.dotSize
+        Layout.preferredHeight: root.dotSize
+        radius: width / 2
+        color: lit ? root.litColor : root.dimColor
+        opacity: lit ? 1.0 : root.dimOpacity
+        scale: connectingLit ? 1.18 : 1.0
+
+        Behavior on opacity {
+          NumberAnimation { duration: 120; easing.type: Easing.OutCubic }
+        }
+
+        Behavior on scale {
+          NumberAnimation { duration: 120; easing.type: Easing.OutCubic }
+        }
+      }
+    }
   }
 }

--- a/tailscale/manifest.json
+++ b/tailscale/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "tailscale",
   "name": "Tailscale",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "minNoctaliaVersion": "4.0.0",
   "author": "nineluj",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Updates the Tailscale bar widget icon to improve readability and better communicate connection state.

- Replaces the tinted SVG/slash icon with a native 3x3 dot-grid icon
- Uses the theme primary/accent color for active dots
- Adds distinct states for disconnected, connecting, and connected
- Slows the connecting animation and limits it to three lit dots at a time
- Bumps the Tailscale plugin version to 1.5.1