### PR TITLE
feat(tailscale): add account switching

### DIFF
--- a/tailscale/Main.qml
+++ b/tailscale/Main.qml
@@ -63,6 +63,10 @@ Item {
   property var _realPeerList: []
   property var exitNodeStatus: null
 
+  property var accounts: []
+  property string currentAccountId: ""
+  property bool accountSwitchInProgress: false
+
   // Dev/testing: override the peer list with a short mock to reproduce few-device layouts.
   // Toggle via: qs -c noctalia-shell ipc call plugin:tailscale setMockPeers
   property bool useMockData: false
@@ -145,6 +149,7 @@ Item {
       root.tailscaleInstalled = (exitCode === 0);
       root.isRefreshing = false;
       updateTailscaleStatus();
+      loadAccounts();
     }
   }
 
@@ -187,6 +192,9 @@ Item {
             root.tailscaleStatus = "Connected";
             root.authUrl = "";
             // Login flow settled — reset flags so the next attempt starts clean
+            if (root._loginInProgress) {
+              loadAccounts();
+            }
             root._loginInProgress = false;
             root._loginUrlOpened = false;
             root._preLoginAuthUrl = "";
@@ -247,6 +255,7 @@ Item {
         root._realPeerList = [];
         root.authUrl = "";
       }
+      root.accountSwitchInProgress = false;
     }
   }
 
@@ -274,6 +283,54 @@ Item {
   }
 
   property string lastExitNodeAction: ""
+
+  // ─── Account switching ──────────────────────────────────────────────────
+
+  Process {
+    id: accountsListProcess
+    stdout: StdioCollector {}
+    stderr: StdioCollector {}
+
+    onExited: function (exitCode, exitStatus) {
+      // Older tailscale binaries may not support this; treat as no accounts.
+      root.accounts = [];
+      root.currentAccountId = "";
+      if (exitCode !== 0) return;
+      var raw = String(accountsListProcess.stdout.text || "").trim();
+      if (raw.length === 0) return;
+      try {
+        var arr = JSON.parse(raw);
+        if (!Array.isArray(arr)) return;
+        root.accounts = arr;
+        for (var i = 0; i < arr.length; i++) {
+          if (arr[i].selected) {
+            root.currentAccountId = arr[i].id || "";
+            break;
+          }
+        }
+      } catch (e) {
+        Logger.e("Tailscale", "Failed to parse accounts: " + e);
+      }
+    }
+  }
+
+  Process {
+    id: switchAccountProcess
+    stdout: StdioCollector {}
+    stderr: StdioCollector {}
+
+    onExited: function (exitCode, exitStatus) {
+      if (exitCode === 0) {
+        ToastService.showNotice(pluginApi?.tr("toast.title"), pluginApi?.tr("toast.account-switched"), "user");
+      } else {
+        var stderr = String(switchAccountProcess.stderr.text || "").trim();
+        Logger.e("Tailscale", "Account switch failed (exit " + exitCode + "): " + stderr);
+        ToastService.showError(pluginApi?.tr("toast.title"), pluginApi?.tr("toast.account-switch-failed"), "alert-circle");
+      }
+      loadAccounts();
+      statusDelayTimer.start();
+    }
+  }
 
   // ─── Login flow state ────────────────────────────────────────────────────
   // A login attempt is tracked across two asynchronous sources that may deliver
@@ -564,6 +621,26 @@ Item {
     exitNodeProcess.running = true;
   }
 
+  function loadAccounts() {
+    if (!root.tailscaleInstalled) {
+      root.accounts = [];
+      root.currentAccountId = "";
+      return;
+    }
+    accountsListProcess.command = ["tailscale", "switch", "--list", "--json"];
+    accountsListProcess.running = true;
+  }
+
+  function switchAccount(id) {
+    if (!root.tailscaleInstalled || !id)
+      return;
+    if (id === root.currentAccountId)
+      return;
+    root.accountSwitchInProgress = true;
+    switchAccountProcess.command = ["tailscale", "switch", id];
+    switchAccountProcess.running = true;
+  }
+
   Timer {
     id: statusDelayTimer
     interval: 500
@@ -701,6 +778,10 @@ Item {
 
     function login() {
       loginTailscale();
+    }
+
+    function switchAccount(id: string) {
+      root.switchAccount(id);
     }
 
     // Taildrop IPC: qs ipc call plugin:tailscale receive

--- a/tailscale/Panel.qml
+++ b/tailscale/Panel.qml
@@ -432,25 +432,19 @@ Item {
             }
           }
 
-          ComboBox {
+          NComboBox {
             Layout.fillWidth: true
             visible: (mainInstance?.accounts?.length ?? 0) >= 2
-            textRole: "name"
             model: (mainInstance?.accounts || []).map(function (a) {
               return { key: a.id, name: a.tailnet || a.account || a.nickname || a.id }
             })
-            currentIndex: {
-              var id = mainInstance?.currentAccountId || ""
-              for (var i = 0; i < model.length; i++) {
-                if (model[i].key === id) return i
-              }
-              return -1
-            }
-            onActivated: function (index) {
-              if (mainInstance && index >= 0 && index < model.length) {
-                mainInstance.switchAccount(model[index].key)
+            currentKey: mainInstance?.currentAccountId || ""
+            onSelected: function (key) {
+              if (mainInstance) {
+                mainInstance.switchAccount(key)
               }
             }
+            Component.onCompleted: comboBox.Layout.fillWidth = true
           }
 
           // Exit node status

--- a/tailscale/Panel.qml
+++ b/tailscale/Panel.qml
@@ -413,7 +413,7 @@ Item {
             pointSize: Style.fontSizeS
             color: mainIpMouseArea.containsMouse ? Color.mPrimary : Color.mOnSurfaceVariant
             font.family: Settings.data.ui.fontFixed
-            
+
             MouseArea {
               id: mainIpMouseArea
               anchors.fill: parent
@@ -428,6 +428,27 @@ Item {
                     "clipboard"
                   )
                 }
+              }
+            }
+          }
+
+          ComboBox {
+            Layout.fillWidth: true
+            visible: (mainInstance?.accounts?.length ?? 0) >= 2
+            textRole: "name"
+            model: (mainInstance?.accounts || []).map(function (a) {
+              return { key: a.id, name: a.tailnet || a.account || a.nickname || a.id }
+            })
+            currentIndex: {
+              var id = mainInstance?.currentAccountId || ""
+              for (var i = 0; i < model.length; i++) {
+                if (model[i].key === id) return i
+              }
+              return -1
+            }
+            onActivated: function (index) {
+              if (mainInstance && index >= 0 && index < model.length) {
+                mainInstance.switchAccount(model[index].key)
               }
             }
           }
@@ -559,6 +580,12 @@ Item {
             interactive: contentHeight > height
             boundsBehavior: Flickable.StopAtBounds
             pressDelay: 0
+            enabled: !(mainInstance?.accountSwitchInProgress ?? false)
+            opacity: enabled ? 1.0 : 0.4
+
+            Behavior on opacity {
+              NumberAnimation { duration: Style.animationFast }
+            }
 
               ColumnLayout {
               id: peerListColumn

--- a/tailscale/README.md
+++ b/tailscale/README.md
@@ -16,6 +16,7 @@ A Tailscale status plugin for Noctalia that shows your Tailscale connection stat
 - **Node Search**: Optionally filter the panel node list by hostname, DNS name, Tailscale name, IP address, or OS
 - **Taildrop Receive**: Toggle file receiving from the panel
 - **Exit Node Management**: Activate/deactivate exit nodes from the panel
+- **Account Switching**: When multiple Tailscale accounts are logged in locally, a dropdown appears in the panel to switch between them via `tailscale switch`
 - **Context Menu**: Right-click for additional options (connect, disconnect, refresh, settings)
 - **Configurable Refresh**: Customize how often the plugin checks Tailscale status
 - **Compact Mode**: Option to show only the icon for a minimal display
@@ -94,6 +95,7 @@ qs -c noctalia-shell ipc call plugin:tailscale <command>
 | `status` | Get current Tailscale status | `qs -c noctalia-shell ipc call plugin:tailscale status` |
 | `refresh` | Force refresh Tailscale status | `qs -c noctalia-shell ipc call plugin:tailscale refresh` |
 | `login` | Trigger Tailscale login (opens browser) | `qs -c noctalia-shell ipc call plugin:tailscale login` |
+| `switchAccount` | Switch to a Tailscale account by id (see `tailscale switch --list`) | `qs -c noctalia-shell ipc call plugin:tailscale switchAccount a585` |
 | `receive` | Fetch any pending Taildrop files | `qs -c noctalia-shell ipc call plugin:tailscale receive` |
 
 ## Usage

--- a/tailscale/i18n/de.json
+++ b/tailscale/i18n/de.json
@@ -74,7 +74,9 @@
       "message": "Bitte leg einen Terminalbefehl in den Plugin Einstellungen fest"
     },
     "login-browser-opened": "Authentifizierungsseite im Browser geöffnet",
-    "login-failed": "Anmeldung fehlgeschlagen"
+    "login-failed": "Anmeldung fehlgeschlagen",
+    "account-switched": "Tailscale-Konto gewechselt",
+    "account-switch-failed": "Konnte Tailscale-Konto nicht wechseln"
   },
   "panel": {
     "title": "Tailscale Netzwerk",

--- a/tailscale/i18n/en.json
+++ b/tailscale/i18n/en.json
@@ -74,7 +74,9 @@
       "message": "Please set a terminal command in plugin settings"
     },
     "login-browser-opened": "Authentication page opened in browser",
-    "login-failed": "Login failed"
+    "login-failed": "Login failed",
+    "account-switched": "Switched Tailscale account",
+    "account-switch-failed": "Failed to switch Tailscale account"
   },
   "panel": {
     "title": "Tailscale Network",

--- a/tailscale/i18n/fr.json
+++ b/tailscale/i18n/fr.json
@@ -74,7 +74,9 @@
       "message": "Veuillez définir une commande de terminal dans les paramètres du plugin"
     },
     "login-browser-opened": "Page d'authentification ouverte dans le navigateur",
-    "login-failed": "Échec de la connexion"
+    "login-failed": "Échec de la connexion",
+    "account-switched": "Compte Tailscale changé",
+    "account-switch-failed": "Échec du changement de compte Tailscale"
   },
   "panel": {
     "title": "Réseau Tailscale",

--- a/tailscale/i18n/sv.json
+++ b/tailscale/i18n/sv.json
@@ -74,7 +74,9 @@
       "message": "Ange ett terminalkommando i plugin-inställningarna"
     },
     "login-browser-opened": "Autentiseringssida öppnad i webbläsaren",
-    "login-failed": "Inloggning misslyckades"
+    "login-failed": "Inloggning misslyckades",
+    "account-switched": "Bytte Tailscale-konto",
+    "account-switch-failed": "Kunde inte byta Tailscale-konto"
   },
   "panel": {
     "title": "Tailscale-nätverk",

--- a/tailscale/i18n/vi.json
+++ b/tailscale/i18n/vi.json
@@ -74,7 +74,9 @@
       "message": "Vui lòng thiết lập lệnh terminal trong cài đặt plugin"
     },
     "login-browser-opened": "Trang xác thực đã mở trong trình duyệt",
-    "login-failed": "Đăng nhập thất bại"
+    "login-failed": "Đăng nhập thất bại",
+    "account-switched": "Đã chuyển tài khoản Tailscale",
+    "account-switch-failed": "Không thể chuyển tài khoản Tailscale"
   },
   "panel": {
     "title": "Mạng Tailscale",

--- a/tailscale/i18n/zh-CN.json
+++ b/tailscale/i18n/zh-CN.json
@@ -74,7 +74,9 @@
       "message": "请在插件设置中设置终端命令"
     },
     "login-browser-opened": "身份验证页面已在浏览器中打开",
-    "login-failed": "登录失败"
+    "login-failed": "登录失败",
+    "account-switched": "已切换 Tailscale 账户",
+    "account-switch-failed": "无法切换 Tailscale 账户"
   },
   "panel": {
     "title": "Tailscale网络",


### PR DESCRIPTION
This PR adds [fast user switching](https://tailscale.com/docs/features/client/fast-user-switching) to the tailscale plugin, specifically a combo box which only appears if you have more than one account (`tailscale switch --list`) and changing its value will switch to that user and refresh the UI.

Useful if you e.g. have separate personal and work networks.