### PR TITLE
docs(keep-awake-plus): add nix/ example module

### DIFF
--- a/keep-awake-plus/README.md
+++ b/keep-awake-plus/README.md
@@ -35,8 +35,9 @@ Required runtime tools: `bash`, `coreutils`, `procps`, `util-linux`,
 `systemd`, `jq`. Optional: `glib` (for UPower lid checks) and `libnotify`
 (for toasts).
 
-For the Nix flavor — packaged with a thermal-guard service and integrated
-into a Hyprland setup — see <https://github.com/noamsto/nix-config>.
+For a NixOS / Home Manager wiring — including an optional thermal-guard
+systemd user service that force-suspends if the laptop overheats while a
+session is active — see [`nix/`](nix/).
 
 ## Settings
 

--- a/keep-awake-plus/nix/README.md
+++ b/keep-awake-plus/nix/README.md
@@ -1,0 +1,58 @@
+# NixOS / Home Manager example
+
+`keep-awake-plus.nix` is a self-contained Home Manager module that complements
+the plugin with two things:
+
+1. **Runtime dependencies on PATH** — `jq`, `glib` (for `gdbus`), and
+   `libnotify` (for `notify-send`). The plugin's shipped
+   [`scripts/system-awake`](../scripts/system-awake) is portable and falls back
+   gracefully when `gdbus` / `notify-send` aren't available, so this is the
+   only wiring you need to make on a stock NixOS setup with `programs.noctalia-shell`.
+
+2. **Optional thermal watchdog** — `system-awake-thermal-guard` is a systemd
+   user service that polls `/sys/class/thermal/thermal_zone*/temp` while a
+   keep-awake session is active and force-suspends the laptop if it overheats.
+   Two trip conditions:
+
+   - **Critical (98 °C × 20 s)** — unconditional suspend. Last-resort
+     protection against thermal damage.
+   - **Bag (85 °C × 60 s + lid closed + no external monitor)** — suspends when
+     the laptop is likely tucked into a bag with full inhibits engaged. Skipped
+     when docked so long renders / builds aren't interrupted.
+
+   The plugin's `system-awake` script starts and stops this unit imperatively
+   as sessions toggle, so it only burns power while you actually need it.
+
+## Usage
+
+```nix
+{
+  imports = [ ./keep-awake-plus.nix ];
+
+  programs.keep-awake-plus = {
+    enable = true;
+    thermalGuard = {
+      enable = true;
+      # Defaults shown — tune per machine.
+      bagThresholdCelsius = 85;
+      bagSustainTicks = 6;            # 6 × 10 s polls = 60 s
+      criticalThresholdCelsius = 98;
+      criticalSustainTicks = 2;       # 2 × 10 s polls = 20 s
+    };
+  };
+}
+```
+
+The watchdog logs to `/tmp/system-awake-thermal-guard.log`. Tail it while
+testing to confirm thresholds make sense for your hardware before relying on
+the bag-mode trip.
+
+## Notes
+
+- This module assumes Noctalia and the plugin are already installed via
+  `programs.noctalia-shell.plugins` — it does not declare the plugin itself.
+- The watchdog has no `[Install]` section. Don't `systemctl --user enable` it
+  manually; the `system-awake` script handles its lifecycle.
+- The bag-mode trip uses `/sys/class/drm/card*/status` to detect external
+  monitors. If your dock exposes connectors with unusual names you may need to
+  tweak `has_external_monitors` in the script.

--- a/keep-awake-plus/nix/keep-awake-plus.nix
+++ b/keep-awake-plus/nix/keep-awake-plus.nix
@@ -1,0 +1,202 @@
+# Example Home Manager module for Keep Awake+ on NixOS.
+#
+# The plugin's shipped `scripts/system-awake` is portable and self-contained
+# (it uses `command -v` fallbacks), so this module only handles two things:
+#
+#   programs.keep-awake-plus.enable           -> puts runtime tools on PATH
+#   programs.keep-awake-plus.thermalGuard.*   -> optional thermal watchdog
+#                                                that force-suspends if the
+#                                                laptop overheats while a
+#                                                keep-awake session is active
+#
+# Usage:
+#
+#   imports = [ ./keep-awake-plus.nix ];
+#
+#   programs.keep-awake-plus = {
+#     enable = true;
+#     thermalGuard.enable = true;
+#   };
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.programs.keep-awake-plus;
+
+  thermal-guard = pkgs.writeShellScriptBin "system-awake-thermal-guard" ''
+    #!/usr/bin/env bash
+    set -uo pipefail
+
+    TAG="noctalia-keep-awake"
+    LOG="/tmp/system-awake-thermal-guard.log"
+    POLL_INTERVAL=10
+    BAG_THRESHOLD=${toString (cfg.thermalGuard.bagThresholdCelsius * 1000)}
+    BAG_SUSTAIN_TICKS=${toString cfg.thermalGuard.bagSustainTicks}
+    CRITICAL_THRESHOLD=${toString (cfg.thermalGuard.criticalThresholdCelsius * 1000)}
+    CRITICAL_SUSTAIN_TICKS=${toString cfg.thermalGuard.criticalSustainTicks}
+
+    log() {
+      echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a "$LOG" >&2
+    }
+
+    max_temp_mC() {
+      local max=0 t
+      for f in /sys/class/thermal/thermal_zone*/temp; do
+        [[ -r "$f" ]] || continue
+        t=$(cat "$f" 2>/dev/null || echo 0)
+        (( t > max )) && max=$t
+      done
+      echo "$max"
+    }
+
+    is_lid_closed() {
+      ${pkgs.glib}/bin/gdbus call --system \
+        --dest org.freedesktop.UPower \
+        --object-path /org/freedesktop/UPower \
+        --method org.freedesktop.DBus.Properties.Get \
+        org.freedesktop.UPower LidIsClosed 2>/dev/null | grep -q 'true'
+    }
+
+    has_external_monitors() {
+      local status connector name
+      for status in /sys/class/drm/card*/status; do
+        [[ -f "$status" ]] || continue
+        connector=$(basename "$(dirname "$status")")
+        name=''${connector#card?-}
+        if [[ "$(cat "$status")" == "connected" && \
+              "$name" != "eDP-1" && \
+              "$name" != "Writeback-1" ]]; then
+          return 0
+        fi
+      done
+      return 1
+    }
+
+    emergency_suspend() {
+      local reason="$1" temp_c="$2"
+      log "EMERGENCY: $reason (max=''${temp_c}°C) — forcing suspend"
+      ${pkgs.libnotify}/bin/notify-send -u critical -i dialog-warning \
+        "Thermal Protection" \
+        "System too hot (''${temp_c}°C) — suspending to protect hardware" \
+        -t 5000 || true
+
+      # Drop the plugin's sleep inhibitors so `systemctl suspend` is not blocked.
+      pkill -f "systemd-inhibit.*$TAG" 2>/dev/null || true
+      sleep 0.3
+
+      ${pkgs.systemd}/bin/loginctl lock-session || true
+      sleep 0.5
+      ${pkgs.systemd}/bin/systemctl suspend
+    }
+
+    log "Thermal guard started (poll=''${POLL_INTERVAL}s, bag=''${BAG_THRESHOLD}mC/$((BAG_SUSTAIN_TICKS * POLL_INTERVAL))s, critical=''${CRITICAL_THRESHOLD}mC/$((CRITICAL_SUSTAIN_TICKS * POLL_INTERVAL))s)"
+
+    bag_sustained=0
+    crit_sustained=0
+    while true; do
+      temp=$(max_temp_mC)
+      temp_c=$(( temp / 1000 ))
+
+      if (( temp >= CRITICAL_THRESHOLD )); then
+        crit_sustained=$(( crit_sustained + 1 ))
+        log "Critical temp: ''${temp_c}°C (tick $crit_sustained/$CRITICAL_SUSTAIN_TICKS)"
+        if (( crit_sustained >= CRITICAL_SUSTAIN_TICKS )); then
+          emergency_suspend "sustained critical temperature" "$temp_c"
+          exit 0
+        fi
+      else
+        (( crit_sustained > 0 )) && log "Critical recovered (''${temp_c}°C) — resetting counter"
+        crit_sustained=0
+      fi
+
+      if (( temp >= BAG_THRESHOLD )) && is_lid_closed && ! has_external_monitors; then
+        bag_sustained=$(( bag_sustained + 1 ))
+        log "Hot + lid-closed + undocked: ''${temp_c}°C (tick $bag_sustained/$BAG_SUSTAIN_TICKS)"
+        if (( bag_sustained >= BAG_SUSTAIN_TICKS )); then
+          emergency_suspend "sustained high temp while undocked+lid-closed" "$temp_c"
+          exit 0
+        fi
+      else
+        (( bag_sustained > 0 )) && log "Recovered (''${temp_c}°C) — resetting bag counter"
+        bag_sustained=0
+      fi
+
+      sleep "$POLL_INTERVAL"
+    done
+  '';
+in {
+  options.programs.keep-awake-plus = {
+    enable = lib.mkEnableOption "Keep Awake+ runtime dependencies on PATH";
+
+    thermalGuard = {
+      enable = lib.mkEnableOption ''
+        the system-awake-thermal-guard systemd user service.
+
+        The plugin's `system-awake` script starts/stops this unit
+        imperatively as keep-awake sessions toggle on and off
+      '';
+
+      bagThresholdCelsius = lib.mkOption {
+        type = lib.types.ints.positive;
+        default = 85;
+        description = ''
+          Temperature (°C) that triggers suspend when sustained for
+          bagSustainTicks polls AND the lid is closed AND no external monitor
+          is connected (i.e. the laptop is probably in a bag).
+        '';
+      };
+
+      bagSustainTicks = lib.mkOption {
+        type = lib.types.ints.positive;
+        default = 6;
+        description = "How many 10-second polls the bag-temp condition must hold before triggering suspend.";
+      };
+
+      criticalThresholdCelsius = lib.mkOption {
+        type = lib.types.ints.positive;
+        default = 98;
+        description = ''
+          Temperature (°C) that triggers unconditional suspend when sustained
+          for criticalSustainTicks polls. Fires regardless of lid/monitor state.
+        '';
+      };
+
+      criticalSustainTicks = lib.mkOption {
+        type = lib.types.ints.positive;
+        default = 2;
+        description = "How many 10-second polls the critical-temp condition must hold before triggering suspend. Kept low to tolerate only brief spikes.";
+      };
+    };
+  };
+
+  config = lib.mkMerge [
+    (lib.mkIf cfg.enable {
+      # The plugin's script auto-detects these via `command -v`; on NixOS the
+      # core ones (bash, coreutils, systemd-inhibit, pgrep, setsid) are
+      # already in the user session, so we only add the genuinely optional ones.
+      home.packages = with pkgs; [
+        jq # required
+        glib # optional: gdbus for UPower lid checks (falls back to /proc/acpi)
+        libnotify # optional: notify-send for toasts
+      ];
+    })
+
+    (lib.mkIf cfg.thermalGuard.enable {
+      home.packages = [thermal-guard];
+
+      systemd.user.services.system-awake-thermal-guard = {
+        Unit.Description = "Thermal watchdog for Keep Awake+ (force suspend if overheating)";
+        Service = {
+          Type = "simple";
+          ExecStart = "${thermal-guard}/bin/system-awake-thermal-guard";
+          Restart = "on-failure";
+          RestartSec = "5s";
+        };
+        # Intentionally no [Install] — started/stopped imperatively by the
+        # plugin's system-awake script as sessions begin/end.
+      };
+    })
+  ];
+}


### PR DESCRIPTION
## Summary
- Replaces a dead link to my private nix-config in `keep-awake-plus/README.md` with a self-contained Home Manager module under `keep-awake-plus/nix/`, so anyone landing on the README has a working reference.
- Adds an optional `system-awake-thermal-guard` systemd user service that force-suspends the machine if it overheats while a Keep Awake+ session is active (useful for "in-bag" scenarios where the lid is closed and airflow is restricted).
- No changes to plugin runtime code — docs/examples only.

## Test plan
- [x] Plugin verified end-to-end overnight: 8h partial session blocked hourly suspend attempts (22:28, 23:25, 00:27) and self-suspended at the 8h mark (06:28) via the lid-closed branch in `cmd_session`.
- [ ] Reviewer: confirm `keep-awake-plus/README.md` link to `nix/` resolves on github.com.
- [ ] Reviewer: skim `keep-awake-plus/nix/keep-awake-plus.nix` — it's an example, not imported by anything in this repo.