### PR TITLE
fix(mangowc-layout-switcher): document mango >=0.14.0 requirement

### DIFF
--- a/mangowc-layout-switcher/manifest.json
+++ b/mangowc-layout-switcher/manifest.json
@@ -21,6 +21,9 @@
     "plugins": []
   },
   "metadata": {
+    "requires": {
+      "mangoVersion": ">=0.14.0"
+    },
     "defaultSettings": {
       "monitorOrder": []
     }


### PR DESCRIPTION
v3 uses the new mmsg IPC interface introduced in mango 0.14.0. Users on 0.13.1 and earlier get a silently broken plugin with no indication of why. Adds a requires.mangoVersion field to the manifest so this dependency is explicit.