### PR TITLE
fix(keybind-cheatsheet): repair empty Settings panel + Lua require path resolution (v3.7.2)

### DIFF
--- a/keybind-cheatsheet/CHANGELOG.md
+++ b/keybind-cheatsheet/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.7.2] - 2026-05-21
+
+### Fixes
+
+- **Settings panel was rendering empty**: `Settings.qml` and `ColorPairRow.qml` reference sibling files (`ColorPairRow`, `ColorPill`) but Quickshell's `NPluginSettingsPopup` loads Settings via `Loader.setSource(file://...)` without adding the plugin directory to the implicit import list. The QML engine threw `ColorPairRow is not a type`, aborting the load. Added `import "."` to both files so the sibling components resolve. Reported by @ajgringo619 (#862)
+- **Hyprland Lua: split configs lost their category headers** (`require("modules.keybinds")` resolved as `modules.keybinds.lua` instead of `modules/keybinds.lua`). Lua's `require` treats dots as path separators; the parser now converts them before resolving, so configs that split binds into submodules — e.g. `hyprland.lua` -> `require("modules.keybinds")` -> `modules/keybinds.lua` — pick up their `-- N. CATEGORY` headers and binds land in the correct categories instead of all falling into "Other". Reported by @ajgringo619 (#862)
+
 ## [3.7.1] - 2026-05-20
 
 ### Fixes

--- a/keybind-cheatsheet/ColorPairRow.qml
+++ b/keybind-cheatsheet/ColorPairRow.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 import qs.Commons
 import qs.Widgets
+import "." as Local
 
 // Label + background pill + text pill + reset. Used by Settings.qml for per-category
 // color customization. Empty bgValue/textValue means "use fallback".
@@ -38,7 +39,7 @@ RowLayout {
     elide: Text.ElideRight
   }
 
-  ColorPill {
+  Local.ColorPill {
     Layout.preferredWidth: 130 * Style.uiScaleRatio
     visible: row.showBg
     screen: row.screen
@@ -51,7 +52,7 @@ RowLayout {
     onPasteRequested: hex => row.bgPasted(hex)
   }
 
-  ColorPill {
+  Local.ColorPill {
     Layout.preferredWidth: 130 * Style.uiScaleRatio
     visible: row.showText
     screen: row.screen

--- a/keybind-cheatsheet/Main.qml
+++ b/keybind-cheatsheet/Main.qml
@@ -735,11 +735,16 @@ Item {
         for (var i = 0; i < root.currentLines.length; i++) {
           var line = root.currentLines[i];
 
-          // require("module") / require 'module' -> sibling <module>.lua
+          // require("a.b.c") / require 'a/b/c' -> a/b/c.lua relative to current file.
+          // Lua module names use dots as path separators; literal paths (with /) and
+          // .lua suffixes are passed through unchanged.
           var reqMatch = line.match(/require\s*\(?\s*["']([^"']+)["']/);
           if (reqMatch) {
             var mod = reqMatch[1];
-            if (!mod.endsWith(".lua")) mod = mod + ".lua";
+            if (!mod.endsWith(".lua")) {
+              if (mod.indexOf("/") === -1) mod = mod.replace(/\./g, "/");
+              mod = mod + ".lua";
+            }
             var resolved = root.resolveRelativePath(currentFilePath, mod);
             if (!root.parsedFiles[resolved] && root.filesToParse.indexOf(resolved) === -1) {
               root.filesToParse.push(resolved);

--- a/keybind-cheatsheet/Settings.qml
+++ b/keybind-cheatsheet/Settings.qml
@@ -6,6 +6,7 @@ import Quickshell.Io
 import qs.Commons
 import qs.Widgets
 import qs.Services.UI
+import "." as Local
 
 ColumnLayout {
   id: root
@@ -1056,7 +1057,7 @@ ColumnLayout {
           }
 
           // Super (modifier: empty bg = theme accent)
-          ColorPairRow {
+          Local.ColorPairRow {
             pluginApi: root.pluginApi
             labelText: pluginApi?.tr("settings.color-super")
             letter: "S"
@@ -1076,7 +1077,7 @@ ColumnLayout {
           }
 
           // Ctrl
-          ColorPairRow {
+          Local.ColorPairRow {
             pluginApi: root.pluginApi
             labelText: pluginApi?.tr("settings.color-ctrl")
             letter: "C"
@@ -1096,7 +1097,7 @@ ColumnLayout {
           }
 
           // Shift
-          ColorPairRow {
+          Local.ColorPairRow {
             pluginApi: root.pluginApi
             labelText: pluginApi?.tr("settings.color-shift")
             letter: "⇧"
@@ -1116,7 +1117,7 @@ ColumnLayout {
           }
 
           // Alt
-          ColorPairRow {
+          Local.ColorPairRow {
             pluginApi: root.pluginApi
             labelText: pluginApi?.tr("settings.color-alt")
             letter: "A"
@@ -1137,7 +1138,7 @@ ColumnLayout {
           }
 
           // XF86
-          ColorPairRow {
+          Local.ColorPairRow {
             pluginApi: root.pluginApi
             labelText: pluginApi?.tr("settings.color-xf86")
             letter: "♪"
@@ -1158,7 +1159,7 @@ ColumnLayout {
           }
 
           // Print
-          ColorPairRow {
+          Local.ColorPairRow {
             pluginApi: root.pluginApi
             labelText: pluginApi?.tr("settings.color-print")
             letter: "P"
@@ -1179,7 +1180,7 @@ ColumnLayout {
           }
 
           // Numeric
-          ColorPairRow {
+          Local.ColorPairRow {
             pluginApi: root.pluginApi
             labelText: pluginApi?.tr("settings.color-numeric")
             letter: "1"
@@ -1200,7 +1201,7 @@ ColumnLayout {
           }
 
           // Mouse
-          ColorPairRow {
+          Local.ColorPairRow {
             pluginApi: root.pluginApi
             labelText: pluginApi?.tr("settings.color-mouse")
             letter: "M"
@@ -1221,7 +1222,7 @@ ColumnLayout {
           }
 
           // Default letter keys
-          ColorPairRow {
+          Local.ColorPairRow {
             pluginApi: root.pluginApi
             labelText: pluginApi?.tr("settings.color-default")
             letter: "Q"
@@ -1242,7 +1243,7 @@ ColumnLayout {
           }
 
           // Description text (text-only row — no background)
-          ColorPairRow {
+          Local.ColorPairRow {
             pluginApi: root.pluginApi
             labelText: pluginApi?.tr("settings.color-description")
             letter: "T"

--- a/keybind-cheatsheet/manifest.json
+++ b/keybind-cheatsheet/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "keybind-cheatsheet",
   "name": "Keybind Cheatsheet",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "minNoctaliaVersion": "3.6.0",
   "author": "blacku",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Fixes two regressions reported in #862:

1. **Settings panel rendered empty.** `Settings.qml` and `ColorPairRow.qml` reference sibling components (`ColorPairRow`, `ColorPill`) but Quickshell's `NPluginSettingsPopup` loads them via `Loader.setSource(file://...)` and **does not** add the plugin directory to the QML engine's implicit import list. The engine raised `ColorPairRow is not a type` and aborted the load, leaving the popup empty. Fixed by adding `import "." as Local` to both files and using `Local.ColorPairRow` / `Local.ColorPill`. A plain `import "."` is unsafe here — the plugin's own `Settings.qml` collides with the global `qs.Commons.Settings` singleton (`qmldir defines type as singleton, but no pragma Singleton found in type Settings`). The namespace alias avoids the conflict.

2. **Hyprland Lua: split configs lost their categories.** The Lua parser treated `require("modules.keybinds")` literally as `modules.keybinds.lua` instead of the Lua-standard `modules/keybinds.lua`. For users who split their config into submodules — `hyprland.lua` → `require("modules.keybinds")` → `modules/keybinds.lua` — the file with `-- N. CATEGORY` headers was never read, so `descToCategory` stayed empty and every `hyprctl binds -j` entry fell back to "Other". The `require` handler now converts dots to path separators before resolving (the standard Lua semantic). Existing one-file configs and explicit-path requires (`require("foo/bar")`) are unaffected.
