### PR TITLE
linux-wallpaperengine-controller: v1.3.1

### DIFF
--- a/linux-wallpaperengine-controller/Main.qml
+++ b/linux-wallpaperengine-controller/Main.qml
@@ -2,13 +2,10 @@ import QtQuick
 import Quickshell
 import Quickshell.Io
 
-import "helpers/shared/ColorCacheHelpers.js" as ColorCacheHelpers
 import "helpers/runtime/EngineHelpers.js" as EngineHelpers
-import "helpers/runtime/WallpaperColorHelpers.js" as WallpaperColorHelpers
 
 import qs.Commons
 import qs.Services.UI
-import qs.Services.Theming
 
 Item {
   id: root
@@ -22,7 +19,6 @@ Item {
   property bool wallpaperScanShowToast: false
   property bool stopRequested: false
   property bool recoveryInProgress: false
-  property bool applyingWallpaperColors: false
   property string lastError: ""
   property string lastErrorDetails: ""
   property string lastRuntimeErrorKey: ""
@@ -32,35 +28,54 @@ Item {
   property bool wallpapersFolderAccessible: true
   property var cachedWallpaperItems: []
   property double lastWallpaperScanAt: 0
-  property var pendingWallpaperColorRequest: null
-  property string pendingCachedWallpaperColorPath: ""
-  property string pendingCachedWallpaperColorScreenName: ""
-  property bool pendingCachedWallpaperColorNotify: false
-  property var pendingWallpaperColorReuseRequest: null
-  property string wallpaperColorScreenName: ""
-  property string wallpaperColorScaling: "fill"
-  property string wallpaperColorRequestPath: ""
-  property string wallpaperColorScreenshotPath: ""
-  property bool wallpaperColorNotify: false
-  readonly property string activeColorMonitor: String(Settings.data.colorSchemes.monitorForColors || Quickshell.screens[0]?.name || "")
-  readonly property bool wallpaperColorsEnabled: !!Settings.data.colorSchemes.useWallpaperColors
-  readonly property bool wallpaperColorDarkMode: !!Settings.data.colorSchemes.darkMode
-  readonly property string wallpaperColorGenerationMethod: String(Settings.data.colorSchemes.generationMethod || "")
 
   property var pendingCommand: []
 
   readonly property var cfg: pluginApi?.pluginSettings || ({})
   readonly property var defaults: pluginApi?.manifest?.metadata?.defaultSettings || ({})
 
+  // Named timer intervals.
+  readonly property int stableRunDelay: 2500
+  readonly property int screenTopologyDebounceDelay: 800
+
+  // Convenience aliases for external consumers.
+  readonly property bool applyingWallpaperColors: colorManager.applyingWallpaperColors
+
+  // Pass-through for Panel.qml to reach the color manager.
+  function scheduleWallpaperColorsFromPath(path, options) {
+    colorManager.scheduleWallpaperColorsFromPath(path, options);
+  }
+
+  function applyWallpaperColorsFromPath(path, options) {
+    colorManager.applyWallpaperColorsFromPath(path, options);
+  }
+
+  // Wallpaper color extraction subsystem.
+  WallpaperColorManager {
+    id: colorManager
+    pluginApi: root.pluginApi
+    cfg: root.cfg
+    defaults: root.defaults
+    engineAvailable: root.engineAvailable
+    defaultFps: root.defaultFps
+    defaultClamp: root.defaultClamp
+    defaultScaling: root.defaultScaling
+    normalizedPathFn: root.normalizedPath
+    wallpaperIdFromPathFn: root.wallpaperIdFromPath
+    getWallpaperPropertiesFn: root.getWallpaperProperties
+    getScreenConfigFn: root.getScreenConfig
+  }
+
   // Initialization.
   Component.onCompleted: {
     Logger.i("LWEController", "Main initialized");
+    ensureSettingsRoot();
 
     // Clean up leftover processes from previous sessions.
     startupCleanupProcess.running = true;
 
     lastScreenSetSignature = currentScreenSetSignature();
-    startupWallpaperColorResyncTimer.restart();
+    colorManager.scheduleStartupResync();
   }
 
   // Settings persistence and recovery snapshots.
@@ -116,7 +131,6 @@ Item {
       return;
     }
 
-    ensureSettingsRoot();
     const nextValue = !!value;
     if (pluginApi.pluginSettings.runtimeRecoveryPending === nextValue) {
       return;
@@ -132,8 +146,6 @@ Item {
     if (!pluginApi) {
       return false;
     }
-
-    ensureSettingsRoot();
 
     const currentScreens = cloneValue(pluginApi.pluginSettings.screens || ({}));
     if (!hasAnyScreenPathFrom(currentScreens)) {
@@ -153,8 +165,6 @@ Item {
     if (!pluginApi) {
       return false;
     }
-
-    ensureSettingsRoot();
 
     const snapshot = pluginApi.pluginSettings.lastKnownGoodScreens || ({});
     if (!hasAnyScreenPathFrom(snapshot)) {
@@ -194,7 +204,6 @@ Item {
       return false;
     }
 
-    ensureSettingsRoot();
     const pending = !!pluginApi.pluginSettings.runtimeRecoveryPending;
     if (!pending) {
       return false;
@@ -332,7 +341,6 @@ Item {
       return;
     }
 
-    ensureSettingsRoot();
     const wallpaperId = wallpaperIdFromPath(path);
     if (wallpaperId.length === 0) {
       return;
@@ -374,189 +382,6 @@ Item {
     for (const screen of Quickshell.screens) {
       clearLegacyScreenRuntimeOptions(screen.name);
     }
-  }
-
-  // Wallpaper color synchronization helpers.
-  function currentWallpaperColorMode() {
-    return Settings.data.colorSchemes.darkMode ? "dark" : "light";
-  }
-
-  function applyWallpaperColorsFromScreenshot(screenshotPath) {
-    if (String(screenshotPath || "").trim().length === 0) {
-      return;
-    }
-
-    TemplateProcessor.processWallpaperColors(screenshotPath, currentWallpaperColorMode());
-  }
-
-  function screenshotPathForWallpaper(path, screenName = "") {
-    const pluginId = pluginApi?.manifest?.id || pluginApi?.pluginId || "linux-wallpaperengine-controller";
-    return ColorCacheHelpers.screenshotPathForWallpaper(Settings.cacheDir, pluginId, wallpaperIdFromPath(path), screenName);
-  }
-
-  function wallpaperColorScreenshotEntry(screenName) {
-    ensureSettingsRoot();
-    return ColorCacheHelpers.cachedScreenshotEntry(pluginApi?.pluginSettings?.wallpaperColorScreenshots, screenName);
-  }
-
-  function canReuseWallpaperColorScreenshot(screenName, wallpaperPath, scaling) {
-    return ColorCacheHelpers.canReuseScreenshot(
-      pluginApi?.pluginSettings?.wallpaperColorScreenshots,
-      screenName,
-      wallpaperPath,
-      scaling,
-      normalizedPath,
-      defaultScaling
-    );
-  }
-
-  function startWallpaperColorCapture(wallpaperPath, targetScreenName, targetScaling, notify = false) {
-    const screenshotPath = screenshotPathForWallpaper(wallpaperPath, targetScreenName);
-    const pluginDir = pluginApi?.pluginDir || "";
-    const scriptPath = pluginDir + "/scripts/capture-wallpaper-colors.sh";
-    const wallpaperProperties = getWallpaperProperties(wallpaperPath);
-    const resolvedScaling = targetScaling.length > 0 ? targetScaling : "fill";
-    const command = WallpaperColorHelpers.buildCaptureCommand(
-      scriptPath,
-      screenshotPath,
-      "",
-      defaultFps,
-      defaultClamp,
-      targetScreenName,
-      wallpaperPath,
-      resolvedScaling,
-      wallpaperProperties
-    );
-
-    applyingWallpaperColors = true;
-    wallpaperColorRequestPath = wallpaperPath;
-    wallpaperColorScreenshotPath = screenshotPath;
-    wallpaperColorScreenName = targetScreenName;
-    wallpaperColorScaling = resolvedScaling;
-    wallpaperColorNotify = !!notify;
-    wallpaperColorProcess.command = command;
-    wallpaperColorProcess.running = true;
-
-    Logger.i("LWEController", "Generating screenshot for wallpaper color extraction", "path=", wallpaperPath, "screen=", targetScreenName, "scaling=", wallpaperColorScaling, "output=", screenshotPath);
-  }
-
-  function saveWallpaperColorScreenshot(screenName, screenshotPath, wallpaperPath, scaling) {
-    if (!pluginApi || screenName.length === 0 || screenshotPath.length === 0) {
-      return;
-    }
-
-    ensureSettingsRoot();
-    pluginApi.pluginSettings.wallpaperColorScreenshots[screenName] = WallpaperColorHelpers.buildScreenshotCacheEntry(
-      screenshotPath,
-      wallpaperPath,
-      scaling
-    );
-    pluginApi.saveSettings();
-
-    const pluginDir = pluginApi?.pluginDir || "";
-    const scriptPath = pluginDir + "/scripts/update-noctalia-wallpapers-cache.sh";
-    Quickshell.execDetached(["bash", scriptPath, screenName, screenshotPath]);
-  }
-
-  function scheduleCachedWallpaperColorsForMonitor(reason = "") {
-    pendingCachedWallpaperColorPath = "";
-    pendingCachedWallpaperColorScreenName = "";
-
-    if (!wallpaperColorsEnabled) {
-      return;
-    }
-
-    const screenName = activeColorMonitor;
-    if (screenName.length === 0) {
-      return;
-    }
-
-    const screenCfg = getScreenConfig(screenName);
-    const request = WallpaperColorHelpers.buildActiveMonitorSyncRequest(screenName, screenCfg, defaultScaling, normalizedPath);
-    if (!request) {
-      Logger.d("LWEController", "Skip wallpaper color sync: no configured wallpaper for active monitor", "screen=", screenName, "reason=", reason);
-      return;
-    }
-
-    Logger.d("LWEController", "Scheduling wallpaper color sync for current active monitor wallpaper", "screen=", request.screenName, "path=", request.path, "scaling=", request.scaling, "reason=", reason);
-    scheduleWallpaperColorsFromPath(request.path, request);
-  }
-
-  function applyWallpaperColorsFromPath(path, options = null) {
-    const request = WallpaperColorHelpers.normalizeWallpaperColorRequest(
-      path,
-      options,
-      defaultScaling,
-      Quickshell.screens[0]?.name || "",
-      normalizedPath
-    );
-    const wallpaperPath = request.path;
-    const targetScreenName = request.screenName;
-    const targetScaling = request.scaling;
-    const notify = request.notify;
-    if (!engineAvailable) {
-      if (notify) {
-        ToastService.showWarning(pluginApi?.tr("panel.title"), pluginApi?.tr("toast.wallpaperColorsEngineUnavailable"), "alert-circle");
-      }
-      return;
-    }
-
-    if (wallpaperPath.length === 0) {
-      if (notify) {
-        ToastService.showWarning(pluginApi?.tr("panel.title"), pluginApi?.tr("toast.wallpaperColorsNoSelection"), "alert-circle");
-      }
-      return;
-    }
-
-    if (targetScreenName.length === 0) {
-      if (notify) {
-        ToastService.showError(pluginApi?.tr("panel.title"), pluginApi?.tr("toast.wallpaperColorsFailed"), "alert-circle");
-      }
-      return;
-    }
-
-    if (applyingWallpaperColors) {
-      return;
-    }
-
-    if (canReuseWallpaperColorScreenshot(targetScreenName, wallpaperPath, targetScaling)) {
-      const entry = wallpaperColorScreenshotEntry(targetScreenName);
-      const cachedPath = normalizedPath(entry?.path || "");
-      const pluginDir = pluginApi?.pluginDir || "";
-      const scriptPath = pluginDir + "/scripts/check-file-exists.sh";
-      pendingWallpaperColorReuseRequest = WallpaperColorHelpers.buildReuseCheckRequest(
-        targetScreenName,
-        wallpaperPath,
-        targetScaling,
-        cachedPath,
-        notify
-      );
-      reusedWallpaperColorCheckProcess.command = ["bash", scriptPath, cachedPath];
-      reusedWallpaperColorCheckProcess.running = true;
-      return;
-    }
-    startWallpaperColorCapture(wallpaperPath, targetScreenName, targetScaling, notify);
-  }
-
-  function scheduleWallpaperColorsFromPath(path, options = null) {
-    const request = WallpaperColorHelpers.normalizeWallpaperColorRequest(
-      path,
-      options,
-      defaultScaling,
-      Quickshell.screens[0]?.name || "",
-      normalizedPath
-    );
-    if (request.path.length === 0) {
-      return;
-    }
-
-    pendingCachedWallpaperColorPath = "";
-    pendingCachedWallpaperColorScreenName = "";
-    pendingCachedWallpaperColorNotify = false;
-
-    pendingWallpaperColorRequest = request;
-    wallpaperColorStartTimer.restart();
-    Logger.d("LWEController", "Scheduled wallpaper color extraction", "path=", pendingWallpaperColorRequest.path, "screen=", pendingWallpaperColorRequest.screenName, "scaling=", pendingWallpaperColorRequest.scaling);
   }
 
   // Wallpaper source scanning and cache refresh.
@@ -610,8 +435,6 @@ Item {
     }
 
     Logger.i("LWEController", "Set wallpaper requested", screenName, path, JSON.stringify(options || ({})));
-
-    ensureSettingsRoot();
 
     if (pluginApi.pluginSettings.screens[screenName] === undefined) {
       pluginApi.pluginSettings.screens[screenName] = {};
@@ -673,8 +496,6 @@ Item {
 
     Logger.i("LWEController", "Clear wallpaper requested", screenName);
 
-    ensureSettingsRoot();
-
     if (pluginApi.pluginSettings.screens[screenName] === undefined) {
       pluginApi.pluginSettings.screens[screenName] = {};
     }
@@ -695,8 +516,6 @@ Item {
     }
 
     Logger.i("LWEController", "Set wallpaper for all screens", path, JSON.stringify(options || ({})));
-
-    ensureSettingsRoot();
 
     const resolvedScaling = (options?.scaling || "").trim();
     const resolvedClamp = (options?.clamp || "").trim();
@@ -1136,55 +955,6 @@ Item {
     stderr: StdioCollector {}
   }
 
-  Process {
-    id: wallpaperColorProcess
-    running: false
-
-    stdout: StdioCollector {}
-    stderr: StdioCollector {}
-
-    onExited: function (exitCode) {
-      const requestPath = root.wallpaperColorRequestPath;
-      const screenshotPath = root.wallpaperColorScreenshotPath;
-      const screenName = root.wallpaperColorScreenName;
-      const appliedScaling = root.wallpaperColorScaling;
-      const notify = root.wallpaperColorNotify;
-      const stderrText = String(stderr.text || "").trim();
-
-      root.applyingWallpaperColors = false;
-      root.wallpaperColorRequestPath = "";
-      root.wallpaperColorScreenshotPath = "";
-      root.wallpaperColorScreenName = "";
-      root.wallpaperColorScaling = "fill";
-      root.wallpaperColorNotify = false;
-
-      if (exitCode !== 0) {
-        const msg = stderrText.length > 0 ? "Wallpaper screenshot generation failed, stderr=" + stderrText : "Wallpaper screenshot generation failed";
-        Logger.w("LWEController", msg, "path=", requestPath, "screen=", screenName, "exitCode=", exitCode);
-        if (notify) {
-          ToastService.showError(pluginApi?.tr("panel.title"), pluginApi?.tr("toast.wallpaperColorsFailed"), "alert-circle");
-        }
-        return;
-      }
-
-      saveWallpaperColorScreenshot(screenName, screenshotPath, requestPath, appliedScaling);
-
-      if (wallpaperColorsEnabled && screenName === activeColorMonitor) {
-        root.applyWallpaperColorsFromScreenshot(screenshotPath);
-        Logger.i("LWEController", "Wallpaper screenshot generated and applied for active color monitor", "path=", requestPath, "screen=", screenName, "screenshot=", screenshotPath);
-        if (notify) {
-          ToastService.showNotice(pluginApi?.tr("panel.title"), pluginApi?.tr("toast.wallpaperColorsApplied"), "palette");
-        }
-        return;
-      }
-
-      Logger.i("LWEController", "Wallpaper screenshot cached for color extraction", "path=", requestPath, "screen=", screenName, "screenshot=", screenshotPath);
-      if (notify) {
-        ToastService.showNotice(pluginApi?.tr("panel.title"), pluginApi?.tr("toast.wallpaperColorsCached"), "palette");
-      }
-    }
-  }
-
   // Startup cleanup: kill any orphaned wallpaper engine processes from previous sessions.
   Process {
     id: startupCleanupProcess
@@ -1202,108 +972,6 @@ Item {
 
     stdout: StdioCollector {}
     stderr: StdioCollector {}
-  }
-
-  Process {
-    id: reusedWallpaperColorCheckProcess
-    running: false
-
-    onExited: function (exitCode) {
-      const request = root.pendingWallpaperColorReuseRequest;
-      root.pendingWallpaperColorReuseRequest = null;
-      if (!request) {
-        return;
-      }
-
-      if (exitCode === 0) {
-        Logger.i("LWEController", "Reusing cached wallpaper color screenshot", "path=", request.wallpaperPath, "screen=", request.screenName, "scaling=", request.scaling, "screenshot=", request.screenshotPath);
-
-        if (root.wallpaperColorsEnabled && request.screenName === root.activeColorMonitor) {
-          root.applyWallpaperColorsFromScreenshot(request.screenshotPath);
-          if (request.notify) {
-            ToastService.showNotice(pluginApi?.tr("panel.title"), pluginApi?.tr("toast.wallpaperColorsApplied"), "palette");
-          }
-        } else if (request.notify) {
-          ToastService.showNotice(pluginApi?.tr("panel.title"), pluginApi?.tr("toast.wallpaperColorsCached"), "palette");
-        }
-        return;
-      }
-
-      Logger.w("LWEController", "Cached wallpaper color screenshot missing; regenerating", "path=", request.wallpaperPath, "screen=", request.screenName, "scaling=", request.scaling, "screenshot=", request.screenshotPath);
-      root.startWallpaperColorCapture(request.wallpaperPath, request.screenName, request.scaling, !!request.notify);
-    }
-
-    stdout: StdioCollector {}
-    stderr: StdioCollector {}
-  }
-
-  Process {
-    id: cachedWallpaperColorSyncCheckProcess
-    running: false
-
-    onExited: function (exitCode) {
-      const screenshotPath = root.pendingCachedWallpaperColorPath;
-      const screenName = root.pendingCachedWallpaperColorScreenName;
-      const notify = root.pendingCachedWallpaperColorNotify;
-
-      if (exitCode !== 0 || screenshotPath.length === 0) {
-        Logger.w("LWEController", "Cached wallpaper color screenshot missing for active monitor", "screen=", screenName, "path=", screenshotPath, "exitCode=", exitCode);
-        root.pendingCachedWallpaperColorPath = "";
-        root.pendingCachedWallpaperColorScreenName = "";
-        root.pendingCachedWallpaperColorNotify = false;
-        return;
-      }
-
-      root.pendingCachedWallpaperColorNotify = notify;
-      cachedWallpaperColorSyncTimer.restart();
-    }
-
-    stdout: StdioCollector {}
-    stderr: StdioCollector {}
-  }
-
-  // Timers and deferred follow-up work.
-  Timer {
-    id: wallpaperColorStartTimer
-    interval: 1500
-
-    onTriggered: {
-      const request = root.pendingWallpaperColorRequest;
-      root.pendingWallpaperColorRequest = null;
-      if (!request || String(request.path || "").length === 0) {
-        return;
-      }
-      root.applyWallpaperColorsFromPath(request.path, request);
-    }
-  }
-
-  Timer {
-    id: cachedWallpaperColorSyncTimer
-    interval: 250
-    repeat: false
-
-    onTriggered: {
-      const screenshotPath = root.pendingCachedWallpaperColorPath;
-      const screenName = root.pendingCachedWallpaperColorScreenName;
-      root.pendingCachedWallpaperColorPath = "";
-      root.pendingCachedWallpaperColorScreenName = "";
-      root.pendingCachedWallpaperColorNotify = false;
-      if (screenshotPath.length === 0 || !root.wallpaperColorsEnabled) {
-        return;
-      }
-      Logger.i("LWEController", "Applying cached wallpaper colors for active monitor", "screen=", screenName || root.activeColorMonitor, "path=", screenshotPath);
-      root.applyWallpaperColorsFromScreenshot(screenshotPath);
-    }
-  }
-
-  Timer {
-    id: startupWallpaperColorResyncTimer
-    interval: 2200
-    repeat: false
-
-    onTriggered: {
-      root.scheduleCachedWallpaperColorsForMonitor("startup-final-resync");
-    }
   }
 
   // IPC entrypoints.
@@ -1359,15 +1027,20 @@ Item {
     }
   }
 
-  onActiveColorMonitorChanged: scheduleCachedWallpaperColorsForMonitor("monitor-changed")
-  onWallpaperColorsEnabledChanged: scheduleCachedWallpaperColorsForMonitor("wallpaper-colors-toggled")
-  onWallpaperColorDarkModeChanged: scheduleCachedWallpaperColorsForMonitor("dark-mode-changed")
-  onWallpaperColorGenerationMethodChanged: scheduleCachedWallpaperColorsForMonitor("generation-method-changed")
+  Connections {
+    target: root
+
+    function onPluginApiChanged() {
+      if (root.pluginApi) {
+        root.ensureSettingsRoot();
+      }
+    }
+  }
 
   // Stability and topology debounce timers.
   Timer {
     id: stableRunTimer
-    interval: 2500
+    interval: root.stableRunDelay
     repeat: false
 
     onTriggered: {
@@ -1383,7 +1056,7 @@ Item {
 
   Timer {
     id: screenTopologyRestartDebounce
-    interval: 800
+    interval: root.screenTopologyDebounceDelay
     repeat: false
 
     onTriggered: {
@@ -1412,25 +1085,15 @@ Item {
 
     if (wallpaperScanProcess.running)
       wallpaperScanProcess.running = false;
-    if (wallpaperColorProcess.running)
-      wallpaperColorProcess.running = false;
-    if (reusedWallpaperColorCheckProcess.running)
-      reusedWallpaperColorCheckProcess.running = false;
-    if (cachedWallpaperColorSyncCheckProcess.running)
-      cachedWallpaperColorSyncCheckProcess.running = false;
 
     if (!forceStopProcess.running)
       forceStopProcess.running = true;
 
     stableRunTimer.stop();
     screenTopologyRestartDebounce.stop();
-    wallpaperColorStartTimer.stop();
-    cachedWallpaperColorSyncTimer.stop();
-    startupWallpaperColorResyncTimer.stop();
 
     isApplying = false;
     scanningWallpapers = false;
-    applyingWallpaperColors = false;
 
     Logger.i("LWEController", "Cleanup complete");
   }

--- a/linux-wallpaperengine-controller/Panel.qml
+++ b/linux-wallpaperengine-controller/Panel.qml
@@ -126,7 +126,7 @@ Item {
   property var wallpaperByPath: ({})
 
   function rebuildWallpaperByPath() {
-    const map = {};
+    const map = Object.create(null);
     for (const item of wallpaperItems) {
       map[String(item.path || "")] = item;
     }
@@ -238,6 +238,7 @@ Item {
         }
         wallpaperPropertyValues = nextValues;
         wallpaperPropertyError = "";
+        setWallpaperPropertyLoadFailed(wallpaperPath, false);
       }
       loadingWallpaperProperties = false;
       return;

--- a/linux-wallpaperengine-controller/Panel.qml
+++ b/linux-wallpaperengine-controller/Panel.qml
@@ -13,6 +13,7 @@ import "helpers/panel/BadgeHelpers.js" as BadgeHelpers
 import "helpers/panel/WallpaperFilterHelpers.js" as WallpaperFilterHelpers
 import "helpers/panel/WallpaperMetaHelpers.js" as WallpaperMetaHelpers
 import "helpers/panel/WallpaperUiHelpers.js" as WallpaperUiHelpers
+import "helpers/shared/ColorCacheHelpers.js" as ColorCacheHelpers
 import "helpers/panel/PropertyHelpers.js" as PropertyHelpers
 
 Item {
@@ -117,17 +118,27 @@ Item {
   readonly property int currentPageStartIndex: visibleWallpapers.length === 0 ? 0 : currentPage * pageSize + 1
   readonly property int currentPageEndIndex: Math.min((currentPage + 1) * pageSize, visibleWallpapers.length)
 
+  // Named timer intervals.
+  readonly property int searchDebounceDelay: 250
+  readonly property int propertyLoadDelay: 500
+
+  // O(1) lookup map rebuilt when wallpaper items change.
+  property var wallpaperByPath: ({})
+
+  function rebuildWallpaperByPath() {
+    const map = {};
+    for (const item of wallpaperItems) {
+      map[String(item.path || "")] = item;
+    }
+    wallpaperByPath = map;
+  }
+
   function getSelectedWallpaperData() {
     const target = String(pendingPath || "");
     if (target.length === 0) {
       return null;
     }
-    for (const item of wallpaperItems) {
-      if (String(item.path || "") === target) {
-        return item;
-      }
-    }
-    return null;
+    return wallpaperByPath[target] || null;
   }
 
   // Basic file and metadata helpers.
@@ -148,7 +159,7 @@ Item {
   }
 
   function formatBytes(bytesValue) {
-    return WallpaperMetaHelpers.formatBytes(bytesValue);
+    return ColorCacheHelpers.formatBytes(bytesValue);
   }
 
   function sortLabel(value) {
@@ -204,7 +215,30 @@ Item {
     wallpaperPropertyError = "";
     wallpaperPropertyRequestPath = wallpaperPath;
 
-    if (!extraPropertiesEditorEnabled || wallpaperPath.length === 0 || !(mainInstance?.engineAvailable ?? false)) {
+    if (!extraPropertiesEditorEnabled || wallpaperPath.length === 0) {
+      loadingWallpaperProperties = false;
+      return;
+    }
+
+    if (!(mainInstance?.engineAvailable ?? false)) {
+      const savedProperties = mainInstance?.getWallpaperProperties(wallpaperPath) || ({});
+      const savedKeys = Object.keys(savedProperties).filter(k => String(k || "").trim().length > 0);
+      if (savedKeys.length > 0) {
+        const fallbackDefinitions = savedKeys.map(key => ({
+          key: key,
+          type: "textinput",
+          label: key,
+          defaultValue: "",
+          choices: []
+        }));
+        wallpaperPropertyDefinitions = fallbackDefinitions;
+        const nextValues = {};
+        for (const key of savedKeys) {
+          nextValues[key] = String(savedProperties[key] ?? "");
+        }
+        wallpaperPropertyValues = nextValues;
+        wallpaperPropertyError = "";
+      }
       loadingWallpaperProperties = false;
       return;
     }
@@ -598,6 +632,7 @@ Item {
 
   // Reactive state updates.
   onWallpaperItemsChanged: {
+    rebuildWallpaperByPath();
     refreshVisibleWallpapers();
     reconcilePendingSelection();
   }
@@ -917,11 +952,32 @@ Item {
       }
 
       if (exitCode !== 0) {
-        root.wallpaperPropertyDefinitions = [];
-        root.wallpaperPropertyValues = ({});
-        root.setWallpaperPropertyLoadFailed(requestPath, true);
-        root.wallpaperPropertyError = pluginApi?.tr("panel.propertiesLoadFailed");
-        Logger.w("LWEController", "Wallpaper properties load failed", "path=", requestPath, "exitCode=", exitCode);
+        const savedProperties = mainInstance?.getWallpaperProperties(requestPath) || ({});
+        const savedKeys = Object.keys(savedProperties).filter(k => String(k || "").trim().length > 0);
+        if (savedKeys.length > 0) {
+          const fallbackDefinitions = savedKeys.map(key => ({
+            key: key,
+            type: "textinput",
+            label: key,
+            defaultValue: "",
+            choices: []
+          }));
+          root.wallpaperPropertyDefinitions = fallbackDefinitions;
+          const nextValues = {};
+          for (const key of savedKeys) {
+            nextValues[key] = String(savedProperties[key] ?? "");
+          }
+          root.wallpaperPropertyValues = nextValues;
+          root.setWallpaperPropertyLoadFailed(requestPath, false);
+          root.wallpaperPropertyError = "";
+          Logger.w("LWEController", "Wallpaper properties load failed, restored saved properties as fallback", "path=", requestPath, "exitCode=", exitCode, "count=", savedKeys.length);
+        } else {
+          root.wallpaperPropertyDefinitions = [];
+          root.wallpaperPropertyValues = ({});
+          root.setWallpaperPropertyLoadFailed(requestPath, true);
+          root.wallpaperPropertyError = pluginApi?.tr("panel.propertiesLoadFailed");
+          Logger.w("LWEController", "Wallpaper properties load failed", "path=", requestPath, "exitCode=", exitCode);
+        }
         return;
       }
 
@@ -991,7 +1047,7 @@ Item {
 
   Timer {
     id: searchDebounceTimer
-    interval: 250
+    interval: root.searchDebounceDelay
     onTriggered: {
       refreshVisibleWallpapers();
       resetPagination();
@@ -1000,7 +1056,7 @@ Item {
 
   Timer {
     id: propertiesLoadTimer
-    interval: 500
+    interval: root.propertyLoadDelay
     onTriggered: {
       loadWallpaperProperties(pendingPath);
     }

--- a/linux-wallpaperengine-controller/WallpaperColorManager.qml
+++ b/linux-wallpaperengine-controller/WallpaperColorManager.qml
@@ -34,9 +34,6 @@ Item {
 
   // Internal state.
   property var pendingWallpaperColorRequest: null
-  property string pendingCachedWallpaperColorPath: ""
-  property string pendingCachedWallpaperColorScreenName: ""
-  property bool pendingCachedWallpaperColorNotify: false
   property var pendingWallpaperColorReuseRequest: null
   property string wallpaperColorScreenName: ""
   property string wallpaperColorScaling: "fill"
@@ -134,9 +131,6 @@ Item {
   }
 
   function scheduleCachedWallpaperColorsForMonitor(reason = "") {
-    pendingCachedWallpaperColorPath = "";
-    pendingCachedWallpaperColorScreenName = "";
-
     if (!wallpaperColorsEnabled) {
       return;
     }
@@ -224,10 +218,6 @@ Item {
     if (request.path.length === 0) {
       return;
     }
-
-    pendingCachedWallpaperColorPath = "";
-    pendingCachedWallpaperColorScreenName = "";
-    pendingCachedWallpaperColorNotify = false;
 
     pendingWallpaperColorRequest = request;
     wallpaperColorStartTimer.restart();
@@ -317,31 +307,6 @@ Item {
     stderr: StdioCollector {}
   }
 
-  Process {
-    id: cachedWallpaperColorSyncCheckProcess
-    running: false
-
-    onExited: function (exitCode) {
-      const screenshotPath = root.pendingCachedWallpaperColorPath;
-      const screenName = root.pendingCachedWallpaperColorScreenName;
-      const notify = root.pendingCachedWallpaperColorNotify;
-
-      if (exitCode !== 0 || screenshotPath.length === 0) {
-        Logger.w("LWEController", "Cached wallpaper color screenshot missing for active monitor", "screen=", screenName, "path=", screenshotPath, "exitCode=", exitCode);
-        root.pendingCachedWallpaperColorPath = "";
-        root.pendingCachedWallpaperColorScreenName = "";
-        root.pendingCachedWallpaperColorNotify = false;
-        return;
-      }
-
-      root.pendingCachedWallpaperColorNotify = notify;
-      cachedWallpaperColorSyncTimer.restart();
-    }
-
-    stdout: StdioCollector {}
-    stderr: StdioCollector {}
-  }
-
   // Timers.
   Timer {
     id: wallpaperColorStartTimer
@@ -354,25 +319,6 @@ Item {
         return;
       }
       root.applyWallpaperColorsFromPath(request.path, request);
-    }
-  }
-
-  Timer {
-    id: cachedWallpaperColorSyncTimer
-    interval: root.colorSyncDelay
-    repeat: false
-
-    onTriggered: {
-      const screenshotPath = root.pendingCachedWallpaperColorPath;
-      const screenName = root.pendingCachedWallpaperColorScreenName;
-      root.pendingCachedWallpaperColorPath = "";
-      root.pendingCachedWallpaperColorScreenName = "";
-      root.pendingCachedWallpaperColorNotify = false;
-      if (screenshotPath.length === 0 || !root.wallpaperColorsEnabled) {
-        return;
-      }
-      Logger.i("LWEController", "Applying cached wallpaper colors for active monitor", "screen=", screenName || root.activeColorMonitor, "path=", screenshotPath);
-      root.applyWallpaperColorsFromScreenshot(screenshotPath);
     }
   }
 
@@ -396,9 +342,7 @@ Item {
   Component.onDestruction: {
     wallpaperColorProcess.running = false;
     reusedWallpaperColorCheckProcess.running = false;
-    cachedWallpaperColorSyncCheckProcess.running = false;
     wallpaperColorStartTimer.stop();
-    cachedWallpaperColorSyncTimer.stop();
     startupWallpaperColorResyncTimer.stop();
     applyingWallpaperColors = false;
   }

--- a/linux-wallpaperengine-controller/WallpaperColorManager.qml
+++ b/linux-wallpaperengine-controller/WallpaperColorManager.qml
@@ -1,0 +1,405 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+
+import "helpers/shared/ColorCacheHelpers.js" as ColorCacheHelpers
+import "helpers/runtime/WallpaperColorHelpers.js" as WallpaperColorHelpers
+
+import qs.Commons
+import qs.Services.UI
+import qs.Services.Theming
+
+Item {
+  id: root
+
+  // Dependencies from parent.
+  required property var pluginApi
+  required property var cfg
+  required property var defaults
+  required property bool engineAvailable
+  required property int defaultFps
+  required property string defaultClamp
+  required property string defaultScaling
+  required property var normalizedPathFn
+  required property var wallpaperIdFromPathFn
+  required property var getWallpaperPropertiesFn
+  required property var getScreenConfigFn
+
+  // Public state.
+  property bool applyingWallpaperColors: false
+  readonly property string activeColorMonitor: String(Settings.data.colorSchemes.monitorForColors || Quickshell.screens[0]?.name || "")
+  readonly property bool wallpaperColorsEnabled: !!Settings.data.colorSchemes.useWallpaperColors
+  readonly property bool wallpaperColorDarkMode: !!Settings.data.colorSchemes.darkMode
+  readonly property string wallpaperColorGenerationMethod: String(Settings.data.colorSchemes.generationMethod || "")
+
+  // Internal state.
+  property var pendingWallpaperColorRequest: null
+  property string pendingCachedWallpaperColorPath: ""
+  property string pendingCachedWallpaperColorScreenName: ""
+  property bool pendingCachedWallpaperColorNotify: false
+  property var pendingWallpaperColorReuseRequest: null
+  property string wallpaperColorScreenName: ""
+  property string wallpaperColorScaling: "fill"
+  property string wallpaperColorRequestPath: ""
+  property string wallpaperColorScreenshotPath: ""
+  property bool wallpaperColorNotify: false
+
+  // Timer intervals (named constants).
+  readonly property int colorStartDelay: 1500
+  readonly property int colorSyncDelay: 250
+  readonly property int startupResyncDelay: 2200
+
+  // Public API.
+  function scheduleStartupResync() {
+    startupWallpaperColorResyncTimer.restart();
+  }
+
+  function currentWallpaperColorMode() {
+    return Settings.data.colorSchemes.darkMode ? "dark" : "light";
+  }
+
+  function applyWallpaperColorsFromScreenshot(screenshotPath) {
+    if (String(screenshotPath || "").trim().length === 0) {
+      return;
+    }
+
+    TemplateProcessor.processWallpaperColors(screenshotPath, currentWallpaperColorMode());
+  }
+
+  function screenshotPathForWallpaper(path, screenName = "") {
+    const pluginId = pluginApi?.manifest?.id || pluginApi?.pluginId || "linux-wallpaperengine-controller";
+    return ColorCacheHelpers.screenshotPathForWallpaper(Settings.cacheDir, pluginId, wallpaperIdFromPathFn(path), screenName);
+  }
+
+  function wallpaperColorScreenshotEntry(screenName) {
+    return ColorCacheHelpers.cachedScreenshotEntry(pluginApi?.pluginSettings?.wallpaperColorScreenshots, screenName);
+  }
+
+  function canReuseWallpaperColorScreenshot(screenName, wallpaperPath, scaling) {
+    return ColorCacheHelpers.canReuseScreenshot(
+      pluginApi?.pluginSettings?.wallpaperColorScreenshots,
+      screenName,
+      wallpaperPath,
+      scaling,
+      normalizedPathFn,
+      defaultScaling
+    );
+  }
+
+  function startWallpaperColorCapture(wallpaperPath, targetScreenName, targetScaling, notify = false) {
+    const screenshotPath = screenshotPathForWallpaper(wallpaperPath, targetScreenName);
+    const pluginDir = pluginApi?.pluginDir || "";
+    const scriptPath = pluginDir + "/scripts/capture-wallpaper-colors.sh";
+    const wallpaperProperties = getWallpaperPropertiesFn(wallpaperPath);
+    const resolvedScaling = targetScaling.length > 0 ? targetScaling : "fill";
+    const command = WallpaperColorHelpers.buildCaptureCommand(
+      scriptPath,
+      screenshotPath,
+      "",
+      defaultFps,
+      defaultClamp,
+      targetScreenName,
+      wallpaperPath,
+      resolvedScaling,
+      wallpaperProperties
+    );
+
+    applyingWallpaperColors = true;
+    wallpaperColorRequestPath = wallpaperPath;
+    wallpaperColorScreenshotPath = screenshotPath;
+    wallpaperColorScreenName = targetScreenName;
+    wallpaperColorScaling = resolvedScaling;
+    wallpaperColorNotify = !!notify;
+    wallpaperColorProcess.command = command;
+    wallpaperColorProcess.running = true;
+
+    Logger.i("LWEController", "Generating screenshot for wallpaper color extraction", "path=", wallpaperPath, "screen=", targetScreenName, "scaling=", wallpaperColorScaling, "output=", screenshotPath);
+  }
+
+  function saveWallpaperColorScreenshot(screenName, screenshotPath, wallpaperPath, scaling) {
+    if (!pluginApi || screenName.length === 0 || screenshotPath.length === 0) {
+      return;
+    }
+
+    pluginApi.pluginSettings.wallpaperColorScreenshots[screenName] = WallpaperColorHelpers.buildScreenshotCacheEntry(
+      screenshotPath,
+      wallpaperPath,
+      scaling
+    );
+    pluginApi.saveSettings();
+
+    const pluginDir = pluginApi?.pluginDir || "";
+    const scriptPath = pluginDir + "/scripts/update-noctalia-wallpapers-cache.sh";
+    Quickshell.execDetached(["bash", scriptPath, screenName, screenshotPath]);
+  }
+
+  function scheduleCachedWallpaperColorsForMonitor(reason = "") {
+    pendingCachedWallpaperColorPath = "";
+    pendingCachedWallpaperColorScreenName = "";
+
+    if (!wallpaperColorsEnabled) {
+      return;
+    }
+
+    const screenName = activeColorMonitor;
+    if (screenName.length === 0) {
+      return;
+    }
+
+    const screenCfg = getScreenConfigFn(screenName);
+    const request = WallpaperColorHelpers.buildActiveMonitorSyncRequest(screenName, screenCfg, defaultScaling, normalizedPathFn);
+    if (!request) {
+      Logger.d("LWEController", "Skip wallpaper color sync: no configured wallpaper for active monitor", "screen=", screenName, "reason=", reason);
+      return;
+    }
+
+    Logger.d("LWEController", "Scheduling wallpaper color sync for current active monitor wallpaper", "screen=", request.screenName, "path=", request.path, "scaling=", request.scaling, "reason=", reason);
+    scheduleWallpaperColorsFromPath(request.path, request);
+  }
+
+  function applyWallpaperColorsFromPath(path, options = null) {
+    const request = WallpaperColorHelpers.normalizeWallpaperColorRequest(
+      path,
+      options,
+      defaultScaling,
+      Quickshell.screens[0]?.name || "",
+      normalizedPathFn
+    );
+    const wallpaperPath = request.path;
+    const targetScreenName = request.screenName;
+    const targetScaling = request.scaling;
+    const notify = request.notify;
+    if (!engineAvailable) {
+      if (notify) {
+        ToastService.showWarning(pluginApi?.tr("panel.title"), pluginApi?.tr("toast.wallpaperColorsEngineUnavailable"), "alert-circle");
+      }
+      return;
+    }
+
+    if (wallpaperPath.length === 0) {
+      if (notify) {
+        ToastService.showWarning(pluginApi?.tr("panel.title"), pluginApi?.tr("toast.wallpaperColorsNoSelection"), "alert-circle");
+      }
+      return;
+    }
+
+    if (targetScreenName.length === 0) {
+      if (notify) {
+        ToastService.showError(pluginApi?.tr("panel.title"), pluginApi?.tr("toast.wallpaperColorsFailed"), "alert-circle");
+      }
+      return;
+    }
+
+    if (applyingWallpaperColors) {
+      return;
+    }
+
+    if (canReuseWallpaperColorScreenshot(targetScreenName, wallpaperPath, targetScaling)) {
+      const entry = wallpaperColorScreenshotEntry(targetScreenName);
+      const cachedPath = normalizedPathFn(entry?.path || "");
+      const pluginDir = pluginApi?.pluginDir || "";
+      const scriptPath = pluginDir + "/scripts/check-file-exists.sh";
+      pendingWallpaperColorReuseRequest = WallpaperColorHelpers.buildReuseCheckRequest(
+        targetScreenName,
+        wallpaperPath,
+        targetScaling,
+        cachedPath,
+        notify
+      );
+      reusedWallpaperColorCheckProcess.command = ["bash", scriptPath, cachedPath];
+      reusedWallpaperColorCheckProcess.running = true;
+      return;
+    }
+    startWallpaperColorCapture(wallpaperPath, targetScreenName, targetScaling, notify);
+  }
+
+  function scheduleWallpaperColorsFromPath(path, options = null) {
+    const request = WallpaperColorHelpers.normalizeWallpaperColorRequest(
+      path,
+      options,
+      defaultScaling,
+      Quickshell.screens[0]?.name || "",
+      normalizedPathFn
+    );
+    if (request.path.length === 0) {
+      return;
+    }
+
+    pendingCachedWallpaperColorPath = "";
+    pendingCachedWallpaperColorScreenName = "";
+    pendingCachedWallpaperColorNotify = false;
+
+    pendingWallpaperColorRequest = request;
+    wallpaperColorStartTimer.restart();
+    Logger.d("LWEController", "Scheduled wallpaper color extraction", "path=", pendingWallpaperColorRequest.path, "screen=", pendingWallpaperColorRequest.screenName, "scaling=", pendingWallpaperColorRequest.scaling);
+  }
+
+  // Processes.
+  Process {
+    id: wallpaperColorProcess
+    running: false
+
+    stdout: StdioCollector {}
+    stderr: StdioCollector {}
+
+    onExited: function (exitCode) {
+      const requestPath = root.wallpaperColorRequestPath;
+      const screenshotPath = root.wallpaperColorScreenshotPath;
+      const screenName = root.wallpaperColorScreenName;
+      const appliedScaling = root.wallpaperColorScaling;
+      const notify = root.wallpaperColorNotify;
+      const stderrText = String(stderr.text || "").trim();
+
+      root.applyingWallpaperColors = false;
+      root.wallpaperColorRequestPath = "";
+      root.wallpaperColorScreenshotPath = "";
+      root.wallpaperColorScreenName = "";
+      root.wallpaperColorScaling = "fill";
+      root.wallpaperColorNotify = false;
+
+      if (exitCode !== 0) {
+        const msg = stderrText.length > 0 ? "Wallpaper screenshot generation failed, stderr=" + stderrText : "Wallpaper screenshot generation failed";
+        Logger.w("LWEController", msg, "path=", requestPath, "screen=", screenName, "exitCode=", exitCode);
+        if (notify) {
+          ToastService.showError(root.pluginApi?.tr("panel.title"), root.pluginApi?.tr("toast.wallpaperColorsFailed"), "alert-circle");
+        }
+        return;
+      }
+
+      root.saveWallpaperColorScreenshot(screenName, screenshotPath, requestPath, appliedScaling);
+
+      if (root.wallpaperColorsEnabled && screenName === root.activeColorMonitor) {
+        root.applyWallpaperColorsFromScreenshot(screenshotPath);
+        Logger.i("LWEController", "Wallpaper screenshot generated and applied for active color monitor", "path=", requestPath, "screen=", screenName, "screenshot=", screenshotPath);
+        if (notify) {
+          ToastService.showNotice(root.pluginApi?.tr("panel.title"), root.pluginApi?.tr("toast.wallpaperColorsApplied"), "palette");
+        }
+        return;
+      }
+
+      Logger.i("LWEController", "Wallpaper screenshot cached for color extraction", "path=", requestPath, "screen=", screenName, "screenshot=", screenshotPath);
+      if (notify) {
+        ToastService.showNotice(root.pluginApi?.tr("panel.title"), root.pluginApi?.tr("toast.wallpaperColorsCached"), "palette");
+      }
+    }
+  }
+
+  Process {
+    id: reusedWallpaperColorCheckProcess
+    running: false
+
+    onExited: function (exitCode) {
+      const request = root.pendingWallpaperColorReuseRequest;
+      root.pendingWallpaperColorReuseRequest = null;
+      if (!request) {
+        return;
+      }
+
+      if (exitCode === 0) {
+        Logger.i("LWEController", "Reusing cached wallpaper color screenshot", "path=", request.wallpaperPath, "screen=", request.screenName, "scaling=", request.scaling, "screenshot=", request.screenshotPath);
+
+        if (root.wallpaperColorsEnabled && request.screenName === root.activeColorMonitor) {
+          root.applyWallpaperColorsFromScreenshot(request.screenshotPath);
+          if (request.notify) {
+            ToastService.showNotice(root.pluginApi?.tr("panel.title"), root.pluginApi?.tr("toast.wallpaperColorsApplied"), "palette");
+          }
+        } else if (request.notify) {
+          ToastService.showNotice(root.pluginApi?.tr("panel.title"), root.pluginApi?.tr("toast.wallpaperColorsCached"), "palette");
+        }
+        return;
+      }
+
+      Logger.w("LWEController", "Cached wallpaper color screenshot missing; regenerating", "path=", request.wallpaperPath, "screen=", request.screenName, "scaling=", request.scaling, "screenshot=", request.screenshotPath);
+      root.startWallpaperColorCapture(request.wallpaperPath, request.screenName, request.scaling, !!request.notify);
+    }
+
+    stdout: StdioCollector {}
+    stderr: StdioCollector {}
+  }
+
+  Process {
+    id: cachedWallpaperColorSyncCheckProcess
+    running: false
+
+    onExited: function (exitCode) {
+      const screenshotPath = root.pendingCachedWallpaperColorPath;
+      const screenName = root.pendingCachedWallpaperColorScreenName;
+      const notify = root.pendingCachedWallpaperColorNotify;
+
+      if (exitCode !== 0 || screenshotPath.length === 0) {
+        Logger.w("LWEController", "Cached wallpaper color screenshot missing for active monitor", "screen=", screenName, "path=", screenshotPath, "exitCode=", exitCode);
+        root.pendingCachedWallpaperColorPath = "";
+        root.pendingCachedWallpaperColorScreenName = "";
+        root.pendingCachedWallpaperColorNotify = false;
+        return;
+      }
+
+      root.pendingCachedWallpaperColorNotify = notify;
+      cachedWallpaperColorSyncTimer.restart();
+    }
+
+    stdout: StdioCollector {}
+    stderr: StdioCollector {}
+  }
+
+  // Timers.
+  Timer {
+    id: wallpaperColorStartTimer
+    interval: root.colorStartDelay
+
+    onTriggered: {
+      const request = root.pendingWallpaperColorRequest;
+      root.pendingWallpaperColorRequest = null;
+      if (!request || String(request.path || "").length === 0) {
+        return;
+      }
+      root.applyWallpaperColorsFromPath(request.path, request);
+    }
+  }
+
+  Timer {
+    id: cachedWallpaperColorSyncTimer
+    interval: root.colorSyncDelay
+    repeat: false
+
+    onTriggered: {
+      const screenshotPath = root.pendingCachedWallpaperColorPath;
+      const screenName = root.pendingCachedWallpaperColorScreenName;
+      root.pendingCachedWallpaperColorPath = "";
+      root.pendingCachedWallpaperColorScreenName = "";
+      root.pendingCachedWallpaperColorNotify = false;
+      if (screenshotPath.length === 0 || !root.wallpaperColorsEnabled) {
+        return;
+      }
+      Logger.i("LWEController", "Applying cached wallpaper colors for active monitor", "screen=", screenName || root.activeColorMonitor, "path=", screenshotPath);
+      root.applyWallpaperColorsFromScreenshot(screenshotPath);
+    }
+  }
+
+  Timer {
+    id: startupWallpaperColorResyncTimer
+    interval: root.startupResyncDelay
+    repeat: false
+
+    onTriggered: {
+      root.scheduleCachedWallpaperColorsForMonitor("startup-final-resync");
+    }
+  }
+
+  // React to settings changes.
+  onActiveColorMonitorChanged: scheduleCachedWallpaperColorsForMonitor("monitor-changed")
+  onWallpaperColorsEnabledChanged: scheduleCachedWallpaperColorsForMonitor("wallpaper-colors-toggled")
+  onWallpaperColorDarkModeChanged: scheduleCachedWallpaperColorsForMonitor("dark-mode-changed")
+  onWallpaperColorGenerationMethodChanged: scheduleCachedWallpaperColorsForMonitor("generation-method-changed")
+
+  // Cleanup.
+  Component.onDestruction: {
+    wallpaperColorProcess.running = false;
+    reusedWallpaperColorCheckProcess.running = false;
+    cachedWallpaperColorSyncCheckProcess.running = false;
+    wallpaperColorStartTimer.stop();
+    cachedWallpaperColorSyncTimer.stop();
+    startupWallpaperColorResyncTimer.stop();
+    applyingWallpaperColors = false;
+  }
+}

--- a/linux-wallpaperengine-controller/components/wallpaper/GridSection.qml
+++ b/linux-wallpaperengine-controller/components/wallpaper/GridSection.qml
@@ -87,6 +87,11 @@ Rectangle {
        readonly property bool isSelected: root.selectedPath === modelData.path
        readonly property bool isMotion: modelData.motionPreview && modelData.motionPreview.length > 0
        readonly property bool isVideoMotion: root.isVideoMotion && root.isVideoMotion(modelData.motionPreview)
+       readonly property bool isInView: {
+         const gv = GridView.view;
+         const cellY = y - gv.contentY;
+         return cellY + height > -50 && cellY < gv.height + 50;
+       }
        width: GridView.view.cellWidth
        height: GridView.view.cellHeight
        radius: Style.radiusL
@@ -129,7 +134,7 @@ Rectangle {
               source: "file://" + modelData.motionPreview
               fillMode: Image.PreserveAspectCrop
               cache: false
-              playing: true
+              playing: tileCard.isInView
             }
           }
 
@@ -138,11 +143,12 @@ Rectangle {
 
             Video {
               anchors.fill: parent
-              autoPlay: true
+              autoPlay: tileCard.isInView
               loops: MediaPlayer.Infinite
               muted: true
               fillMode: VideoOutput.PreserveAspectCrop
               source: "file://" + modelData.motionPreview
+              visible: tileCard.isInView
             }
           }
 
@@ -198,179 +204,49 @@ Rectangle {
             Repeater {
               model: badgeContainer.visibleBadgeKeys
 
-              Loader {
+              WallpaperBadge {
                 required property var modelData
-                sourceComponent: {
+                compact: true
+                badgeIcon: {
                   const key = String(modelData || "");
-                  if (key === "type") return typeBadgeComponent;
-                  if (key === "dynamic") return dynamicBadgeComponent;
-                  if (key === "music") return musicBadgeComponent;
-                  if (key === "reactive") return reactiveBadgeComponent;
-                  if (key === "approved") return approvedBadgeComponent;
-                  if (key === "resolution") return resolutionBadgeComponent;
-                  if (key === "compatibility") return compatibilityBadgeComponent;
-                  return null;
+                  if (key === "type") return root.typeBadgeIcon ? root.typeBadgeIcon(tileCard.wallpaperData.type) : "category";
+                  if (key === "dynamic") return root.dynamicBadgeIcon ? root.dynamicBadgeIcon(!!tileCard.wallpaperData.dynamic) : (tileCard.wallpaperData.dynamic ? "player-play" : "player-stop");
+                  if (key === "music") return "volume";
+                  if (key === "reactive") return "wave-sine";
+                  if (key === "approved") return "rosette-discount-check";
+                  if (key === "resolution") return "aspect-ratio";
+                  if (key === "compatibility") return "settings-cog";
+                  return "";
                 }
-              }
-            }
-          }
-
-          Component {
-            id: typeBadgeComponent
-
-            Rectangle {
-              color: Qt.alpha(Color.mSecondary, 0.18)
-              radius: Style.radiusXS
-              implicitWidth: typeBadgeRow.implicitWidth + Style.marginS * 2
-              implicitHeight: typeBadgeText.implicitHeight + Style.marginXS * 2
-
-              RowLayout {
-                id: typeBadgeRow
-                anchors.centerIn: parent
-                spacing: Style.marginXS
-
-                NIcon {
-                  icon: root.typeBadgeIcon ? root.typeBadgeIcon(tileCard.wallpaperData.type) : "category"
-                  pointSize: Style.fontSizeM
-                  color: Color.mSecondary
+                badgeColor: {
+                  const key = String(modelData || "");
+                  if (key === "type") return Color.mSecondary;
+                  if (key === "dynamic") return tileCard.wallpaperData.dynamic ? Color.mTertiary : Color.mOnSurfaceVariant;
+                  if (key === "music") return Color.mPrimary;
+                  if (key === "reactive") return Color.mSecondary;
+                  if (key === "approved") return Color.mPrimary;
+                  if (key === "resolution") return Color.mOnSurfaceVariant;
+                  if (key === "compatibility") {
+                    const cPath = String(tileCard.wallpaperData.path || "");
+                    return root.propertyCompatibilityBadgeColorForPath ? root.propertyCompatibilityBadgeColorForPath(cPath) : Color.mError;
+                  }
+                  return Color.mOnSurfaceVariant;
                 }
-
-                NText {
-                  id: typeBadgeText
-                  text: root.typeLabel ? root.typeLabel(tileCard.wallpaperData.type) : ""
-                  color: Color.mSecondary
-                  font.pointSize: Style.fontSizeXS
-                  font.weight: Font.Medium
+                badgeBgColor: {
+                  const key = String(modelData || "");
+                  if (key === "type") return Qt.alpha(Color.mSecondary, 0.18);
+                  if (key === "dynamic") return Qt.alpha(Color.mTertiary, 0.18);
+                  if (key === "music") return Qt.alpha(Color.mPrimary, 0.16);
+                  if (key === "reactive") return Qt.alpha(Color.mSecondary, 0.16);
+                  if (key === "approved") return Qt.alpha(Color.mPrimary, 0.16);
+                  if (key === "resolution") return Qt.alpha(Color.mSurfaceVariant, 0.24);
+                  if (key === "compatibility") {
+                    const cPath = String(tileCard.wallpaperData.path || "");
+                    const cColor = root.propertyCompatibilityBadgeColorForPath ? root.propertyCompatibilityBadgeColorForPath(cPath) : Color.mError;
+                    return root.propertyCompatibilityBadgeBackgroundForPath ? root.propertyCompatibilityBadgeBackgroundForPath(cPath) : Qt.alpha(cColor, 0.16);
+                  }
+                  return Qt.alpha(Color.mSurfaceVariant, 0.24);
                 }
-              }
-            }
-          }
-
-          Component {
-            id: dynamicBadgeComponent
-
-            Rectangle {
-              color: Qt.alpha(Color.mTertiary, 0.18)
-              radius: Style.radiusXS
-              implicitWidth: motionBadgeIcon.implicitWidth + Style.marginXS * 2
-              implicitHeight: motionBadgeIcon.implicitHeight + Style.marginXS * 2
-
-              NIcon {
-                id: motionBadgeIcon
-                anchors.centerIn: parent
-                icon: root.dynamicBadgeIcon ? root.dynamicBadgeIcon(!!tileCard.wallpaperData.dynamic) : (tileCard.wallpaperData.dynamic ? "player-play" : "player-stop")
-                pointSize: Style.fontSizeM
-                color: tileCard.wallpaperData.dynamic ? Color.mTertiary : Color.mOnSurfaceVariant
-              }
-            }
-          }
-
-          Component {
-            id: musicBadgeComponent
-
-            Rectangle {
-              color: Qt.alpha(Color.mPrimary, 0.16)
-              radius: Style.radiusXS
-              implicitWidth: musicBadgeIcon.implicitWidth + Style.marginXS * 2
-              implicitHeight: musicBadgeIcon.implicitHeight + Style.marginXS * 2
-
-              NIcon {
-                id: musicBadgeIcon
-                anchors.centerIn: parent
-                icon: "volume"
-                pointSize: Style.fontSizeM
-                color: Color.mPrimary
-              }
-            }
-          }
-
-          Component {
-            id: reactiveBadgeComponent
-
-            Rectangle {
-              color: Qt.alpha(Color.mSecondary, 0.16)
-              radius: Style.radiusXS
-              implicitWidth: reactiveBadgeIcon.implicitWidth + Style.marginXS * 2
-              implicitHeight: reactiveBadgeIcon.implicitHeight + Style.marginXS * 2
-
-              NIcon {
-                id: reactiveBadgeIcon
-                anchors.centerIn: parent
-                icon: "wave-sine"
-                pointSize: Style.fontSizeM
-                color: Color.mSecondary
-              }
-            }
-          }
-
-          Component {
-            id: approvedBadgeComponent
-
-            Rectangle {
-              color: Qt.alpha(Color.mPrimary, 0.16)
-              radius: Style.radiusXS
-              implicitWidth: approvedBadgeIcon.implicitWidth + Style.marginXS * 2
-              implicitHeight: approvedBadgeIcon.implicitHeight + Style.marginXS * 2
-
-              NIcon {
-                id: approvedBadgeIcon
-                anchors.centerIn: parent
-                icon: "rosette-discount-check"
-                pointSize: Style.fontSizeM
-                color: Color.mPrimary
-              }
-            }
-          }
-
-          Component {
-            id: resolutionBadgeComponent
-
-            Rectangle {
-              color: Qt.alpha(Color.mSurfaceVariant, 0.24)
-              radius: Style.radiusXS
-              implicitWidth: resolutionBadgeRow.implicitWidth + Style.marginS * 2
-              implicitHeight: resolutionBadgeRow.implicitHeight + Style.marginXS * 2
-
-              RowLayout {
-                id: resolutionBadgeRow
-                anchors.centerIn: parent
-                spacing: Style.marginXS
-
-                NIcon {
-                  icon: "aspect-ratio"
-                  pointSize: Style.fontSizeM
-                  color: Color.mOnSurfaceVariant
-                }
-
-                NText {
-                  text: root.resolutionBadgeLabel ? root.resolutionBadgeLabel(tileCard.wallpaperData.resolution) : ""
-                  color: Color.mOnSurfaceVariant
-                  font.pointSize: Style.fontSizeXS
-                  font.weight: Font.Medium
-                }
-              }
-            }
-          }
-
-          Component {
-            id: compatibilityBadgeComponent
-
-            Rectangle {
-              readonly property string compatibilityPath: String(tileCard.wallpaperData.path || "")
-              readonly property color compatibilityColor: root.propertyCompatibilityBadgeColorForPath ? root.propertyCompatibilityBadgeColorForPath(compatibilityPath) : Color.mError
-              color: root.propertyCompatibilityBadgeBackgroundForPath
-                ? root.propertyCompatibilityBadgeBackgroundForPath(compatibilityPath)
-                : Qt.alpha(compatibilityColor, 0.16)
-              radius: Style.radiusXS
-              implicitWidth: compatibilityBadgeIcon.implicitWidth + Style.marginXS * 2
-              implicitHeight: compatibilityBadgeIcon.implicitHeight + Style.marginXS * 2
-
-              NIcon {
-                id: compatibilityBadgeIcon
-                anchors.centerIn: parent
-                icon: "settings-cog"
-                pointSize: Style.fontSizeM
-                color: parent.compatibilityColor
               }
             }
           }

--- a/linux-wallpaperengine-controller/components/wallpaper/PreviewCard.qml
+++ b/linux-wallpaperengine-controller/components/wallpaper/PreviewCard.qml
@@ -181,9 +181,9 @@ ColumnLayout {
             const key = String(modelData || "");
             if (key === "type") return root.typeLabel ? root.typeLabel(root.selectedWallpaperData.type) : "";
             if (key === "dynamic") return root.selectedWallpaperData.dynamic ? pluginApi?.tr("panel.dynamicBadge") : pluginApi?.tr("panel.staticBadge");
-            if (key === "music") return pluginApi?.tr("panel.musicBadge") || "";
-            if (key === "reactive") return pluginApi?.tr("panel.reactiveBadge") || "";
-            if (key === "approved") return pluginApi?.tr("panel.approvedBadge") || "";
+            if (key === "music") return pluginApi?.tr("panel.musicBadge");
+            if (key === "reactive") return pluginApi?.tr("panel.reactiveBadge");
+            if (key === "approved") return pluginApi?.tr("panel.approvedBadge");
             if (key === "resolution") return root.resolutionBadgeLabel ? root.resolutionBadgeLabel(root.selectedWallpaperData.resolution) : "";
             if (key === "compatibility") {
               const cPath = String(root.selectedWallpaperData?.path || "");

--- a/linux-wallpaperengine-controller/components/wallpaper/PreviewCard.qml
+++ b/linux-wallpaperengine-controller/components/wallpaper/PreviewCard.qml
@@ -163,248 +163,62 @@ ColumnLayout {
       Repeater {
         model: root.visibleBadgeKeys
 
-        Loader {
+        WallpaperBadge {
           required property var modelData
-          sourceComponent: {
+          compact: false
+          badgeIcon: {
             const key = String(modelData || "");
-            if (key === "resolution") return resolutionBadgeComponent;
-            if (key === "type") return typeBadgeComponent;
-            if (key === "dynamic") return motionBadgeComponent;
-            if (key === "music") return musicBadgeComponent;
-            if (key === "reactive") return reactiveBadgeComponent;
-            if (key === "approved") return approvedBadgeComponent;
-            if (key === "compatibility") return compatibilityBadgeComponent;
-            return null;
+            if (key === "type") return root.typeBadgeIcon ? root.typeBadgeIcon(root.selectedWallpaperData.type) : "category";
+            if (key === "dynamic") return root.dynamicBadgeIcon ? root.dynamicBadgeIcon(!!root.selectedWallpaperData.dynamic) : (root.selectedWallpaperData.dynamic ? "player-play" : "player-stop");
+            if (key === "music") return "volume";
+            if (key === "reactive") return "wave-sine";
+            if (key === "approved") return "rosette-discount-check";
+            if (key === "resolution") return "aspect-ratio";
+            if (key === "compatibility") return "settings-cog";
+            return "";
           }
-        }
-      }
-
-      Component {
-        id: resolutionBadgeComponent
-
-        Rectangle {
-          color: Qt.alpha(Color.mSurfaceVariant, 0.24)
-          radius: Style.radiusS
-          width: resolutionBadgeContent.implicitWidth + Style.marginS * 2
-          height: resolutionBadgeContent.implicitHeight + Style.marginXS * 2
-
-          RowLayout {
-            id: resolutionBadgeContent
-            anchors.centerIn: parent
-            spacing: Style.marginXS
-
-            NIcon {
-              icon: "aspect-ratio"
-              pointSize: Style.fontSizeM
-              color: Color.mOnSurfaceVariant
+          badgeText: {
+            const key = String(modelData || "");
+            if (key === "type") return root.typeLabel ? root.typeLabel(root.selectedWallpaperData.type) : "";
+            if (key === "dynamic") return root.selectedWallpaperData.dynamic ? pluginApi?.tr("panel.dynamicBadge") : pluginApi?.tr("panel.staticBadge");
+            if (key === "music") return pluginApi?.tr("panel.musicBadge") || "";
+            if (key === "reactive") return pluginApi?.tr("panel.reactiveBadge") || "";
+            if (key === "approved") return pluginApi?.tr("panel.approvedBadge") || "";
+            if (key === "resolution") return root.resolutionBadgeLabel ? root.resolutionBadgeLabel(root.selectedWallpaperData.resolution) : "";
+            if (key === "compatibility") {
+              const cPath = String(root.selectedWallpaperData?.path || "");
+              return root.propertyCompatibilityBadgeTextForPath ? root.propertyCompatibilityBadgeTextForPath(cPath) : "";
             }
-
-            NText {
-              text: root.resolutionBadgeLabel ? root.resolutionBadgeLabel(root.selectedWallpaperData.resolution) : ""
-              color: Color.mOnSurfaceVariant
-              font.pointSize: Style.fontSizeXS
-              font.weight: Font.Medium
-              elide: Text.ElideRight
-            }
+            return "";
           }
-        }
-      }
-
-      Component {
-        id: typeBadgeComponent
-
-        Rectangle {
-          color: Qt.alpha(Color.mSecondary, 0.1)
-          radius: Style.radiusS
-          width: typeBadgeContent.implicitWidth + Style.marginS * 2
-          height: typeBadgeContent.implicitHeight + Style.marginXS * 2
-
-          RowLayout {
-            id: typeBadgeContent
-            anchors.centerIn: parent
-            spacing: Style.marginXS
-
-            NIcon {
-              icon: root.typeBadgeIcon ? root.typeBadgeIcon(root.selectedWallpaperData.type) : "category"
-              pointSize: Style.fontSizeM
-              color: Color.mSecondary
+          badgeColor: {
+            const key = String(modelData || "");
+            if (key === "type") return Color.mSecondary;
+            if (key === "dynamic") return root.selectedWallpaperData.dynamic ? Color.mTertiary : Color.mOnSurfaceVariant;
+            if (key === "music") return Color.mPrimary;
+            if (key === "reactive") return Color.mSecondary;
+            if (key === "approved") return Color.mPrimary;
+            if (key === "resolution") return Color.mOnSurfaceVariant;
+            if (key === "compatibility") {
+              const cPath = String(root.selectedWallpaperData?.path || "");
+              return root.propertyCompatibilityBadgeColorForPath ? root.propertyCompatibilityBadgeColorForPath(cPath) : Color.mError;
             }
-
-            NText {
-              text: root.typeLabel ? root.typeLabel(root.selectedWallpaperData.type) : ""
-              color: Color.mSecondary
-              font.pointSize: Style.fontSizeXS
-              font.weight: Font.Medium
-              elide: Text.ElideRight
-            }
+            return Color.mOnSurfaceVariant;
           }
-        }
-      }
-
-      Component {
-        id: motionBadgeComponent
-
-        Rectangle {
-          color: root.selectedWallpaperData.dynamic
-            ? Qt.alpha(Color.mTertiary, 0.1)
-            : Qt.alpha(Color.mOutline, 0.1)
-          radius: Style.radiusS
-          width: motionBadgeContent.implicitWidth + Style.marginS * 2
-          height: motionBadgeContent.implicitHeight + Style.marginXS * 2
-
-          RowLayout {
-            id: motionBadgeContent
-            anchors.centerIn: parent
-            spacing: Style.marginXS
-
-            NIcon {
-              icon: root.dynamicBadgeIcon
-                ? root.dynamicBadgeIcon(!!root.selectedWallpaperData.dynamic)
-                : (root.selectedWallpaperData.dynamic ? "player-play" : "player-stop")
-              pointSize: Style.fontSizeM
-              color: root.selectedWallpaperData.dynamic ? Color.mTertiary : Color.mOnSurfaceVariant
+          badgeBgColor: {
+            const key = String(modelData || "");
+            if (key === "type") return Qt.alpha(Color.mSecondary, 0.1);
+            if (key === "dynamic") return root.selectedWallpaperData.dynamic ? Qt.alpha(Color.mTertiary, 0.1) : Qt.alpha(Color.mOutline, 0.1);
+            if (key === "music") return Qt.alpha(Color.mPrimary, 0.1);
+            if (key === "reactive") return Qt.alpha(Color.mSecondary, 0.1);
+            if (key === "approved") return Qt.alpha(Color.mPrimary, 0.1);
+            if (key === "resolution") return Qt.alpha(Color.mSurfaceVariant, 0.24);
+            if (key === "compatibility") {
+              const cPath = String(root.selectedWallpaperData?.path || "");
+              const cColor = root.propertyCompatibilityBadgeColorForPath ? root.propertyCompatibilityBadgeColorForPath(cPath) : Color.mError;
+              return root.propertyCompatibilityBadgeBackgroundForPath ? root.propertyCompatibilityBadgeBackgroundForPath(cPath) : Qt.alpha(cColor, 0.1);
             }
-
-            NText {
-              text: root.selectedWallpaperData.dynamic
-                ? pluginApi?.tr("panel.dynamicBadge")
-                : pluginApi?.tr("panel.staticBadge")
-              color: root.selectedWallpaperData.dynamic ? Color.mTertiary : Color.mOnSurfaceVariant
-              font.pointSize: Style.fontSizeXS
-              font.weight: Font.Medium
-              elide: Text.ElideRight
-            }
-          }
-        }
-      }
-
-      Component {
-        id: musicBadgeComponent
-
-        Rectangle {
-          color: Qt.alpha(Color.mPrimary, 0.1)
-          radius: Style.radiusS
-          width: audioBadgeContent.implicitWidth + Style.marginS * 2
-          height: audioBadgeContent.implicitHeight + Style.marginXS * 2
-
-          RowLayout {
-            id: audioBadgeContent
-            anchors.centerIn: parent
-            spacing: Style.marginXS
-
-            NIcon {
-              icon: "volume"
-              pointSize: Style.fontSizeM
-              color: Color.mPrimary
-            }
-
-            NText {
-              text: pluginApi?.tr("panel.musicBadge")
-              color: Color.mPrimary
-              font.pointSize: Style.fontSizeXS
-              font.weight: Font.Medium
-              elide: Text.ElideRight
-            }
-          }
-        }
-      }
-
-      Component {
-        id: reactiveBadgeComponent
-
-        Rectangle {
-          color: Qt.alpha(Color.mSecondary, 0.1)
-          radius: Style.radiusS
-          width: reactiveBadgeContent.implicitWidth + Style.marginS * 2
-          height: reactiveBadgeContent.implicitHeight + Style.marginXS * 2
-
-          RowLayout {
-            id: reactiveBadgeContent
-            anchors.centerIn: parent
-            spacing: Style.marginXS
-
-            NIcon {
-              icon: "wave-sine"
-              pointSize: Style.fontSizeM
-              color: Color.mSecondary
-            }
-
-            NText {
-              text: pluginApi?.tr("panel.reactiveBadge")
-              color: Color.mSecondary
-              font.pointSize: Style.fontSizeXS
-              font.weight: Font.Medium
-              elide: Text.ElideRight
-            }
-          }
-        }
-      }
-
-      Component {
-        id: approvedBadgeComponent
-
-        Rectangle {
-          color: Qt.alpha(Color.mPrimary, 0.1)
-          radius: Style.radiusS
-          width: approvedBadgeContent.implicitWidth + Style.marginS * 2
-          height: approvedBadgeContent.implicitHeight + Style.marginXS * 2
-
-          RowLayout {
-            id: approvedBadgeContent
-            anchors.centerIn: parent
-            spacing: Style.marginXS
-
-            NIcon {
-              icon: "rosette-discount-check"
-              pointSize: Style.fontSizeM
-              color: Color.mPrimary
-            }
-
-            NText {
-              text: pluginApi?.tr("panel.approvedBadge")
-              color: Color.mPrimary
-              font.pointSize: Style.fontSizeXS
-              font.weight: Font.Medium
-              elide: Text.ElideRight
-            }
-          }
-        }
-      }
-
-      Component {
-        id: compatibilityBadgeComponent
-
-        Rectangle {
-          id: compatibilityBadge
-          readonly property string compatibilityPath: String(root.selectedWallpaperData?.path || "")
-          readonly property string compatibilityLabel: root.propertyCompatibilityBadgeTextForPath ? root.propertyCompatibilityBadgeTextForPath(compatibilityPath) : ""
-          readonly property color compatibilityColor: root.propertyCompatibilityBadgeColorForPath ? root.propertyCompatibilityBadgeColorForPath(compatibilityPath) : Color.mError
-          readonly property string compatibilityIcon: root.propertyCompatibilityBadgeIconForPath ? root.propertyCompatibilityBadgeIconForPath(compatibilityPath) : "alert-triangle"
-          color: root.propertyCompatibilityBadgeBackgroundForPath
-            ? root.propertyCompatibilityBadgeBackgroundForPath(compatibilityPath)
-            : Qt.alpha(compatibilityColor, 0.1)
-          radius: Style.radiusS
-          width: compatBadgeContent.implicitWidth + Style.marginS * 2
-          height: compatBadgeContent.implicitHeight + Style.marginXS * 2
-
-          RowLayout {
-            id: compatBadgeContent
-            anchors.centerIn: parent
-            spacing: Style.marginXS
-
-            NIcon {
-              icon: "settings-cog"
-              pointSize: Style.fontSizeM
-              color: compatibilityBadge.compatibilityColor
-            }
-
-            NText {
-              text: compatibilityBadge.compatibilityLabel
-              color: compatibilityBadge.compatibilityColor
-              font.pointSize: Style.fontSizeXS
-              font.weight: Font.Medium
-              elide: Text.ElideRight
-            }
+            return Qt.alpha(Color.mSurfaceVariant, 0.24);
           }
         }
       }

--- a/linux-wallpaperengine-controller/components/wallpaper/WallpaperBadge.qml
+++ b/linux-wallpaperengine-controller/components/wallpaper/WallpaperBadge.qml
@@ -1,0 +1,51 @@
+import QtQuick
+import QtQuick.Layouts
+
+import qs.Commons
+import qs.Widgets
+
+Rectangle {
+  id: root
+
+  property string badgeIcon: ""
+  property string badgeText: ""
+  property color badgeColor: Color.mOnSurfaceVariant
+  property color badgeBgColor: Qt.alpha(Color.mSurfaceVariant, 0.24)
+  property bool compact: false
+
+  color: badgeBgColor
+  radius: compact ? Style.radiusXS : Style.radiusS
+  implicitWidth: compact ? badgeIconItem.implicitWidth + Style.marginXS * 2 : badgeRow.implicitWidth + Style.marginS * 2
+  implicitHeight: compact ? badgeIconItem.implicitHeight + Style.marginXS * 2 : badgeRow.implicitHeight + Style.marginXS * 2
+
+  RowLayout {
+    id: badgeRow
+    anchors.centerIn: parent
+    spacing: Style.marginXS
+    visible: !root.compact
+
+    NIcon {
+      icon: root.badgeIcon
+      pointSize: Style.fontSizeM
+      color: root.badgeColor
+    }
+
+    NText {
+      text: root.badgeText
+      color: root.badgeColor
+      font.pointSize: Style.fontSizeXS
+      font.weight: Font.Medium
+      elide: Text.ElideRight
+      visible: root.badgeText.length > 0
+    }
+  }
+
+  NIcon {
+    id: badgeIconItem
+    anchors.centerIn: parent
+    visible: root.compact
+    icon: root.badgeIcon
+    pointSize: Style.fontSizeM
+    color: root.badgeColor
+  }
+}

--- a/linux-wallpaperengine-controller/helpers/panel/WallpaperMetaHelpers.js
+++ b/linux-wallpaperengine-controller/helpers/panel/WallpaperMetaHelpers.js
@@ -16,27 +16,6 @@ function isVideoMotion(path) {
   return ext === "mp4" || ext === "webm" || ext === "mov" || ext === "mkv";
 }
 
-function formatBytes(bytesValue) {
-  const size = Number(bytesValue || 0);
-  if (isNaN(size) || size <= 0) {
-    return "0 B";
-  }
-
-  if (size < 1024) {
-    return Math.floor(size) + " B";
-  }
-
-  if (size < 1024 * 1024) {
-    return (size / 1024).toFixed(1) + " KB";
-  }
-
-  if (size < 1024 * 1024 * 1024) {
-    return (size / (1024 * 1024)).toFixed(1) + " MB";
-  }
-
-  return (size / (1024 * 1024 * 1024)).toFixed(1) + " GB";
-}
-
 function resolutionBadgeIcon(value) {
   const resolution = String(value || "").toLowerCase().trim();
   if (resolution.length === 0 || resolution === "unknown") {

--- a/linux-wallpaperengine-controller/manifest.json
+++ b/linux-wallpaperengine-controller/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "linux-wallpaperengine-controller",
   "name": "Linux WallpaperEngine Controller",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "minNoctaliaVersion": "4.6.6",
   "author": "PaloMiku",
   "license": "MIT",

--- a/linux-wallpaperengine-controller/scripts/capture-wallpaper-colors.sh
+++ b/linux-wallpaperengine-controller/scripts/capture-wallpaper-colors.sh
@@ -5,7 +5,7 @@
 #   1: output screenshot path
 #   2..n: linux-wallpaperengine command and arguments
 
-set -u
+set -eu
 
 output_file="$1"
 shift

--- a/linux-wallpaperengine-controller/scripts/check-file-exists.sh
+++ b/linux-wallpaperengine-controller/scripts/check-file-exists.sh
@@ -4,6 +4,8 @@
 # Args:
 #   1: file path to check
 
+set -eu
+
 file_path="$1"
 
 [ -f "$file_path" ]

--- a/linux-wallpaperengine-controller/scripts/clear-color-cache.sh
+++ b/linux-wallpaperengine-controller/scripts/clear-color-cache.sh
@@ -5,7 +5,7 @@
 #   1: cache directory path
 #   2..n: screenshot file paths to keep
 
-set -u
+set -eu
 
 if [ "$#" -lt 1 ]; then
   exit 20

--- a/linux-wallpaperengine-controller/scripts/detect-steam-workshop.sh
+++ b/linux-wallpaperengine-controller/scripts/detect-steam-workshop.sh
@@ -4,6 +4,8 @@
 # Output:
 #   First matching workshop directory path, or empty output if not found
 
+set -eu
+
 for common in "$HOME/.steam/steam/steamapps/common" \
               "$HOME/.local/share/Steam/steamapps/common" \
               "$HOME/.var/app/com.valvesoftware.Steam/.local/share/Steam/steamapps/common" \

--- a/linux-wallpaperengine-controller/scripts/force-stop-engine.sh
+++ b/linux-wallpaperengine-controller/scripts/force-stop-engine.sh
@@ -2,6 +2,8 @@
 
 # Stop any running linux-wallpaperengine processes started by this plugin.
 
+set -eu
+
 if command -v pkill >/dev/null 2>&1; then
   pkill -x linux-wallpaper >/dev/null 2>&1 || true
   pkill -f '(^|/)linux-wallpaperengine([[:space:]]|$)' >/dev/null 2>&1 || true

--- a/linux-wallpaperengine-controller/scripts/get-cache-size-bytes.sh
+++ b/linux-wallpaperengine-controller/scripts/get-cache-size-bytes.sh
@@ -4,6 +4,8 @@
 # Args:
 #   1: cache directory path
 
+set -eu
+
 cache_dir="$1"
 
 if [ -d "$cache_dir" ]; then

--- a/linux-wallpaperengine-controller/scripts/scan-properties-compatibility.sh
+++ b/linux-wallpaperengine-controller/scripts/scan-properties-compatibility.sh
@@ -10,6 +10,8 @@
 #     1 = failed
 #     2 = limited editor support
 
+set -eu
+
 dir="$1"
 [ -d "$dir" ] || exit 10
 

--- a/linux-wallpaperengine-controller/scripts/scan-wallpapers.sh
+++ b/linux-wallpaperengine-controller/scripts/scan-wallpapers.sh
@@ -7,7 +7,7 @@
 #   Tab-separated rows:
 #   <path>\t<name>\t<thumb>\t<motion>\t<dynamic>\t<id>\t<type>\t<resolution>\t<embedded_audio>\t<audio_reactive>\t<bytes>:<mtime>\t<approved>\t<description>
 
-set -u
+set -eu
 dir="${1:-}"
 [ -n "$dir" ] || exit 10
 [ -d "$dir" ] || exit 10


### PR DESCRIPTION
## Summary
- **Extract WallpaperColorManager** from Main.qml (~338 lines) — isolates color extraction subsystem with its own Process objects and timers
- **Extract shared WallpaperBadge component** from GridSection.qml and PreviewCard.qml (~300 lines of duplication removed)
- **O(1) wallpaper-by-path lookup** in Panel.qml via Map rebuild on item change
- **Off-screen animation pausing** for AnimatedImage/Video in grid tiles using `isInView` detection
- **Property loading fallback** — restore saved properties from settings.json when `--list-properties` fails or engine is unavailable, instead of losing user config
- **Shell script hardening** — add `set -eu` to all 9 scripts for consistent error handling
- **Minor cleanups** — named timer constants, remove duplicated `formatBytes`, remove unused import