### PR TITLE
fix(protonvpn): collapse BarPill to icon-only mode when there is no text (remove empty space when text is empty) and bump version to 1.0.1

### DIFF
--- a/protonvpn/BarWidget.qml
+++ b/protonvpn/BarWidget.qml
@@ -86,7 +86,7 @@ Item {
         customTextColor: Color.resolveColorKeyOptional(root.activeColor)
 
         forceOpen: !root.isBarVertical && root.displayMode === "alwaysShow"
-        forceClose: root.isBarVertical || root.displayMode === "alwaysHide"
+        forceClose: root.isBarVertical || root.displayMode === "alwaysHide" || !root.pillText
 
         onClicked: {
             if (pluginApi)

--- a/protonvpn/manifest.json
+++ b/protonvpn/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "protonvpn",
   "name": "ProtonVPN Status",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "minNoctaliaVersion": "3.6.0",
   "author": "blessonmathewsam",
   "license": "MIT",

--- a/usb-drive-manager/BarWidget.qml
+++ b/usb-drive-manager/BarWidget.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import QtQuick.Layouts
 import Quickshell
 import qs.Commons
 import qs.Services.UI
@@ -40,8 +41,33 @@ NIconButton {
     readonly property string iconColorKey: cfg.iconColor ?? defaults.iconColor ?? "none"
     readonly property color iconColor: Color.resolveColorKey(iconColorKey)
 
-    // ===== VISIBILITY =====
-    visible: shouldShow
+    visible: shouldShow || opacity > 0
+    opacity: shouldShow ? 1.0 : 0.0
+
+    Layout.preferredWidth: shouldShow ? -1 : 0
+    Layout.preferredHeight: shouldShow ? -1 : 0
+    Layout.margins: shouldShow ? -1 : 0
+
+    Behavior on opacity {
+        NumberAnimation {
+            duration: Style.animationNormal
+            easing.type: Easing.OutCubic
+        }
+    }
+    
+    Behavior on Layout.preferredWidth {
+        NumberAnimation {
+            duration: Style.animationNormal
+            easing.type: Easing.InOutCubic
+        }
+    }
+    
+    Behavior on Layout.preferredHeight {
+        NumberAnimation {
+            duration: Style.animationNormal
+            easing.type: Easing.InOutCubic
+        }
+    }
 
     // ===== APPEARANCE =====
     icon: "usb"
@@ -100,7 +126,6 @@ NIconButton {
     // ===== CONTEXT MENU =====
     NPopupContextMenu {
         id: contextMenu
-
         model: [
             {
                 "label": pluginApi?.tr("context.open"),

--- a/usb-drive-manager/DeviceCard.qml
+++ b/usb-drive-manager/DeviceCard.qml
@@ -92,14 +92,14 @@ Rectangle {
                 width: statusLabel.implicitWidth + Style.marginS * 2
                 height: statusLabel.implicitHeight + 4
                 radius: height / 2
-                color: Color.mPrimaryContainer
+                color: Color.mPrimary
 
                 NText {
                     id: statusLabel
                     anchors.centerIn: parent
                     text: pluginApi?.tr("device.mounted")
                     pointSize: Style.fontSizeXXS
-                    color: Color.mOnPrimaryContainer
+                    color: Color.mOnPrimary
                     font.weight: Font.Medium
                 }
             }
@@ -127,7 +127,7 @@ Rectangle {
                 Layout.fillWidth: true
                 height: Style.marginXS
                 radius: height / 2
-                color: Color.mOutlineVariant
+                color: Color.mOutline
 
                 Rectangle {
                     width: parent.width * Math.min((device?.usedPercent ?? 0) / 100, 1)

--- a/usb-drive-manager/Main.qml
+++ b/usb-drive-manager/Main.qml
@@ -10,30 +10,17 @@ Item {
     property var pluginApi: null
     property var devices: []
     property bool loading: false
-
-    readonly property int mountedCount: {
-        let c = 0
-        for (let i = 0; i < devices.length; i++) {
-            if (devices[i].isMounted) c++
-        }
-        return c
-    }
+    property int mountedCount: 0
+    property bool pendingAutoMount: false
 
     // ===== SETTINGS SHORTCUTS =====
-
     readonly property bool autoMount:          pluginApi?.pluginSettings?.autoMount          ?? false
     readonly property string fileBrowser:      pluginApi?.pluginSettings?.fileBrowser        || "yazi"
     readonly property string terminalCommand:  pluginApi?.pluginSettings?.terminalCommand    || "kitty"
     readonly property bool showNotifications:  pluginApi?.pluginSettings?.showNotifications  ?? true
     readonly property bool hideWhenEmpty:      pluginApi?.pluginSettings?.hideWhenEmpty      ?? false
 
-    // ===== INIT =====
-
-    Component.onCompleted: {
-        refreshDevices()
-    }
-
-    // ===== IPC =====
+    Component.onCompleted: refreshDevices()
 
     IpcHandler {
         target: "plugin:usb-drive-manager"
@@ -41,15 +28,12 @@ Item {
         function refresh() {
             root.refreshDevices()
         }
-
         function unmountAll() {
             root.unmountAll()
         }
     }
 
     // ===== DEVICE MONITORING =====
-
-    // udevadm monitor watches for block device add/remove events
     Process {
         id: deviceWatcher
         command: ["udevadm", "monitor", "--subsystem-match=block", "--property"]
@@ -57,44 +41,30 @@ Item {
 
         stdout: SplitParser {
             onRead: line => {
-                // Trigger refresh on USB add/remove events
-                if (line.startsWith("ACTION=add") || line.startsWith("ACTION=remove")) {
+                if (line.startsWith("ACTION=add")) {
+                    root.pendingAutoMount = true
+                    refreshDebounce.restart()
+                } else if (line.startsWith("ACTION=remove") || line.startsWith("ACTION=change")) {
                     refreshDebounce.restart()
                 }
             }
         }
-
-        onExited: exitCode => {
-            // Restart watcher if it dies unexpectedly
-            if (exitCode !== 0) {
-                restartWatcherTimer.start()
-            }
-        }
+        onExited: exitCode => { if (exitCode !== 0) restartWatcherTimer.start() }
     }
 
     Timer {
         id: restartWatcherTimer
         interval: 3000
-        repeat: false
         onTriggered: deviceWatcher.running = true
     }
 
-    // Debounce rapid udev events (e.g. partition table re-read)
     Timer {
         id: refreshDebounce
         interval: 800
-        repeat: false
-        onTriggered: {
-            refreshDevices()
-            if (root.autoMount) {
-                autoMountNewDevices()
-            }
-        }
+        onTriggered: refreshDevices()
     }
 
     // ===== DEVICE ENUMERATION =====
-
-    // lsblk -J gives us structured JSON with all block device info
     Process {
         id: deviceQuery
         command: [
@@ -102,7 +72,6 @@ Item {
             "-o", "NAME,SIZE,FSTYPE,LABEL,MOUNTPOINT,HOTPLUG,TRAN,MODEL,VENDOR,RM,PATH,PKNAME"
         ]
         running: false
-
         stdout: StdioCollector {}
         stderr: StdioCollector {}
 
@@ -112,6 +81,12 @@ Item {
                 try {
                     const data = JSON.parse(String(stdout.text))
                     root.devices = internal.parseDevices(data.blockdevices || [])
+
+                    if (root.autoMount && root.pendingAutoMount) {
+                        root.autoMountNewDevices()
+                        root.pendingAutoMount = false
+                    }
+
                     root.devicesChanged()
                 } catch (e) {
                     console.warn("[usb-drive-manager] Failed to parse lsblk output:", e)
@@ -120,16 +95,11 @@ Item {
         }
     }
 
-    // ===== DISK USAGE =====
-
-    // df gives us used/free space for mounted devices
     Process {
         id: dfQuery
         command: ["df", "--output=target,pcent,used,avail", "-h"]
         running: false
-
         stdout: StdioCollector {}
-
         onExited: exitCode => {
             if (exitCode === 0) {
                 internal.parseDfOutput(String(stdout.text))
@@ -138,7 +108,6 @@ Item {
     }
 
     // ===== ACTION PROCESSES =====
-
     Process {
         id: mountProc
         property string devicePath: ""
@@ -146,21 +115,11 @@ Item {
         running: false
         stdout: StdioCollector {}
         stderr: StdioCollector {}
-
         onExited: exitCode => {
-            if (exitCode === 0) {
-                if (root.showNotifications) {
-                    ToastService.showNotice(
-                        pluginApi?.tr("notifications.mounted"),
-                        mountProc.deviceLabel || mountProc.devicePath
-                    )
-                }
-            } else {
-                const errMsg = String(stderr.text).trim()
-                ToastService.showError(
-                    pluginApi?.tr("notifications.mount-failed"),
-                    errMsg || mountProc.devicePath
-                )
+            if (exitCode === 0 && root.showNotifications) {
+                ToastService.showNotice(pluginApi?.tr("notifications.mounted"), mountProc.deviceLabel || mountProc.devicePath)
+            } else if (exitCode !== 0) {
+                ToastService.showError(pluginApi?.tr("notifications.mount-failed"), String(stderr.text).trim() || mountProc.devicePath)
             }
             refreshDebounce.restart()
         }
@@ -173,21 +132,11 @@ Item {
         running: false
         stdout: StdioCollector {}
         stderr: StdioCollector {}
-
         onExited: exitCode => {
-            if (exitCode === 0) {
-                if (root.showNotifications) {
-                    ToastService.showNotice(
-                        pluginApi?.tr("notifications.unmounted"),
-                        unmountProc.deviceLabel || unmountProc.devicePath
-                    )
-                }
-            } else {
-                const errMsg = String(stderr.text).trim()
-                ToastService.showError(
-                    pluginApi?.tr("notifications.unmount-failed"),
-                    errMsg || unmountProc.devicePath
-                )
+            if (exitCode === 0 && root.showNotifications) {
+                ToastService.showNotice(pluginApi?.tr("notifications.unmounted"), unmountProc.deviceLabel || unmountProc.devicePath)
+            } else if (exitCode !== 0) {
+                ToastService.showError(pluginApi?.tr("notifications.unmount-failed"), String(stderr.text).trim() || unmountProc.devicePath)
             }
             refreshDebounce.restart()
         }
@@ -200,52 +149,40 @@ Item {
         running: false
         stdout: StdioCollector {}
         stderr: StdioCollector {}
-
         onExited: exitCode => {
-            if (exitCode === 0) {
-                if (root.showNotifications) {
-                    ToastService.showNotice(
-                        pluginApi?.tr("notifications.ejected"),
-                        ejectProc.deviceLabel || ejectProc.devicePath
-                    )
-                }
-            } else {
-                const errMsg = String(stderr.text).trim()
-                ToastService.showError(
-                    pluginApi?.tr("notifications.eject-failed"),
-                    errMsg || ejectProc.devicePath
-                )
+            if (exitCode === 0 && root.showNotifications) {
+                ToastService.showNotice(pluginApi?.tr("notifications.ejected"), ejectProc.deviceLabel || ejectProc.devicePath)
+            } else if (exitCode !== 0) {
+                ToastService.showError(pluginApi?.tr("notifications.eject-failed"), String(stderr.text).trim() || ejectProc.devicePath)
             }
             refreshDebounce.restart()
         }
     }
 
     // ===== INTERNAL HELPERS =====
-
     QtObject {
         id: internal
-
-        // Parse lsblk JSON output and extract USB partitions
         function parseDevices(blockdevices) {
             const result = []
+            let newMountedCount = 0
 
             function processDevice(dev, parentPath, parentIsUsb) {
                 const isUsb = parentIsUsb || dev.tran === "usb" || dev.hotplug === true || dev.hotplug === "1"
                 const isRemovable = dev.rm === true || dev.rm === "1"
 
-                // Process children (partitions) of USB devices
                 if (dev.children && dev.children.length > 0) {
                     for (const child of dev.children) {
                         processDevice(child, dev.path || ("/dev/" + dev.name), isUsb)
                     }
                 }
 
-                // Only include partitions (or whole-disk if no partitions) with a filesystem
                 const hasFs = dev.fstype && dev.fstype.length > 0
-                const isPartition = parentPath !== null
-
                 if ((isUsb || isRemovable) && hasFs) {
                     const mountpoint = dev.mountpoint || ""
+                    const isMounted = mountpoint.length > 0
+                    
+                    if (isMounted) newMountedCount++
+
                     result.push({
                         name:        dev.name || "",
                         path:        dev.path || ("/dev/" + dev.name),
@@ -254,7 +191,7 @@ Item {
                         size:        dev.size || "",
                         fstype:      dev.fstype || "",
                         mountpoint:  mountpoint,
-                        isMounted:   mountpoint.length > 0,
+                        isMounted:   isMounted,
                         model:       dev.model || "",
                         vendor:      dev.vendor ? dev.vendor.trim() : "",
                         usedPercent: 0,
@@ -264,65 +201,46 @@ Item {
                 }
             }
 
-            for (const dev of blockdevices) {
-                processDevice(dev, null, false)
-            }
-
+            for (const dev of blockdevices) processDevice(dev, null, false)
+            root.mountedCount = newMountedCount
             return result
         }
 
-        // Parse df output and update device usage stats
         function parseDfOutput(text) {
             const lines = text.split("\n")
             const usageMap = {}
-
             for (let i = 1; i < lines.length; i++) {
                 const parts = lines[i].trim().split(/\s+/)
                 if (parts.length >= 4) {
-                    const mountpoint = parts[0]
-                    const pcent = parseInt(parts[1]) || 0
-                    const used = parts[2] || ""
-                    const avail = parts[3] || ""
-                    usageMap[mountpoint] = { pcent, used, avail }
+                    usageMap[parts[0]] = { pcent: parseInt(parts[1]) || 0, used: parts[2] || "", avail: parts[3] || "" }
                 }
             }
-
-            // Update devices with usage info
-            const updated = root.devices.map(dev => {
+            root.devices = root.devices.map(dev => {
                 if (dev.isMounted && usageMap[dev.mountpoint]) {
-                    const u = usageMap[dev.mountpoint]
                     return Object.assign({}, dev, {
-                        usedPercent: u.pcent,
-                        usedSize:    u.used,
-                        freeSize:    u.avail
+                        usedPercent: usageMap[dev.mountpoint].pcent,
+                        usedSize:    usageMap[dev.mountpoint].used,
+                        freeSize:    usageMap[dev.mountpoint].avail
                     })
                 }
                 return dev
             })
-
-            root.devices = updated
             root.devicesChanged()
         }
     }
 
     // ===== PUBLIC API =====
-
     function refreshDevices() {
         root.loading = true
         deviceQuery.running = false
         deviceQuery.running = true
-        // Also refresh disk usage after a short delay
         dfTimer.restart()
     }
 
     Timer {
         id: dfTimer
         interval: 1200
-        repeat: false
-        onTriggered: {
-            dfQuery.running = false
-            dfQuery.running = true
-        }
+        onTriggered: { dfQuery.running = false; dfQuery.running = true }
     }
 
     function mountDevice(devicePath, deviceLabel) {
@@ -342,28 +260,20 @@ Item {
     }
 
     function ejectDevice(devicePath, parentPath, deviceLabel) {
-        // First unmount the partition, then power off the parent disk
         const target = parentPath || devicePath
         if (ejectProc.running) return
         ejectProc.devicePath = target
         ejectProc.deviceLabel = deviceLabel
-        ejectProc.command = [
-            "sh", "-c",
-            "udisksctl unmount -b " + devicePath + " 2>/dev/null; udisksctl power-off -b " + target
-        ]
+        ejectProc.command = ["sh", "-c", "udisksctl unmount -b " + devicePath + " 2>/dev/null; udisksctl power-off -b " + target]
         ejectProc.running = true
     }
 
     function openInFileBrowser(mountpoint) {
         const browser = root.fileBrowser || "yazi"
         if (browser === "yazi" || browser === "ranger" || browser === "lf" || browser === "nnn") {
-            // Terminal file managers need a terminal emulator
             const term = root.terminalCommand || "kitty"
             const termLower = term.toLowerCase()
-            // Ptyxis, GNOME Terminal, and WezTerm prefer `--` instead of `-e`
-            const flag = (termLower.indexOf("ptyxis") !== -1
-                       || termLower.indexOf("gnome-terminal") !== -1
-                       || termLower.indexOf("wezterm") !== -1) ? "--" : "-e"
+            const flag = (termLower.indexOf("ptyxis") !== -1 || termLower.indexOf("gnome-terminal") !== -1 || termLower.indexOf("wezterm") !== -1) ? "--" : "-e"
             Quickshell.execDetached([term, flag, browser, mountpoint])
         } else {
             Quickshell.execDetached([browser, mountpoint])
@@ -372,16 +282,9 @@ Item {
 
     function unmountAll() {
         for (let i = 0; i < devices.length; i++) {
-            const dev = devices[i]
-            if (dev.isMounted) {
-                Quickshell.execDetached(["udisksctl", "unmount", "-b", dev.path])
-            }
+            if (devices[i].isMounted) Quickshell.execDetached(["udisksctl", "unmount", "-b", devices[i].path])
         }
-        if (root.showNotifications) {
-            ToastService.showNotice(
-                pluginApi?.tr("notifications.unmount-all")
-            )
-        }
+        if (root.showNotifications) ToastService.showNotice(pluginApi?.tr("notifications.unmount-all"))
         refreshDebounce.restart()
     }
 
@@ -392,25 +295,17 @@ Item {
             const parent = dev.parentPath || dev.path
             if (!ejected.includes(parent)) {
                 ejected.push(parent)
-                Quickshell.execDetached([
-                    "sh", "-c",
-                    "udisksctl unmount -b " + dev.path + " 2>/dev/null; udisksctl power-off -b " + parent
-                ])
+                Quickshell.execDetached(["sh", "-c", "udisksctl unmount -b " + dev.path + " 2>/dev/null; udisksctl power-off -b " + parent])
             }
         }
-        if (root.showNotifications) {
-            ToastService.showNotice(
-                pluginApi?.tr("notifications.eject-all")
-            )
-        }
+        if (root.showNotifications) ToastService.showNotice(pluginApi?.tr("notifications.eject-all"))
         refreshDebounce.restart()
     }
 
     function autoMountNewDevices() {
         for (let i = 0; i < devices.length; i++) {
-            const dev = devices[i]
-            if (!dev.isMounted && dev.fstype) {
-                mountDevice(dev.path, dev.label)
+            if (!devices[i].isMounted && devices[i].fstype) {
+                mountDevice(devices[i].path, devices[i].label)
             }
         }
     }

--- a/usb-drive-manager/manifest.json
+++ b/usb-drive-manager/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "usb-drive-manager",
   "name": "USB Drive Manager",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "minNoctaliaVersion": "3.6.0",
   "author": "hennifant",
   "license": "MIT",


### PR DESCRIPTION
### What does this PR do?
Fixes an unexpected blank space that appears next to the ProtonVPN icon when the VPN is disconnected or in a loading state. 

**Changes made:**
- Changed `forceClose` evaluation in the `BarPill`: