### PR TITLE
fix(keybind-cheatsheet): theme-aware description color + Mango binds= variant (v3.7.3)

### DIFF
--- a/keybind-cheatsheet/CHANGELOG.md
+++ b/keybind-cheatsheet/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.7.3] - 2026-05-25
+
+### Fixes
+
+- **Niri: descriptions invisible on light/transparent backgrounds.** Since v3.5.0 the description text color defaulted to a hardcoded `#E0E0E0` (light gray), which is unreadable on light wallpapers shining through a transparent panel. Default is now empty → falls back to `Color.mOnSurface` (theme-aware, always readable). Existing users with a baked-in `#E0E0E0` in their `settings.json` should hit **Reset** on the Description color in Settings → Appearance to pick up the theme-aware default. Reported by @porcaror (#884)
+- **MangoWC: `binds=` / `axisbinds=` / `mousebinds=` (plural) directives now parsed.** MangoWC has two directive families: singular (keycode, QWERTY-mapped) and plural (keysym, layout-aware — used by AZERTY and other non-QWERTY layouts). The parser previously only matched the singular form, so AZERTY configs showed no binds. Both forms are now recognised. Reported by @Pintjebier (#881)
+
 ## [3.7.2] - 2026-05-21
 
 ### Fixes

--- a/keybind-cheatsheet/Main.qml
+++ b/keybind-cheatsheet/Main.qml
@@ -1539,8 +1539,9 @@ Item {
         if (effectiveLine.length === 0) continue;
       }
 
-      // bind=MODS,KEY,ACTION,ARGS
-      var bindMatch = effectiveLine.match(/^bind\s*=\s*(.+)$/);
+      // bind=MODS,KEY,ACTION,ARGS  (also `binds=` — keysym-based variant
+      // used by layout-aware setups like AZERTY)
+      var bindMatch = effectiveLine.match(/^binds?\s*=\s*(.+)$/);
       if (bindMatch) {
         var parts = bindMatch[1].split(',');
         if (parts.length >= 3) {
@@ -1558,8 +1559,8 @@ Item {
         continue;
       }
 
-      // axisbind=MODS,AXIS,ACTION,ARGS
-      var axisMatch = effectiveLine.match(/^axisbind\s*=\s*(.+)$/);
+      // axisbind=MODS,AXIS,ACTION,ARGS  (also `axisbinds=` keysym variant)
+      var axisMatch = effectiveLine.match(/^axisbinds?\s*=\s*(.+)$/);
       if (axisMatch) {
         var axisParts = axisMatch[1].split(',');
         if (axisParts.length >= 3) {
@@ -1578,8 +1579,8 @@ Item {
         continue;
       }
 
-      // mousebind=MODS,BTN,ACTION,ARGS
-      var mouseMatch = effectiveLine.match(/^mousebind\s*=\s*(.+)$/);
+      // mousebind=MODS,BTN,ACTION,ARGS  (also `mousebinds=` keysym variant)
+      var mouseMatch = effectiveLine.match(/^mousebinds?\s*=\s*(.+)$/);
       if (mouseMatch) {
         var mouseParts = mouseMatch[1].split(',');
         if (mouseParts.length >= 3) {

--- a/keybind-cheatsheet/Panel.qml
+++ b/keybind-cheatsheet/Panel.qml
@@ -140,7 +140,10 @@ Item {
   readonly property string keyColorShiftOverride: cfg.keyColorShift ?? defaults.keyColorShift ?? ""
   readonly property color keyColorDefault: cfg.keyColorDefault || defaults.keyColorDefault || "#6C757D"
   readonly property color keyLabelColor:   cfg.keyLabelColor   || defaults.keyLabelColor   || "#FFFFFF"
-  readonly property color descriptionTextColor: cfg.descriptionTextColor || defaults.descriptionTextColor || "#E0E0E0"
+  // Empty string = theme-aware fallback (Color.mOnSurface). Any non-empty
+  // value is treated as an explicit user override.
+  readonly property string descriptionColorOverride: cfg.descriptionTextColor || defaults.descriptionTextColor || ""
+  readonly property color descriptionTextColor: descriptionColorOverride !== "" ? descriptionColorOverride : Color.mOnSurface
 
   // Per-category text color overrides (empty = fall back to keyLabelColor)
   readonly property string keyTextSuperOverride:   cfg.keyTextSuper   ?? defaults.keyTextSuper   ?? ""

--- a/keybind-cheatsheet/Settings.qml
+++ b/keybind-cheatsheet/Settings.qml
@@ -67,7 +67,7 @@ ColumnLayout {
   property string valueKeyTextMouse:   cfg.keyTextMouse   ?? defaults.keyTextMouse   ?? ""
   property string valueKeyTextDefault: cfg.keyTextDefault ?? defaults.keyTextDefault ?? ""
   property string valueKeyLabelColor:  cfg.keyLabelColor  ?? defaults.keyLabelColor  ?? "#FFFFFF"
-  property string valueDescriptionTextColor: cfg.descriptionTextColor ?? defaults.descriptionTextColor ?? "#E0E0E0"
+  property string valueDescriptionTextColor: cfg.descriptionTextColor ?? defaults.descriptionTextColor ?? ""
 
   // Clipboard polling for quick-paste feature.
   // Reads wl-paste periodically while Settings is visible; exposes a validated hex if found.
@@ -1243,6 +1243,7 @@ ColumnLayout {
           }
 
           // Description text (text-only row — no background)
+          // Empty value = theme-aware (Color.mOnSurface) at render time.
           Local.ColorPairRow {
             pluginApi: root.pluginApi
             labelText: pluginApi?.tr("settings.color-description")
@@ -1250,13 +1251,12 @@ ColumnLayout {
             showBg: false
             bgValue: ""
             textValue: root.valueDescriptionTextColor
-            textFallback: defaults.descriptionTextColor || "#E0E0E0"
+            textFallback: Color.mOnSurface
             clipboardHex: root.clipboardHex
             onTextPicked: c => { root.valueDescriptionTextColor = c.toString(); root._applyPreview("descriptionTextColor", c.toString()); }
             onTextPasted: hex => { root.valueDescriptionTextColor = hex; root._applyPreview("descriptionTextColor", hex); }
             onResetRequested: {
-              var d = defaults.descriptionTextColor || "#E0E0E0";
-              root.valueDescriptionTextColor = d; root._applyPreview("descriptionTextColor", d);
+              root.valueDescriptionTextColor = ""; root._applyPreview("descriptionTextColor", "");
             }
           }
 
@@ -1279,7 +1279,7 @@ ColumnLayout {
               var dMouse   = defaults.keyColorMouse   || "#F38181";
               var dDefault = defaults.keyColorDefault || "#6C757D";
               var dLabel   = defaults.keyLabelColor   || "#FFFFFF";
-              var dDesc    = defaults.descriptionTextColor || "#E0E0E0";
+              var dDesc    = defaults.descriptionTextColor ?? "";
 
               root.valueKeyColorSuper = "";
               root.valueKeyColorCtrl = "";

--- a/keybind-cheatsheet/manifest.json
+++ b/keybind-cheatsheet/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "keybind-cheatsheet",
   "name": "Keybind Cheatsheet",
-  "version": "3.7.2",
+  "version": "3.7.3",
   "minNoctaliaVersion": "3.6.0",
   "author": "blacku",
   "license": "MIT",
@@ -62,7 +62,7 @@
       "keyTextNumeric": "",
       "keyTextMouse": "",
       "keyTextDefault": "",
-      "descriptionTextColor": "#E0E0E0",
+      "descriptionTextColor": "",
       "bindOverrides": {}
     }
   }


### PR DESCRIPTION
## Summary

Two reported regressions/gaps in the keybind-cheatsheet plugin.

### #884 — Niri descriptions invisible on light/transparent backgrounds
- Since v3.5.0 the description text color defaulted to a hardcoded `#E0E0E0` (light gray)
- On light wallpapers shining through a semi-transparent panel, the text is unreadable
- Confirmed against @porcaror's `settings.json` + screenshot: descriptions are present in `cheatsheetData`, just rendered in invisible gray
- **Fix:** manifest default is now empty → `Panel.qml` falls back to `Color.mOnSurface` (theme-aware). `Settings.qml` Reset clears to empty so the theme-aware fallback kicks in
- Existing users with the baked-in `#E0E0E0` should hit Reset on the Description color in Settings → Appearance

### #881 — MangoWC `binds=` (plural, keysym-based) directives not parsed
- MangoWC has two directive families: singular (`bind=`, keycode/QWERTY-mapped) and plural (`binds=`, keysym/layout-aware)
- AZERTY (and other non-QWERTY) users have to use the plural form; the parser only matched the singular one, so the cheatsheet showed no binds
- **Fix:** regex now accepts both forms for `bind`, `axisbind`, and `mousebind`