### PR TITLE
screen-toolkit: fix NixOS scripts and rename Annotate to Markup

### DIFF
--- a/screen-toolkit/i18n/en.json
+++ b/screen-toolkit/i18n/en.json
@@ -50,7 +50,7 @@
   },
   "tools": {
     "colorpicker": "Color",
-    "annotate": "Annotate",
+    "annotate": "Markup",
     "ocr": "OCR",
     "pin": "Pin",
     "palette": "Palette",

--- a/screen-toolkit/manifest.json
+++ b/screen-toolkit/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "screen-toolkit",
   "name": "Screen Toolkit",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "minNoctaliaVersion": "4.5.0",
   "author": "ycf-anon",
   "license": "MIT",

--- a/screen-toolkit/scripts/annotate.sh
+++ b/screen-toolkit/scripts/annotate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # annotate.sh
 # Usage:
 #   annotate.sh save-overlay-auto <base> <overlay> <filename> <ss_dir> <pic_dir>

--- a/screen-toolkit/scripts/capture.sh
+++ b/screen-toolkit/scripts/capture.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # capture.sh <action> [args...]
 #
 # Actions:

--- a/screen-toolkit/scripts/color-picker.sh
+++ b/screen-toolkit/scripts/color-picker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # color-picker.sh <output-png>
 # Picks a color from screen, outputs "R G B" to stdout.
 # Uses hyprpicker (preferred) or falls back to slurp+grim.

--- a/screen-toolkit/scripts/lens-upload.sh
+++ b/screen-toolkit/scripts/lens-upload.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 GX="$1"; GY="$2"; GW="$3"; GH="$4"
 FILE="/tmp/screen-toolkit-lens.png"

--- a/screen-toolkit/scripts/measure.sh
+++ b/screen-toolkit/scripts/measure.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # measure.sh — capture a measurement overlay
 # Args: sx sy rx ry rw rh lx1 ly1 lx2 ly2 lw lh color scale dest_dir full_path
 set -euo pipefail

--- a/screen-toolkit/scripts/mirror-record.sh
+++ b/screen-toolkit/scripts/mirror-record.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # mirror-record.sh — process and save a mirror recording
 # Args: $1=src $2=destDir $3=destFile $4=filters (optional, comma-separated ffmpeg -vf string)
 #       $5=audio 0|1 (optional, default 0)

--- a/screen-toolkit/scripts/mirror-screenshot.sh
+++ b/screen-toolkit/scripts/mirror-screenshot.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # mirror-screenshot.sh — process and save a mirror screenshot
 # Args: $1=src $2=destDir $3=destFile $4=filters (optional, comma-separated ffmpeg -vf string)
 # Exit codes:

--- a/screen-toolkit/scripts/ocr.sh
+++ b/screen-toolkit/scripts/ocr.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Args: $1=gx $2=gy $3=gw $4=gh $5=lang $6=upscale_flag $7=psm
 
 GX="$1"; GY="$2"; GW="$3"; GH="$4"

--- a/screen-toolkit/scripts/pick-file.sh
+++ b/screen-toolkit/scripts/pick-file.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # XDG-portal-aware file picker with GUI fallbacks.
 # Portal logic lives in pick-file-portal.py (same directory).
 

--- a/screen-toolkit/scripts/record.sh
+++ b/screen-toolkit/scripts/record.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # record.sh <action> [args...]
 #
 # Actions:

--- a/screen-toolkit/scripts/share-upload.sh
+++ b/screen-toolkit/scripts/share-upload.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # share-upload.sh <file> [api_key] [expiry]
 # api_key: X02 API key — if empty, falls back to uguu.se (anonymous, 3h, 128MB max)
 # expiry:  1h | 1d | 7d | 30d | permanent (X02 only, default: 7d)


### PR DESCRIPTION
This addresses NixOS-specific issues causing screen-toolkit scripts to hang, and updates the tool name from "Annotate" to "Markup".