### PR TITLE
Fix/model usage gemini type error

### DIFF
--- a/model-usage/Main.qml
+++ b/model-usage/Main.qml
@@ -1,6 +1,6 @@
 import QtQuick
 import Quickshell
-import "providers"
+import "providers" as Providers
 
 Item {
     id: root
@@ -9,37 +9,37 @@ Item {
     property var pluginApi: null
     property var pluginSettings: pluginApi?.pluginSettings ?? ({})
 
-    Claude {
+    Providers.Claude {
         id: claudeProvider
         enabled: root.providerEnabled("claude")
         providerSettings: root.pluginSettings?.providers?.claude ?? ({})
     }
 
-    Codex {
+    Providers.Codex {
         id: codexProvider
         enabled: root.providerEnabled("codex")
         providerSettings: root.pluginSettings?.providers?.codex ?? ({})
     }
 
-    OpenRouter {
+    Providers.OpenRouter {
         id: openRouterProvider
         enabled: root.providerEnabled("openrouter")
         providerSettings: root.pluginSettings?.providers?.openrouter ?? ({})
     }
 
-    Copilot {
+    Providers.Copilot {
         id: copilotProvider
         enabled: root.providerEnabled("copilot")
         providerSettings: root.pluginSettings?.providers?.copilot ?? ({})
     }
 
-    Gemini {
+    Providers.Gemini {
         id: geminiProvider
         enabled: root.providerEnabled("gemini")
         providerSettings: root.pluginSettings?.providers?.gemini ?? ({})
     }
 
-    Zen {
+    Providers.Zen {
         id: zenProvider
         enabled: root.providerEnabled("zen")
         providerSettings: root.pluginSettings?.providers?.zen ?? ({})

--- a/model-usage/manifest.json
+++ b/model-usage/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "model-usage",
   "name": "Model Usage",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "minNoctaliaVersion": "3.6.0",
   "author": "cmptr",
   "license": "MIT",


### PR DESCRIPTION
Fixes a settings load error introduced by the recent Gemini provider change.

The Model Usage plugin was instantiating provider components with unqualified QML type names, causing `Gemini` to resolve incorrectly at runtime and fail with `Gemini is not a type`. This namespaces the local provider imports and references them as `Providers.*`, ensuring the new Gemini provider resolves from the plugin’s own `providers/` directory consistently.