### PR TITLE
model-usage: add MiniMax provider and show Codex weekly limit

### DIFF
--- a/model-usage/Main.qml
+++ b/model-usage/Main.qml
@@ -33,13 +33,19 @@ Item {
         providerSettings: root.pluginSettings?.providers?.copilot ?? ({})
     }
 
+    MiniMax {
+        id: minimaxProvider
+        enabled: root.providerEnabled("minimax")
+        providerSettings: root.pluginSettings?.providers?.minimax ?? ({})
+    }
+
     Zen {
         id: zenProvider
         enabled: root.providerEnabled("zen")
         providerSettings: root.pluginSettings?.providers?.zen ?? ({})
     }
 
-    property var providers: [claudeProvider, codexProvider, copilotProvider, openRouterProvider, zenProvider]
+    property var providers: [claudeProvider, codexProvider, copilotProvider, openRouterProvider, minimaxProvider, zenProvider]
 
     property var enabledProviders: {
         const result = [];
@@ -51,6 +57,8 @@ Item {
             result.push(copilotProvider);
         if (openRouterProvider.enabled)
             result.push(openRouterProvider);
+        if (minimaxProvider.enabled)
+            result.push(minimaxProvider);
         if (zenProvider.enabled)
             result.push(zenProvider);
         return result;

--- a/model-usage/README.md
+++ b/model-usage/README.md
@@ -12,15 +12,16 @@ This plugin adds a compact usage capsule to the Noctalia bar and a detail panel 
 Current providers:
 
 - `Claude` reads local Claude auth/session files, refreshes OAuth tokens when needed.
-- `Codex` reads local `~/.codex` history/session/auth files.
+- `Codex` reads local `~/.codex` history/session/auth files. Displays both the primary (5-hour) and secondary (weekly) rate-limit windows.
 - `OpenRouter` uses the OpenRouter key/activity APIs.
 - `Zen` uses the OpenCode Zen API for key validation and model discovery. Zen usage percent is not currently exposed by a documented endpoint, so it reports a neutral usage value.
+- `MiniMax` fetches the MiniMax coding/token plan quota endpoint. Shows the 5-hour rolling window as the primary limit and the weekly window as the secondary limit when weekly data is available. Does not track local prompt/token history.
 
 ## Usage
 
 1. Open the plugin settings.
 2. Enable the providers you want.
-3. Add API keys for API-based providers (`OpenRouter`, `Zen`) or use environment variables.
+3. Add API keys for API-based providers (`OpenRouter`, `Zen`, `MiniMax`) or use environment variables.
 4. Choose the bar metric and refresh interval.
 5. Apply settings and open the panel to verify provider status.
 
@@ -28,3 +29,8 @@ Current providers:
 
 - OpenRouter: `OPENROUTER_API_KEY` or settings field.
 - Zen: `OPENCODE_ZEN_API_KEY`, `OPENCODE_API_KEY`, `ZEN_API_KEY`, or settings field.
+- MiniMax: `MINIMAX_API_KEY`, `MINIMAX_TOKEN_PLAN_API_KEY`, `MINIMAX_CODING_PLAN_API_KEY`, or settings field. MiniMax also checks `ANTHROPIC_AUTH_TOKEN` when `ANTHROPIC_BASE_URL` contains "minimax", and `OPENAI_API_KEY` when `OPENAI_BASE_URL` or `OPENAI_API_BASE` contains "minimax".
+
+## MiniMax region
+
+MiniMax defaults to the international endpoint (`https://api.minimax.io/v1`). Set region to "China" in settings to use the China endpoint (`https://api.minimaxi.com/v1`). A custom `apiBaseUrl` in settings overrides both defaults.

--- a/model-usage/Settings.qml
+++ b/model-usage/Settings.qml
@@ -374,6 +374,81 @@ ColumnLayout {
                     }
                 }
             }
+
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: Style.marginXS
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: Style.marginM
+                    NToggle {
+                        checked: editSettings?.providers?.minimax?.enabled ?? false
+                        onToggled: value => {
+                            if (!editSettings.providers)
+                                editSettings.providers = {};
+                            if (!editSettings.providers.minimax)
+                                editSettings.providers.minimax = {};
+                            editSettings.providers.minimax.enabled = value;
+                            editSettingsChanged();
+                        }
+                    }
+                    NText {
+                        text: "MiniMax"
+                        pointSize: Style.fontSizeM
+                        color: Color.mOnSurface
+                        Layout.fillWidth: true
+                    }
+                    NText {
+                        text: "API key"
+                        pointSize: Style.fontSizeXS
+                        color: Color.mOnSurfaceVariant
+                    }
+                }
+
+                NTextInput {
+                    visible: editSettings?.providers?.minimax?.enabled ?? false
+                    Layout.fillWidth: true
+                    Layout.leftMargin: Style.marginXL
+                    placeholderText: "MINIMAX_API_KEY env var or enter key here"
+                    text: editSettings?.providers?.minimax?.apiKey ?? ""
+
+                    onTextChanged: {
+                        if (!editSettings.providers)
+                            editSettings.providers = {};
+                        if (!editSettings.providers.minimax)
+                            editSettings.providers.minimax = {};
+                        editSettings.providers.minimax.apiKey = text;
+                    }
+                }
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: Style.marginM
+                    visible: editSettings?.providers?.minimax?.enabled ?? false
+                    Layout.leftMargin: Style.marginXL
+
+                    NText {
+                        text: "Region"
+                        pointSize: Style.fontSizeM
+                        color: Color.mOnSurface
+                    }
+                    NComboBox {
+                        model: [
+                            { key: "international", name: "International" },
+                            { key: "china",          name: "China" }
+                        ]
+                        currentKey: editSettings?.providers?.minimax?.region ?? "international"
+                        onSelected: key => {
+                            if (!editSettings.providers)
+                                editSettings.providers = {};
+                            if (!editSettings.providers.minimax)
+                                editSettings.providers.minimax = {};
+                            editSettings.providers.minimax.region = key;
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/model-usage/manifest.json
+++ b/model-usage/manifest.json
@@ -1,11 +1,11 @@
 {
   "id": "model-usage",
   "name": "Model Usage",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "minNoctaliaVersion": "3.6.0",
   "author": "cmptr",
   "license": "MIT",
-  "description": "Shows AI coding assistant usage stats in the bar with detail panel (Claude Code, Codex, Copilot, OpenRouter, Zen)",
+  "description": "Shows AI coding assistant usage stats in the bar with detail panel (Claude Code, Codex, Copilot, OpenRouter, Zen, MiniMax)",
   "repository": "https://github.com/noctalia-dev/noctalia-plugins",
   "tags": [
     "Bar",
@@ -42,6 +42,12 @@
         "zen": {
           "enabled": false,
           "apiKey": ""
+        },
+        "minimax": {
+          "enabled": false,
+          "apiKey": "",
+          "region": "international",
+          "apiBaseUrl": ""
         }
       },
       "barDisplayMode": "active",

--- a/model-usage/providers/Codex.qml
+++ b/model-usage/providers/Codex.qml
@@ -260,17 +260,44 @@ Item {
                 return;
             }
 
-            const rl = lastTokenCount.rate_limits?.primary;
-            if (rl) {
-                root.rateLimitPercent = (rl.used_percent ?? 0) / 100;
-                if (rl.window_minutes === 10080)
+            // Normalize a rate-limit window regardless of field spelling
+            function normalizeWindow(w) {
+                if (!w || typeof w !== "object") return null;
+                const usedPct = w.used_percent ?? w.used ?? 0;
+                const durationMins = w.window_minutes ?? w.window_duration_mins ?? 0;
+                const resetAt = w.resets_at ?? w.reset_at ?? null;
+                return { usedPct, durationMins, resetAt };
+            }
+
+            const primary = normalizeWindow(lastTokenCount.rate_limits?.primary);
+            if (primary) {
+                root.rateLimitPercent = primary.usedPct / 100;
+                if (primary.durationMins >= 10080)
                     root.rateLimitLabel = "Weekly (7-day)";
                 else
-                    root.rateLimitLabel = Math.round(rl.window_minutes / 60) + "h window";
-                if (rl.resets_at) {
-                    const resetDate = new Date(rl.resets_at * 1000);
+                    root.rateLimitLabel = Math.round(primary.durationMins / 60) + "h window";
+                if (primary.resetAt) {
+                    const resetDate = new Date(primary.resetAt * 1000);
                     root.rateLimitResetAt = resetDate.toISOString();
                 }
+            }
+
+            const secondary = normalizeWindow(lastTokenCount.rate_limits?.secondary);
+            if (secondary) {
+                root.secondaryRateLimitPercent = secondary.usedPct / 100;
+                if (secondary.durationMins >= 10080)
+                    root.secondaryRateLimitLabel = "Weekly (7-day)";
+                else
+                    root.secondaryRateLimitLabel = Math.round(secondary.durationMins / 60) + "h window";
+                if (secondary.resetAt) {
+                    const resetDate = new Date(secondary.resetAt * 1000);
+                    root.secondaryRateLimitResetAt = resetDate.toISOString();
+                }
+            } else {
+                // No secondary window in this snapshot — clear stale value
+                root.secondaryRateLimitPercent = -1;
+                root.secondaryRateLimitLabel = "";
+                root.secondaryRateLimitResetAt = "";
             }
 
             const usage = lastTokenCount.info?.total_token_usage;

--- a/model-usage/providers/MiniMax.qml
+++ b/model-usage/providers/MiniMax.qml
@@ -1,0 +1,245 @@
+import QtQuick
+import Quickshell
+
+Item {
+    id: root
+    visible: false
+
+    property string providerId: "minimax"
+    property string providerName: "MiniMax"
+    property string providerIcon: "ai"
+    property bool enabled: false
+    property bool ready: false
+    property string usageStatusText: ""
+
+    property real rateLimitPercent: -1
+    property string rateLimitLabel: "5h window"
+    property string rateLimitResetAt: ""
+    property real secondaryRateLimitPercent: -1
+    property string secondaryRateLimitLabel: "Weekly"
+    property string secondaryRateLimitResetAt: ""
+
+    property int todayPrompts: 0
+    property int todaySessions: 0
+    property int todayTotalTokens: 0
+    property var todayTokensByModel: ({})
+
+    property var recentDays: []
+    property int totalPrompts: 0
+    property int totalSessions: 0
+    property var modelUsage: ({})
+
+    property string tierLabel: ""
+    property string authHelpText: "Set MINIMAX_API_KEY or enter key in settings."
+    property bool hasLocalStats: false
+
+    property var providerSettings: ({})
+
+    // ----- API key resolution -----
+
+    property string apiKey: {
+        // 1. Settings (explicit override)
+        const settingsKey = providerSettings?.apiKey ?? "";
+        if (settingsKey && settingsKey.trim() !== "")
+            return settingsKey.trim();
+
+        // 2. Direct MiniMax env vars
+        const directKey = Quickshell.env("MINIMAX_TOKEN_PLAN_API_KEY")
+                        ?? Quickshell.env("MINIMAX_CODING_PLAN_API_KEY")
+                        ?? Quickshell.env("MINIMAX_API_KEY")
+                        ?? "";
+        if (directKey)
+            return directKey;
+
+        // 3. ANTHROPIC_AUTH_TOKEN proxied through minimax base URL
+        const anthropicToken = Quickshell.env("ANTHROPIC_AUTH_TOKEN") ?? "";
+        const anthropicBase = Quickshell.env("ANTHROPIC_BASE_URL") ?? "";
+        if (anthropicToken && /minimax/i.test(anthropicBase))
+            return anthropicToken;
+
+        // 4. OPENAI_API_KEY proxied through minimax base URL
+        const openaiKey = Quickshell.env("OPENAI_API_KEY") ?? "";
+        const openaiBase = Quickshell.env("OPENAI_BASE_URL")
+                        ?? Quickshell.env("OPENAI_API_BASE")
+                        ?? "";
+        if (openaiKey && /minimax/i.test(openaiBase))
+            return openaiKey;
+
+        return "";
+    }
+
+    // ----- Endpoint resolution -----
+
+    property string apiBaseUrl: {
+        // Custom override from settings takes priority
+        const override = providerSettings?.apiBaseUrl ?? "";
+        if (override && override.trim() !== "")
+            return override.trim();
+
+        // Region-based default
+        const region = providerSettings?.region ?? "international";
+        if (region === "china")
+            return "https://api.minimaxi.com/v1";
+        // "international" or any other value
+        return "https://api.minimax.io/v1";
+    }
+
+    // ----- Refresh timer -----
+
+    Timer {
+        interval: 5 * 60 * 1000
+        running: root.enabled && root.apiKey !== ""
+        repeat: true
+        onTriggered: root.fetchQuota()
+    }
+
+    onEnabledChanged: {
+        if (enabled && apiKey !== "")
+            fetchQuota();
+    }
+
+    onApiKeyChanged: {
+        if (enabled && apiKey !== "")
+            fetchQuota();
+    }
+
+    // ----- Fetch -----
+
+    function fetchQuota() {
+        if (!root.apiKey)
+            return;
+
+        root.usageStatusText = "";
+        const url = root.apiBaseUrl + "/api/openplatform/coding_plan/remains";
+        const xhr = new XMLHttpRequest();
+        xhr.open("GET", url);
+        xhr.setRequestHeader("Authorization", "Bearer " + root.apiKey);
+        xhr.setRequestHeader("Content-Type", "application/json");
+
+        xhr.onreadystatechange = function () {
+            if (xhr.readyState !== XMLHttpRequest.DONE)
+                return;
+
+            if (xhr.status !== 200) {
+                root.usageStatusText = "HTTP " + xhr.status;
+                root.rateLimitPercent = -1;
+                root.secondaryRateLimitPercent = -1;
+                return;
+            }
+
+            try {
+                const data = JSON.parse(xhr.responseText);
+
+                // Check application-level status code
+                const appStatus = data?.base_resp?.status_code
+                               ?? data?.base_resp?.statuscode
+                               ?? data?.status_code
+                               ?? 0;
+                if (appStatus !== 0 && appStatus !== "0" && appStatus !== "success" && appStatus !== 200) {
+                    const msg = data?.base_resp?.status_msg
+                             ?? data?.base_resp?.message
+                             ?? data?.message
+                             ?? ("status " + appStatus);
+                    root.usageStatusText = msg;
+                    root.rateLimitPercent = -1;
+                    root.secondaryRateLimitPercent = -1;
+                    return;
+                }
+
+                root.parseModelRemains(data);
+                root.ready = true;
+            } catch (e) {
+                root.usageStatusText = "Parse error";
+                root.rateLimitPercent = -1;
+                root.secondaryRateLimitPercent = -1;
+                Logger.e("model-usage/minimax", "Failed to parse quota response:", e);
+            }
+        };
+
+        xhr.send();
+    }
+
+    function parseModelRemains(data) {
+        const records = data?.model_remains ?? [];
+        if (records.length === 0)
+            return;
+
+        // Prefer MiniMax-M* coding models; fall back to the row with the
+        // tightest remaining quota (lowest remaining/total ratio).
+        let codingRow = null;
+        for (const rec of records) {
+            const id = rec?.model_name ?? rec?.model ?? "";
+            if (/^MiniMax-M/i.test(id)) {
+                codingRow = rec;
+                break;
+            }
+            if (!codingRow) {
+                codingRow = rec;
+            } else {
+                // Compare remaining ratio; prefer tighter
+                const prevTotal = codingRow?.total_intervals ?? 0;
+                const prevRemaining = codingRow?.current_interval_usage_count ?? 0;
+                const prevRatio = prevTotal > 0 ? prevRemaining / prevTotal : 0;
+
+                const currTotal = rec?.total_intervals ?? 0;
+                const currRemaining = rec?.current_interval_usage_count ?? 0;
+                const currRatio = currTotal > 0 ? currRemaining / currTotal : 0;
+
+                if (currRatio < prevRatio)
+                    codingRow = rec;
+            }
+        }
+
+        if (!codingRow)
+            return;
+
+        const total5h   = codingRow?.total_intervals          ?? 0;
+        const remain5h  = codingRow?.current_interval_usage_count ?? 0;
+        const totalWk   = codingRow?.total_weekly_intervals   ?? 0;
+        const remainWk = codingRow?.current_weekly_usage_count ?? 0;
+
+        // 5-hour rolling window -> primary
+        if (total5h > 0) {
+            root.rateLimitPercent = Math.min(1, Math.max(0, (total5h - remain5h) / total5h));
+            root.rateLimitLabel = "5h window";
+            // No discrete reset time in this endpoint -- leave resetAt empty
+            root.rateLimitResetAt = "";
+        } else {
+            root.rateLimitPercent = -1;
+        }
+
+        // Weekly window -> secondary (only if weekly fields are present)
+        if (totalWk > 0) {
+            root.secondaryRateLimitPercent = Math.min(1, Math.max(0, (totalWk - remainWk) / totalWk));
+            root.secondaryRateLimitLabel = "Weekly";
+            root.secondaryRateLimitResetAt = "";
+        } else {
+            // No weekly data in this snapshot -- clear stale value
+            root.secondaryRateLimitPercent = -1;
+            root.secondaryRateLimitLabel = "";
+            root.secondaryRateLimitResetAt = "";
+        }
+    }
+
+    function refresh() {
+        if (root.apiKey !== "")
+            fetchQuota();
+    }
+
+    function formatResetTime(isoTimestamp) {
+        if (!isoTimestamp)
+            return "";
+        const reset = new Date(isoTimestamp);
+        const now = new Date();
+        const diffMs = reset.getTime() - now.getTime();
+        if (diffMs <= 0)
+            return "now";
+        const hours = Math.floor(diffMs / 3600000);
+        const mins  = Math.floor((diffMs % 3600000) / 60000);
+        if (hours > 24)
+            return Math.floor(hours / 24) + "d " + (hours % 24) + "h";
+        if (hours > 0)
+            return hours + "h " + mins + "m";
+        return mins + "m";
+    }
+}


### PR DESCRIPTION
## Summary

Extends the **Model Usage** plugin with two capabilities:

### 1. Codex — now shows weekly limit data
 already parsed  but left the secondary window untouched. Updated  to:
- Normalize both  and  windows via a  helper that handles field spellings ( / ,  / ).
- Label windows by duration:  or .
- Populate , , .
- Clear stale secondary values when the latest snapshot lacks a secondary window.

### 2. MiniMax — new provider
 fetches the MiniMax coding/token plan quota endpoint.

**API key resolution** (in priority order):
1.  (explicit override)
2.  /  / 
3.  when  contains "minimax"
4.  when / contains "minimax"

**Endpoint resolution**:
- Region setting:  → ,  → 
- Custom  override from settings takes priority.

**Behavior**:
- Validates HTTP status and ; surfaces sanitized error messages via  instead of reporting fake zero usage.
- Parses , prefers  rows, falls back to the row with the tightest remaining ratio.
- Computes used percent as  clamped to .
- Primary field populated from **5-hour rolling window** ( / ).
- Secondary field populated from **weekly window** ( / ) when weekly fields are present.
-  — MiniMax endpoint provides plan quota, not local prompt/token history.

### Files changed

| File | Change |
|------|--------|
|  | Parse primary + secondary rate-limit windows |
|  | **New** — MiniMax provider |
|  | Register MiniMax component |
|  | Add toggle, API key input, Region combo |
|  |  defaults, description, version 0.2.1 → 0.2.2 |
|  | Document Codex weekly display and MiniMax usage |