### PR TITLE
feat(mini-docker): add customizable icon, active/inactive indicator colors, and status states

### DIFF
--- a/mini-docker/BarWidget.qml
+++ b/mini-docker/BarWidget.qml
@@ -26,7 +26,15 @@ Item {
     property bool allowClickWhenDisabled: false
     property bool hovering: false
     property color colorBg: Color.mSurfaceVariant
-    property color colorFg: Color.mPrimary
+    property var cfg: pluginApi?.pluginSettings || ({})
+    property var defaults: pluginApi?.manifest?.metadata?.defaultSettings || ({})
+    readonly property string iconColorKey: cfg.iconColor ?? defaults.iconColor ?? "none"
+    readonly property string statusStateKey: cfg.statusState ?? defaults.statusState ?? "all"
+    property color colorFg: Color.resolveColorKey(iconColorKey)
+    readonly property string activeColorKey: cfg.activeColor ?? defaults.activeColor ?? "success"
+    readonly property string inactiveColorKey: cfg.inactiveColor ?? defaults.inactiveColor ?? "error"
+    readonly property color activeColor: Color.resolveColorKey(activeColorKey)
+    readonly property color inactiveColor: Color.resolveColorKey(inactiveColorKey)
     property color colorBgHover: Color.mHover
     property color colorFgHover: Color.mOnHover
     property color colorBorder: Color.mOutline
@@ -126,8 +134,8 @@ Item {
             width: 6
             height: 6
             radius: 3
-            color: runningCount > 0 ? "#4caf50" : "#f44336"
-            visible: dockerAvailable
+            color: runningCount > 0 ? activeColor : inactiveColor
+            visible: dockerAvailable && statusStateKey !== "hidden" && (statusStateKey !== "running-only" || runningCount > 0)
             border.width: 1
             border.color: visualCapsule.color
         }

--- a/mini-docker/Settings.qml
+++ b/mini-docker/Settings.qml
@@ -7,7 +7,15 @@ ColumnLayout {
     id: root
 
     property var pluginApi: null
-    property int valueRefreshInterval: (pluginApi && pluginApi.pluginSettings) ? pluginApi.pluginSettings.refreshInterval : 5000
+
+    property var cfg: pluginApi?.pluginSettings || ({})
+    property var defaults: pluginApi?.manifest?.metadata?.defaultSettings || ({})
+
+    property int valueRefreshInterval: cfg.refreshInterval ?? defaults.refreshInterval ?? 5000
+    property string iconColor: cfg.iconColor ?? defaults.iconColor ?? "none"
+    property string statusState: cfg.statusState ?? defaults.statusState ?? "all"
+    property string activeColor: cfg.activeColor ?? defaults.activeColor ?? "success"
+    property string inactiveColor: cfg.inactiveColor ?? defaults.inactiveColor ?? "error"
 
     function saveSettings() {
         if (!pluginApi) {
@@ -15,6 +23,10 @@ ColumnLayout {
             return ;
         }
         pluginApi.pluginSettings.refreshInterval = root.valueRefreshInterval;
+        pluginApi.pluginSettings.iconColor = root.iconColor;
+        pluginApi.pluginSettings.statusState = root.statusState;
+        pluginApi.pluginSettings.activeColor = root.activeColor;
+        pluginApi.pluginSettings.inactiveColor = root.inactiveColor;
         pluginApi.saveSettings();
         Logger.i("MiniDocker", "Settings saved successfully");
     }
@@ -73,6 +85,52 @@ ColumnLayout {
             font.pointSize: Style.fontSizeS
         }
 
+    }
+
+    NColorChoice {
+        Layout.fillWidth: true
+        label: pluginApi?.tr("settings.icon_color_label")
+        description: pluginApi?.tr("settings.icon_color_description")
+        currentKey: root.iconColor
+        onSelected: key => root.iconColor = key
+    }
+
+    NColorChoice {
+        Layout.fillWidth: true
+        label: pluginApi?.tr("settings.active_color_label")
+        description: pluginApi?.tr("settings.active_color_description")
+        currentKey: root.activeColor
+        onSelected: key => root.activeColor = key
+    }
+
+    NColorChoice {
+        Layout.fillWidth: true
+        label: pluginApi?.tr("settings.inactive_color_label")
+        description: pluginApi?.tr("settings.inactive_color_description")
+        currentKey: root.inactiveColor
+        onSelected: key => root.inactiveColor = key
+    }
+
+    NComboBox {
+        Layout.fillWidth: true
+        label: pluginApi?.tr("settings.status_state_label")
+        description: pluginApi?.tr("settings.status_state_description")
+        model: [
+            {
+                "key": "all",
+                "name": pluginApi?.tr("settings.status_state_always")
+            },
+            {
+                "key": "running-only",
+                "name": pluginApi?.tr("settings.status_state_running_only")
+            },
+            {
+                "key": "hidden",
+                "name": pluginApi?.tr("settings.status_state_hidden")
+            }
+        ]
+        currentKey: root.statusState
+        onSelected: key => root.statusState = key
     }
 
 }

--- a/mini-docker/i18n/de.json
+++ b/mini-docker/i18n/de.json
@@ -1,11 +1,22 @@
 {
   "settings": {
+    "active_color_description": "Color of the status indicator when active (running)",
+    "active_color_label": "Active Indicator Color",
     "current_value": "Ausgewählt: {value} ms",
     "default_network_description": "Default network to use when running images",
     "default_network_label": "Default Network",
     "general": "Allgemein",
+    "icon_color_description": "Change the color of the Bar widget icon",
+    "icon_color_label": "Icon Color",
+    "inactive_color_description": "Color of the status indicator when inactive (stopped)",
+    "inactive_color_label": "Inactive Indicator Color",
     "refresh_interval_description": "Wie oft das Plugin den Containerstatus überprüft",
     "refresh_interval_label": "Aktualisierungsintervall",
+    "status_state_always": "Always show",
+    "status_state_description": "Choose how to display the status indicator dot",
+    "status_state_hidden": "Hide completely",
+    "status_state_label": "Status State",
+    "status_state_running_only": "Show when running",
     "title": "Container Manager Einstellungen"
   },
   "tooltip": {

--- a/mini-docker/i18n/en.json
+++ b/mini-docker/i18n/en.json
@@ -1,11 +1,22 @@
 {
   "settings": {
+    "active_color_description": "Color of the status indicator when active (running)",
+    "active_color_label": "Active Indicator Color",
     "current_value": "Selected: {value} ms",
     "default_network_description": "Default network to use when running images",
     "default_network_label": "Default Network",
     "general": "General",
+    "icon_color_description": "Change the color of the Bar widget icon",
+    "icon_color_label": "Icon Color",
+    "inactive_color_description": "Color of the status indicator when inactive (stopped)",
+    "inactive_color_label": "Inactive Indicator Color",
     "refresh_interval_description": "How often the plugin checks for container status changes",
     "refresh_interval_label": "Refresh Interval",
+    "status_state_always": "Always show",
+    "status_state_description": "Choose how to display the status indicator dot",
+    "status_state_hidden": "Hide completely",
+    "status_state_label": "Status State",
+    "status_state_running_only": "Show when running",
     "title": "Container Manager Settings"
   },
   "tooltip": {

--- a/mini-docker/i18n/es.json
+++ b/mini-docker/i18n/es.json
@@ -1,11 +1,22 @@
 {
   "settings": {
+    "active_color_description": "Color of the status indicator when active (running)",
+    "active_color_label": "Active Indicator Color",
     "current_value": "Seleccionado: {value} ms",
     "default_network_description": "Default network to use when running images",
     "default_network_label": "Default Network",
     "general": "General",
+    "icon_color_description": "Change the color of the Bar widget icon",
+    "icon_color_label": "Icon Color",
+    "inactive_color_description": "Color of the status indicator when inactive (stopped)",
+    "inactive_color_label": "Inactive Indicator Color",
     "refresh_interval_description": "Con qué frecuencia el plugin verifica el estado de los contenedores",
     "refresh_interval_label": "Intervalo de actualización",
+    "status_state_always": "Always show",
+    "status_state_description": "Choose how to display the status indicator dot",
+    "status_state_hidden": "Hide completely",
+    "status_state_label": "Status State",
+    "status_state_running_only": "Show when running",
     "title": "Configuración del Administrador de Contenedores"
   },
   "tooltip": {

--- a/mini-docker/i18n/fr.json
+++ b/mini-docker/i18n/fr.json
@@ -1,11 +1,22 @@
 {
   "settings": {
+    "active_color_description": "Color of the status indicator when active (running)",
+    "active_color_label": "Active Indicator Color",
     "current_value": "Sélectionné: {value} ms",
     "default_network_description": "Réseau par défaut à utiliser lors de l'exécution d'images",
     "default_network_label": "Réseau par Défaut",
     "general": "Général",
+    "icon_color_description": "Change the color of the Bar widget icon",
+    "icon_color_label": "Icon Color",
+    "inactive_color_description": "Color of the status indicator when inactive (stopped)",
+    "inactive_color_label": "Inactive Indicator Color",
     "refresh_interval_description": "À quelle fréquence le plugin vérifie l'état des conteneurs",
     "refresh_interval_label": "Intervalle de rafraîchissement",
+    "status_state_always": "Always show",
+    "status_state_description": "Choose how to display the status indicator dot",
+    "status_state_hidden": "Hide completely",
+    "status_state_label": "Status State",
+    "status_state_running_only": "Show when running",
     "title": "Paramètres du Gestionnaire de Conteneurs"
   },
   "tooltip": {

--- a/mini-docker/i18n/hu.json
+++ b/mini-docker/i18n/hu.json
@@ -1,11 +1,22 @@
 {
   "settings": {
+    "active_color_description": "Color of the status indicator when active (running)",
+    "active_color_label": "Active Indicator Color",
     "current_value": "Kiválasztva: {value} ms",
     "default_network_description": "Alapértelmezett hálózat a képek futtatásához",
     "default_network_label": "Alapértelmezett hálózat",
     "general": "Általános",
+    "icon_color_description": "Change the color of the Bar widget icon",
+    "icon_color_label": "Icon Color",
+    "inactive_color_description": "Color of the status indicator when inactive (stopped)",
+    "inactive_color_label": "Inactive Indicator Color",
     "refresh_interval_description": "Milyen gyakran ellenőrzi a bővítmény a konténer állapotváltozásait",
     "refresh_interval_label": "Frissítési időköz",
+    "status_state_always": "Always show",
+    "status_state_description": "Choose how to display the status indicator dot",
+    "status_state_hidden": "Hide completely",
+    "status_state_label": "Status State",
+    "status_state_running_only": "Show when running",
     "title": "Konténerkezelő beállításai"
   },
   "tooltip": {

--- a/mini-docker/i18n/it.json
+++ b/mini-docker/i18n/it.json
@@ -1,11 +1,22 @@
 {
   "settings": {
+    "active_color_description": "Color of the status indicator when active (running)",
+    "active_color_label": "Active Indicator Color",
     "current_value": "Zgjodhur: {value} ms",
     "default_network_description": "Netzwerkstandard für die Ausführung von Images",
     "default_network_label": "Netzstandard",
     "general": "Ġeneralo",
+    "icon_color_description": "Change the color of the Bar widget icon",
+    "icon_color_label": "Icon Color",
+    "inactive_color_description": "Color of the status indicator when inactive (stopped)",
+    "inactive_color_label": "Inactive Indicator Color",
     "refresh_interval_description": "Sa unsang kasubsub ang plugin nagsusi sa mga kausaban sa kahimtang sa sudlanan",
     "refresh_interval_label": "Interval rifreskoje",
+    "status_state_always": "Always show",
+    "status_state_description": "Choose how to display the status indicator dot",
+    "status_state_hidden": "Hide completely",
+    "status_state_label": "Status State",
+    "status_state_running_only": "Show when running",
     "title": "Mga Setting ng Tagapamahala ng Lalagyan"
   },
   "tooltip": {

--- a/mini-docker/i18n/ja.json
+++ b/mini-docker/i18n/ja.json
@@ -1,11 +1,22 @@
 {
   "settings": {
+    "active_color_description": "Color of the status indicator when active (running)",
+    "active_color_label": "Active Indicator Color",
     "current_value": "選択済み: {value} ms",
     "default_network_description": "イメージの実行時に使用するデフォルトネットワーク",
     "default_network_label": "デフォルトネットワーク",
     "general": "一般",
+    "icon_color_description": "Change the color of the Bar widget icon",
+    "icon_color_label": "Icon Color",
+    "inactive_color_description": "Color of the status indicator when inactive (stopped)",
+    "inactive_color_label": "Inactive Indicator Color",
     "refresh_interval_description": "プラグインがコンテナの状態をチェックする頻度",
     "refresh_interval_label": "更新間隔",
+    "status_state_always": "Always show",
+    "status_state_description": "Choose how to display the status indicator dot",
+    "status_state_hidden": "Hide completely",
+    "status_state_label": "Status State",
+    "status_state_running_only": "Show when running",
     "title": "コンテナマネージャー設定"
   },
   "tooltip": {

--- a/mini-docker/i18n/ku.json
+++ b/mini-docker/i18n/ku.json
@@ -1,11 +1,22 @@
 {
   "settings": {
+    "active_color_description": "Color of the status indicator when active (running)",
+    "active_color_label": "Active Indicator Color",
     "current_value": "Hilbijartî: {value} ms",
     "default_network_description": "Tora şebekeya ku dema wêneyan dimeşîne were bikar anîn",
     "default_network_label": "Tora Şebekeyî",
     "general": "Giştî",
+    "icon_color_description": "Change the color of the Bar widget icon",
+    "icon_color_label": "Icon Color",
+    "inactive_color_description": "Color of the status indicator when inactive (stopped)",
+    "inactive_color_label": "Inactive Indicator Color",
     "refresh_interval_description": "Plugin çiqas caran guherînên rewşa konteynerê kontrol dike",
     "refresh_interval_label": "Demê Nûkirinê",
+    "status_state_always": "Always show",
+    "status_state_description": "Choose how to display the status indicator dot",
+    "status_state_hidden": "Hide completely",
+    "status_state_label": "Status State",
+    "status_state_running_only": "Show when running",
     "title": "Mîhengên Birêvebirê Konteyner"
   },
   "tooltip": {

--- a/mini-docker/i18n/nl.json
+++ b/mini-docker/i18n/nl.json
@@ -1,11 +1,22 @@
 {
   "settings": {
+    "active_color_description": "Color of the status indicator when active (running)",
+    "active_color_label": "Active Indicator Color",
     "current_value": "Geselecteerd: {value} ms",
     "default_network_description": "Standaardnetwerk dat gebruikt moet worden bij het uitvoeren van images",
     "default_network_label": "Standaardnetwerk",
     "general": "Algemeen",
+    "icon_color_description": "Change the color of the Bar widget icon",
+    "icon_color_label": "Icon Color",
+    "inactive_color_description": "Color of the status indicator when inactive (stopped)",
+    "inactive_color_label": "Inactive Indicator Color",
     "refresh_interval_description": "Hoe vaak de plugin de containerstatus controleert",
     "refresh_interval_label": "Vernieuwingsinterval",
+    "status_state_always": "Always show",
+    "status_state_description": "Choose how to display the status indicator dot",
+    "status_state_hidden": "Hide completely",
+    "status_state_label": "Status State",
+    "status_state_running_only": "Show when running",
     "title": "Container Manager Instellingen"
   },
   "tooltip": {

--- a/mini-docker/i18n/pl.json
+++ b/mini-docker/i18n/pl.json
@@ -1,11 +1,22 @@
 {
   "settings": {
+    "active_color_description": "Color of the status indicator when active (running)",
+    "active_color_label": "Active Indicator Color",
     "current_value": "Wybrano: {value} ms",
     "default_network_description": "Domyślna sieć do użycia podczas uruchamiania obrazów",
     "default_network_label": "Domyślna Sieć",
     "general": "Ogólne",
+    "icon_color_description": "Change the color of the Bar widget icon",
+    "icon_color_label": "Icon Color",
+    "inactive_color_description": "Color of the status indicator when inactive (stopped)",
+    "inactive_color_label": "Inactive Indicator Color",
     "refresh_interval_description": "Jak często wtyczka sprawdza zmiany stanu kontenera",
     "refresh_interval_label": "Interwał odświeżania",
+    "status_state_always": "Always show",
+    "status_state_description": "Choose how to display the status indicator dot",
+    "status_state_hidden": "Hide completely",
+    "status_state_label": "Status State",
+    "status_state_running_only": "Show when running",
     "title": "Ustawienia Menedżera Kontenerów"
   },
   "tooltip": {

--- a/mini-docker/i18n/pt.json
+++ b/mini-docker/i18n/pt.json
@@ -1,11 +1,22 @@
 {
   "settings": {
+    "active_color_description": "Color of the status indicator when active (running)",
+    "active_color_label": "Active Indicator Color",
     "current_value": "Selecionado: {value} ms",
     "default_network_description": "Rede padrão a ser usada ao executar imagens",
     "default_network_label": "Rede Padrão",
     "general": "Geral",
+    "icon_color_description": "Change the color of the Bar widget icon",
+    "icon_color_label": "Icon Color",
+    "inactive_color_description": "Color of the status indicator when inactive (stopped)",
+    "inactive_color_label": "Inactive Indicator Color",
     "refresh_interval_description": "Com que frequência o plugin verifica o status dos contêineres",
     "refresh_interval_label": "Intervalo de atualização",
+    "status_state_always": "Always show",
+    "status_state_description": "Choose how to display the status indicator dot",
+    "status_state_hidden": "Hide completely",
+    "status_state_label": "Status State",
+    "status_state_running_only": "Show when running",
     "title": "Configurações do Gerenciador de Contêineres"
   },
   "tooltip": {

--- a/mini-docker/i18n/ru.json
+++ b/mini-docker/i18n/ru.json
@@ -1,11 +1,22 @@
 {
   "settings": {
+    "active_color_description": "Color of the status indicator when active (running)",
+    "active_color_label": "Active Indicator Color",
     "current_value": "Выбрано: {value} мс",
     "default_network_description": "Сеть по умолчанию для запуска образов",
     "default_network_label": "Стандартная сеть",
     "general": "Общие",
+    "icon_color_description": "Change the color of the Bar widget icon",
+    "icon_color_label": "Icon Color",
+    "inactive_color_description": "Color of the status indicator when inactive (stopped)",
+    "inactive_color_label": "Inactive Indicator Color",
     "refresh_interval_description": "Как часто плагин проверяет статус контейнеров",
     "refresh_interval_label": "Интервал обновления",
+    "status_state_always": "Always show",
+    "status_state_description": "Choose how to display the status indicator dot",
+    "status_state_hidden": "Hide completely",
+    "status_state_label": "Status State",
+    "status_state_running_only": "Show when running",
     "title": "Настройки Менеджера Контейнеров"
   },
   "tooltip": {

--- a/mini-docker/i18n/tr.json
+++ b/mini-docker/i18n/tr.json
@@ -1,11 +1,22 @@
 {
   "settings": {
+    "active_color_description": "Color of the status indicator when active (running)",
+    "active_color_label": "Active Indicator Color",
     "current_value": "Seçildi: {value} ms",
     "default_network_description": "Görüntüleri çalıştırırken kullanılacak varsayılan ağ",
     "default_network_label": "Varsayılan Ağ",
     "general": "Genel",
+    "icon_color_description": "Change the color of the Bar widget icon",
+    "icon_color_label": "Icon Color",
+    "inactive_color_description": "Color of the status indicator when inactive (stopped)",
+    "inactive_color_label": "Inactive Indicator Color",
     "refresh_interval_description": "Eklenti konteyner durumunu ne sıklıkta kontrol eder",
     "refresh_interval_label": "Yenileme Aralığı",
+    "status_state_always": "Always show",
+    "status_state_description": "Choose how to display the status indicator dot",
+    "status_state_hidden": "Hide completely",
+    "status_state_label": "Status State",
+    "status_state_running_only": "Show when running",
     "title": "Konteyner Yöneticisi Ayarları"
   },
   "tooltip": {

--- a/mini-docker/i18n/uk-UA.json
+++ b/mini-docker/i18n/uk-UA.json
@@ -1,11 +1,22 @@
 {
   "settings": {
+    "active_color_description": "Color of the status indicator when active (running)",
+    "active_color_label": "Active Indicator Color",
     "current_value": "Обрано: {value} мс",
     "default_network_description": "Мережа за замовчуванням для використання під час запуску образів",
     "default_network_label": "Мережа за замовчуванням",
     "general": "Загальні",
+    "icon_color_description": "Change the color of the Bar widget icon",
+    "icon_color_label": "Icon Color",
+    "inactive_color_description": "Color of the status indicator when inactive (stopped)",
+    "inactive_color_label": "Inactive Indicator Color",
     "refresh_interval_description": "Як часто плагін перевіряє статус контейнерів",
     "refresh_interval_label": "Інтервал оновлення",
+    "status_state_always": "Always show",
+    "status_state_description": "Choose how to display the status indicator dot",
+    "status_state_hidden": "Hide completely",
+    "status_state_label": "Status State",
+    "status_state_running_only": "Show when running",
     "title": "Налаштування Менеджера Контейнерів"
   },
   "tooltip": {

--- a/mini-docker/i18n/zh-CN.json
+++ b/mini-docker/i18n/zh-CN.json
@@ -1,11 +1,22 @@
 {
   "settings": {
+    "active_color_description": "Color of the status indicator when active (running)",
+    "active_color_label": "Active Indicator Color",
     "current_value": "已选择: {value} 毫秒",
     "default_network_description": "运行镜像时使用的默认网络",
     "default_network_label": "默认网络",
     "general": "通用",
+    "icon_color_description": "Change the color of the Bar widget icon",
+    "icon_color_label": "Icon Color",
+    "inactive_color_description": "Color of the status indicator when inactive (stopped)",
+    "inactive_color_label": "Inactive Indicator Color",
     "refresh_interval_description": "插件检查容器状态的频率",
     "refresh_interval_label": "刷新间隔",
+    "status_state_always": "Always show",
+    "status_state_description": "Choose how to display the status indicator dot",
+    "status_state_hidden": "Hide completely",
+    "status_state_label": "Status State",
+    "status_state_running_only": "Show when running",
     "title": "容器管理器设置"
   },
   "tooltip": {

--- a/mini-docker/manifest.json
+++ b/mini-docker/manifest.json
@@ -22,7 +22,11 @@
   },
   "metadata": {
     "defaultSettings": {
-      "refreshInterval": 5000
+      "refreshInterval": 5000,
+      "iconColor": "none",
+      "statusState": "all",
+      "activeColor": "success",
+      "inactiveColor": "error"
     }
   }
 }


### PR DESCRIPTION
### Overview
This PR adds full visual customization to the Mini Docker plugin's Bar widget:

- **Icon Color Selection:** Customize the Docker icon color using standard NColorChoice pickers.
- **Active & Inactive Indicator Colors:** Customize the status dot color when active (running) or inactive (stopped) instead of relying on hardcoded hex values.
- **Status State Toggling:** A dropdown configuration allowing users to always show the dot, hide it completely, or show it only when container(s) are active (hiding inactive state to save space).
- **Concise Translations:** Added configuration keys across all 15 system languages, resolving dropdown text truncation.

### Screenshot

<img width="584" height="408" alt="image" src="https://github.com/user-attachments/assets/b43a2ffd-4161-44d0-9c5e-b654dd0dd9dc" />

### Technical Changes

- **manifest.json:** Defined defaults for iconColor ("none"), statusState ("all"), activeColor ("success"), and inactiveColor ("error").
- **BarWidget.qml:** Updated properties to resolve iconColor directly via Color.resolveColorKey to support default theme colors. Integrated dynamic active/inactive indicators in the status dot color and visible properties.
- **Settings.qml:** Integrated three standard NColorChoice color pickers and one NComboBox dropdown to manage and persist configurations.
- **i18n/*.json:** Added keys for all 15 supported languages, shortening the active state label to "Show when running" to avoid truncation.

### How to Test

1. Open the Mini Docker settings panel.
2. Select different custom colors for the Icon Color, Active Indicator Color, and Inactive Indicator Color, and verify they apply to the bar immediately.
3. Toggle the Status State dropdown choices (Always show, Show when running, Hide completely) and verify correct visibility of the status dot under various active container states.