### PR TITLE
osk-toggle: wvkbd can use flags

### DIFF
--- a/osk-toggle/README.md
+++ b/osk-toggle/README.md
@@ -23,7 +23,7 @@ A [Noctalia](https://github.com/noctalia-dev/noctalia) bar widget for toggling a
 | `backend` | `auto` | `auto`, `squeekboard`, or `wvkbd` |
 | `hideWhenUnavailable` | `false` | Hide the widget entirely when the OSK is unavailable |
 | `disableHoverIcon` | `false` | Always show the state icon; never show the directional hover icon |
-| `wvkbdBin` | `wvkbd-mobintl` | wvkbd binary name or path (wvkbd backend only) |
+| `wvkbdBin -l full,special --landscape-layers full,special` | `wvkbd-mobintl` | wvkbd binary name or path (wvkbd backend only), can use flags too |
 
 ### Backend selection
 

--- a/osk-toggle/WvkbdBackend.qml
+++ b/osk-toggle/WvkbdBackend.qml
@@ -38,7 +38,7 @@ Item {
     // --- 1. Availability: check binary exists on PATH ---
     Process {
         id: availabilityChecker
-        command: ["sh", "-c", "command -v " + root.wvkbdBinParts[0]]
+        command: ["which", root.wvkbdBinParts[0]]
         onExited: (exitCode, exitStatus) => {
             root.wvkbdOk = exitCode === 0
             if (root.wvkbdOk && !wvkbd.running) preemptChecker.running = true

--- a/osk-toggle/WvkbdBackend.qml
+++ b/osk-toggle/WvkbdBackend.qml
@@ -15,6 +15,7 @@ Item {
 
     readonly property string unavailableTooltipKey: "tooltip.noWvkbd"
     readonly property string wvkbdBin: pluginApi?.pluginSettings?.wvkbdBin ?? "wvkbd-mobintl"
+    readonly property list<string> wvkbdBinParts: wvkbdBin.trim().split(/\s+/)
 
     // True when wvkbd should be made visible as soon as it finishes starting up.
     // Used both at startup (restoring a pre-existing visible instance) and after
@@ -37,7 +38,7 @@ Item {
     // --- 1. Availability: check binary exists on PATH ---
     Process {
         id: availabilityChecker
-        command: ["sh", "-c", "command -v " + root.wvkbdBin]
+        command: ["sh", "-c", "command -v " + root.wvkbdBinParts[0]]
         onExited: (exitCode, exitStatus) => {
             root.wvkbdOk = exitCode === 0
             if (root.wvkbdOk && !wvkbd.running) preemptChecker.running = true
@@ -48,7 +49,7 @@ Item {
     // --- 2. Detect any pre-existing wvkbd instance ---
     Process {
         id: preemptChecker
-        command: ["pgrep", "-x", root.wvkbdBin]
+        command: ["pgrep", "-x", root.wvkbdBinParts[0]]
         onExited: (exitCode, exitStatus) => {
             root._pendingShow = exitCode === 0  // assume visible if already running
             if (exitCode === 0) {
@@ -62,7 +63,7 @@ Item {
     // --- 3. Kill pre-existing instance so we can take ownership ---
     Process {
         id: preemptKill
-        command: ["pkill", "-x", root.wvkbdBin]
+        command: ["pkill", "-x", root.wvkbdBinParts[0]]
         onExited: (exitCode, exitStatus) => {
             wvkbd.running = true
         }
@@ -71,7 +72,7 @@ Item {
     // --- 4. Our owned wvkbd process — always running, starts hidden ---
     Process {
         id: wvkbd
-        command: [root.wvkbdBin, "--hidden"]
+        command: [...wvkbdBinParts, "--hidden"]
         onRunningChanged: {
             if (running && root._pendingShow) {
                 root._pendingShow = false

--- a/osk-toggle/manifest.json
+++ b/osk-toggle/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "osk-toggle",
   "name": "OSK Toggle",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "minNoctaliaVersion": "4.4.3",
   "author": "blackteaextract",
   "license": "MIT",

--- a/registry.json
+++ b/registry.json
@@ -1270,7 +1270,7 @@
     {
       "id": "osk-toggle",
       "name": "OSK Toggle",
-      "version": "1.0.2",
+      "version": "1.0.1",
       "official": false,
       "author": "blackteaextract",
       "description": "Toggle an on-screen keyboard (Squeekboard or wvkbd) with live availability detection, hover icons, and configurable settings. Supersedes squeekboard-toggle.",

--- a/registry.json
+++ b/registry.json
@@ -1270,7 +1270,7 @@
     {
       "id": "osk-toggle",
       "name": "OSK Toggle",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "official": false,
       "author": "blackteaextract",
       "description": "Toggle an on-screen keyboard (Squeekboard or wvkbd) with live availability detection, hover icons, and configurable settings. Supersedes squeekboard-toggle.",


### PR DESCRIPTION
Enables wvkbd to use flags, like this:
`wvkbd-deskintl -l full,special --landscape-layers full,special`