### PR TITLE
fix(daily-wallpaper): download location

### DIFF
--- a/daily-wallpaper/Main.qml
+++ b/daily-wallpaper/Main.qml
@@ -164,7 +164,7 @@ Item {
             throw new Error("HOME environment variable is not available");
         }
 
-        const wpDir = `${homeDir}/Pictures/Wallpapers`;
+        const wpDir = `${homeDir}/.config/noctalia/plugins/daily-wallpaper/downloads`;
         const wpFile = `${wpDir}/${prefix}-${dateString}.jpg`;
 
         root.wallpaperTask = {

--- a/daily-wallpaper/manifest.json
+++ b/daily-wallpaper/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "daily-wallpaper",
   "name": "Daily Wallpaper",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "minNoctaliaVersion": "4.6.6",
   "author": "DigitallyRefined",
   "license": "MIT",


### PR DESCRIPTION
Fixes: https://github.com/noctalia-dev/noctalia-plugins/discussions/836

`~/Pictures` does not always exist for all users, for example users can customize their Pictures folder location based on their language or personal preference.

This PR changes the wallpaper download location to use this plugins storage folder: `~/.config/noctalia/plugins/daily-wallpaper/downloads`