### PR TITLE
i18n(battery-threshold): updated german translations

### DIFF
--- a/battery-threshold/i18n/de.json
+++ b/battery-threshold/i18n/de.json
@@ -6,5 +6,11 @@
   },
   "actions": {
     "widget-settings": "Widget-Einstellungen"
+  },
+  "panel": {
+    "title": "Ladegrenze",
+    "not-available": "Auf diesem System nicht verfügbar",
+    "adjust-limit": "Zieh den Schieberegler, um den Grenzwert anzupassen",
+    "read-only": "Nur-Lese-Zugriff: udev-Regel für Schreibzugriff installieren"
   }
 }

--- a/battery-threshold/manifest.json
+++ b/battery-threshold/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "battery-threshold",
   "name": "Battery Threshold Control",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "minNoctaliaVersion": "3.6.0",
   "author": "Wilfred Mallawa",
   "license": "MIT",


### PR DESCRIPTION
updated german translations for the `battery-threshold` plugin