### PR TITLE
i18n(khal-agenda-widget): added german translations

### DIFF
--- a/khal-agenda-widget/i18n/de.json
+++ b/khal-agenda-widget/i18n/de.json
@@ -1,0 +1,8 @@
+{
+  "widget": {
+    "loading": "Wird geladen...",
+    "no_events": "Keine bevorstehenden Veranstaltungen",
+    "heading": "Bevorstehende Veranstaltungen",
+    "button": "calendar-month"
+  }
+}

--- a/khal-agenda-widget/manifest.json
+++ b/khal-agenda-widget/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "khal-agenda-widget",
   "name": "Khal Agenda Info",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "minNoctaliaVersion": "4.6.6",
   "author": "Simon",
   "license": "MIT",


### PR DESCRIPTION
added german translations for the `khal-agenda-widget` plugin